### PR TITLE
rdoc --coverage-report bombs on class/module alias

### DIFF
--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -215,7 +215,7 @@ class RDoc::Stats
         report << nil
 
         cm.each_constant do |constant|
-          next if constant.documented?
+          next if constant.documented? || constant.is_alias_for
           report << "  # in file #{constant.file.full_name}"
           report << "  #{constant.name} = nil"
         end


### PR DESCRIPTION
Given a file _class_alias.rb_:

<pre>
module Test
  class Foo
  end
end

Foo = Test::Foo
</pre>


Running _rdoc -C class_alias.rb_ will bomb with this stack trace:

<pre>
undefined method `full_name' for nil:NilClass
/home/andy/workspace/rdoc/lib/rdoc/stats.rb:219:in `report'
    /home/andy/workspace/rdoc/lib/rdoc/context.rb:651:in `each_constant'
    /home/andy/workspace/rdoc/lib/rdoc/context.rb:651:in `each'
    /home/andy/workspace/rdoc/lib/rdoc/context.rb:651:in `each_constant'
    /home/andy/workspace/rdoc/lib/rdoc/stats.rb:217:in `report'
    /home/andy/workspace/rdoc/lib/rdoc/stats.rb:182:in `each'
    /home/andy/workspace/rdoc/lib/rdoc/stats.rb:182:in `report'
    /home/andy/workspace/rdoc/lib/rdoc/rdoc.rb:421:in `document'
    bin/rdoc:15
</pre>


My commit will ignore undocumented class/modules aliases in the report printing routine.  The original class is the only one that needs to appear in the report.
