### PR TITLE
darkfish generator for :call-seq: directive with dots

### DIFF
--- a/lib/rdoc/generator/template/darkfish/classpage.rhtml
+++ b/lib/rdoc/generator/template/darkfish/classpage.rhtml
@@ -228,7 +228,7 @@
         <% if method.call_seq %>
         <% method.call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
         <div class="method-heading">
-          <span class="method-callseq"><%= call_seq.strip.gsub(/->/, '&rarr;').gsub( /^\w.+\./m, '') %></span>
+          <span class="method-callseq"><%= call_seq.strip.gsub(/->/, '&rarr;').gsub( /^\w+\./m, '') %></span>
           <% if i == 0 %>
           <span class="method-click-advice">click to toggle source</span>
           <% end %>


### PR DESCRIPTION
array.c of ruby has the following :call-seq: directive.

<pre>
/*
 *  call-seq:
 *     ary.insert(index, obj...)  -> ary
 *
</pre>


Rdoc generate the following output because darkfish generator strips all characters before last dot.

<pre>
 ) &rarr; ary
</pre>

I fixed it by changing darkfish generator to strip all characters which looks like a method name before first dot.
Could you apply it to git master?
