### PR TITLE
Make RDoc::AnyMethod#add_alias context optional

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -44,7 +44,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   ##
   # Adds +an_alias+ as an alias for this method in +context+.
 
-  def add_alias(an_alias, context)
+  def add_alias(an_alias, context = nil )
     method = self.class.new an_alias.text, an_alias.new_name
 
     method.record_location an_alias.file
@@ -54,7 +54,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     method.comment = an_alias.comment
     method.is_alias_for = self
     @aliases << method
-    context.add_method method
+    context.add_method( method ) if context
     method
   end
 


### PR DESCRIPTION
RDoc::AnyMethod#marshal_load calls add_alias without the mandatory context parameter. I didn't see a likely candidate for a context in the context (ahem) in which add_alias is being called. 

This commit makes the context parameter optional, while leaving the rest of the functionality of add_alias untouched.
