### PR TITLE
Topic/fix attribute duplication on multiple runs

### DIFF
--- a/lib/rdoc/class_module.rb
+++ b/lib/rdoc/class_module.rb
@@ -263,7 +263,7 @@ class RDoc::ClassModule < RDoc::Context
 
     class_module.each_attribute do |attr|
       if match = attributes.find { |a| a.name == attr.name } then
-        match.rw = [match.rw, attr.rw].compact.join
+        match.rw = [match.rw, attr.rw].compact.uniq.join
       else
         add_attribute attr
       end


### PR DESCRIPTION
If rdoc is run with --ri over the same class multiple times, the attribute rw flags are multiplied; i.e. a class such as

class Foo
  attr_reader :read_me
end

with have the attribute "read me" with rw "R" after one rdoc run, "RR" after two runs and so on. 

This patch fixes this.
