### PR TITLE
Topic/fix include duplication on multiple runs

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -480,7 +480,7 @@ class RDoc::Context < RDoc::CodeObject
   # Adds included module +include+ which should be an RDoc::Include
 
   def add_include(include)
-    add_to @includes, include
+    add_to @includes, include unless @includes.map { |i| i.full_name }.include?( include.full_name )
   end
 
   ##


### PR DESCRIPTION
Similar to the attribute duplication, the same happens for includes. Note that I don't know how far back your ruby support goes, so I used the more cautious form of map with a block instead of map(&:full_name). 

Also, the same duplication issue exists for class documentation, however so far I haven't been able to pin down where it happens. If I can't find it by tonight, I'll create an issue for this.
