### PR TITLE
Failing test case for Rdoc::Parser::C for C methods with a prototype

### DIFF
--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -929,6 +929,37 @@ Init_IO(void) {
     assert read_method.singleton
   end
 
+  def test_define_method_with_prototype
+    content = <<-EOF
+static VALUE rb_io_s_read(int, VALUE*, VALUE);
+
+/*Method Comment! */
+static VALUE
+rb_io_s_read(argc, argv, io)
+    int argc;
+    VALUE *argv;
+    VALUE io;
+{
+}
+
+void
+Init_IO(void) {
+    /*
+     * a comment for class Foo on rb_define_class
+     */
+    VALUE rb_cIO = rb_define_class("IO", rb_cObject);
+    rb_define_singleton_method(rb_cIO, "read", rb_io_s_read, -1);
+}
+    EOF
+
+    klass = util_get_class content, 'rb_cIO'
+    read_method = klass.method_list.first
+    assert_equal "read", read_method.name
+    assert_equal "Method Comment!   ", read_method.comment
+    assert_equal "rb_io_s_read", read_method.c_function
+    assert read_method.singleton
+  end
+
   def test_define_method_private
     content = <<-EOF
 /*Method Comment! */


### PR DESCRIPTION
(My C knowledge is rusty, so prototype might not be the right term. My apologies).

When looking into why Zlib and WIN32OLE methods showed up on the missing documentation list when they had valid docs, I found that rdoc couldn't find documentation for C methods that had a prototype.

For example, with a recent checkout of ruby's trunk, running:

```
rdoc --encoding=UTF-8 -C ext/zlib/zlib.c
```

Outputs:

```
<snip>
Methods:     95 ( 83 undocumented)

Total:      150 (126 undocumented)
 16.00% documented
```

If I then open ext/zlib/zlib.c and delete lines 59-228 and rerun the above command, I get this output:

```
<snip>
Methods:     95 ( 1 undocumented)

Total:      150 (44 undocumented)
 70.67% documented
```
