### PR TITLE
Allow an image URL using SSL to be converted into an `img` HTML tag.

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -310,7 +310,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
             end
     end
 
-    if (type == "http" or type == "link") and
+    if (type == "http" or type == "https" or type == "link") and
        url =~ /\.(gif|png|jpg|jpeg|bmp)$/ then
       "<img src=\"#{url}\" />"
     else

--- a/test/test_rdoc_markup_to_html.rb
+++ b/test/test_rdoc_markup_to_html.rb
@@ -375,6 +375,14 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
                  @to.gen_url('rdoc-label:foottext-1:footmark-1', 'example')
   end
 
+  def test_gem_url_image_url
+    assert_equal '<img src="http://example.com/image.png" />', @to.gen_url('http://example.com/image.png', 'ignored')
+  end
+
+  def test_gem_url_ssl_image_url
+    assert_equal '<img src="https://example.com/image.png" />', @to.gen_url('https://example.com/image.png', 'ignored')
+  end
+
   def test_handle_special_HYPERLINK_link
     special = RDoc::Markup::Special.new 0, 'link:README.txt'
 


### PR DESCRIPTION
I want to display the Travis CI build status image from my README.rdoc [1] file on Github. Travis CI suggest [2] that I should use an image served over SSL, but as it stands I can't seem to get rdoc to generate an `img` tag for an SSL image URL.

[1] https://github.com/floehopper/mocha/blob/master/README.rdoc
[2] http://about.travis-ci.org/docs/user/status-images/#using-ssl-enabled-status-images-on-github
