### PR TITLE
Parse top-level docs for Range.

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -230,6 +230,17 @@ class RDoc::Parser::C < RDoc::Parser
       handle_class_module(var_name, "class", class_name, parent, nil)
     end
 
+    @content.scan(/([\w\.]+)\s* = \s*rb_struct_define_without_accessor\s*
+              \(
+                 \s*"(\w+)",  # Class name
+                 \s*(\w+),    # Parent class
+                 \s*\w+,      # Allocation function
+                 (\s*"\w+",)* # Attributes
+                 \s*NULL
+              \)/mx) do |var_name, class_name, parent|
+      handle_class_module(var_name, "class", class_name, parent, nil)
+    end
+
     @content.scan(/(\w+)\s*=\s*boot_defclass\s*\(\s*"(\w+?)",\s*(\w+?)\s*\)/) do
       |var_name, class_name, parent|
       parent = nil if parent == "0"

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -263,6 +263,20 @@ VALUE cFoo = rb_define_class("Foo", rb_cObject);
     assert_equal "this is the Foo class", klass.comment.text
   end
 
+  def test_do_classes_struct
+    content = <<-EOF
+/* Document-class: Foo
+ * this is the Foo class
+ */
+VALUE cFoo = rb_struct_define_without_accessor(
+        "Foo", rb_cObject, foo_alloc,
+        "some", "various", "fields", NULL);
+    EOF
+
+    klass = util_get_class content, 'cFoo'
+    assert_equal "this is the Foo class", klass.comment.text
+  end
+
   def test_do_classes_class_under
     content = <<-EOF
 /* Document-class: Kernel::Foo


### PR DESCRIPTION
Parse c files for classes defined with rb_struct_define_without_accessor (like Range).

Fix for https://github.com/rdoc/rdoc/issues/72
