### PR TITLE
Fix legacy template support in Darkfish

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -308,7 +308,7 @@ class RDoc::Generator::Darkfish
       page_file.exist? or fileinfo_file.exist?
 
     return unless
-      page_file.exist? or fileinfo_file.exist? or template_file.exist?
+      page_file.exist? or fileinfo_file.exist? or filepage_file.exist?
 
     debug_msg "Generating file documentation in #{@outputdir}"
 


### PR DESCRIPTION
When using a legacy template that contains `filepage.rhtml` the method `generate_file_files` checks `template_file` (which hasn't been declared yet) instead of `filepage_file`.

The resulting error is:

```
error generating : undefined local variable or method `template_file'
```
