### PR TITLE
Ensure that we're checking the correct child status in setup_pager

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1185,7 +1185,7 @@ Options may also be set in the 'RI' environment variable.
 
       io = IO.popen(pager, 'w') rescue next
 
-      next if $? and $?.exited? # pager didn't work
+      next if $? and $?.pid == io.pid and $?.exited? # pager didn't work
 
       @paging = true
 

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -808,6 +808,19 @@ Foo::Bar#bother
     refute @driver.paging?
   end
 
+  def test_page_in_presence_of_child_status
+    @driver.use_stdout = false
+
+    dummy = `:;\n`
+
+    with_dummy_pager do
+      @driver.page do |io|
+        refute_equal $stdout, io
+        assert @driver.paging?
+      end
+    end
+  end
+
   def test_page_stdout
     @driver.use_stdout = true
 


### PR DESCRIPTION
The test for whether the pager has been opened in setup_pager fails when `$?` has already been set by another child process being reaped (for example, running a command in backticks).  This can happen when all of the following are satisfied:
- `ri` is run with `bundle exec`;
- the Gemfile refers to a git repo;
- the gemspec in the git repo spawns a process (such as running `git ls-files` in backticks).

This can result in the terminal becoming unusable if control characters are in the ri output, necessitating saying `reset` to it!

I've changed the test in driver.rb to check whether `$?` refers to the correct process, and added a unit test to check this.
