### PR TITLE
Bug on regex inside the find_class_comment method (c.rb)

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -558,10 +558,10 @@ class RDoc::Parser::C < RDoc::Parser
     elsif @content =~ %r%Document-(?:class|module):\s+#{class_name}\s*?
                          (?:<\s+[:,\w]+)?\n((?>.*?\*/))%xm then
       comment = "/*\n#{$1}"
-    elsif @content =~ %r%((?>/\*.*?\*/\s+))
+    elsif @content =~ %r%.*((?>/\*.*?\*/\s+))
                          ([\w\.\s]+\s* = \s+)?rb_define_(class|module).*?"(#{class_name})"%xm then
       comment = $1
-    elsif @content =~ %r%((?>/\*.*?\*/\s+))
+    elsif @content =~ %r%.*((?>/\*.*?\*/\s+))
                          ([\w\.\s]+\s* = \s+)?rb_define_(class|module)_under.*?"(#{class_name.split('::').last})"%xm then
       comment = $1
     else


### PR DESCRIPTION
If we have a file like this:

```
/*
 * Comment 1
 */
foo = rb_define_class ("MyClassName1", rb_cObject);

/*
 * Comment 2
 */
bar = rb_define_class ("MyClassName2", rb_cObject);
```

RDoc assigns the `Comment 1` for both classes `MyClassName1` and `MyClassName2`.
Currently the `.*?` after `rb_define_(class|module)` in your regex is causing you to always match and capture the first part of the string, and the `.*?` matches up until the class name you are actually looking for.  

This pull request fix this problem adding a greedy match at the beginning of the regex to make sure that you only start your capture group at the last `/*` before the class name you want.
