### PR TITLE
Add -v as an alias to --version command line option

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -981,6 +981,13 @@ Usage: #{opt.program_name} [options] [names...]
       end
 
       opt.separator nil
+
+      opt.on("--version", "-v", "print the version") do
+        puts opt.version
+        exit
+      end
+
+      opt.separator nil
     end
 
     setup_generator 'darkfish' if


### PR DESCRIPTION
Both the `ruby` and `ri` commands support -v as an option to print the
version. Anyone doing `rdoc -v` will be surprised when rdoc starts attempting
to parse sources. 
