### PR TITLE
C functions with casts now accepted by the parser

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -422,7 +422,7 @@ class RDoc::Parser::C < RDoc::Parser
                    )
                    \s*\(\s*([\w\.]+),
                      \s*"([^"]+)",
-                     \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\()?(\w+)\)?,
+                     \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(METHOD\))?(\w+)\)?,
                      \s*(-?\w+)\s*\)
                    (?:;\s*/[*/]\s+in\s+(\w+?\.(?:cpp|c|y)))?
                  %xm) do |type, var_name, meth_name, function, param_count, source_file|

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -1000,6 +1000,36 @@ init_gi_repository (void)
     assert_equal 2, klass.method_list.length
   end
 
+  def test_find_body_cast
+    content = <<-EOF
+/*
+ * a comment for other_function
+ */
+VALUE
+other_function() {
+}
+
+void
+Init_Foo(void) {
+    VALUE foo = rb_define_class("Foo", rb_cObject);
+
+    rb_define_method(foo, "my_method", (METHOD)other_function, 0);
+}
+    EOF
+
+    klass = util_get_class content, 'foo'
+    other_function = klass.method_list.first
+
+    assert_equal 'my_method', other_function.name
+    assert_equal "a comment for other_function",
+                 other_function.comment.text
+    assert_equal '()', other_function.params
+
+    code = other_function.token_stream.first.text
+
+    assert_equal "VALUE\nother_function() {\n}", code
+  end
+
   def test_find_body_define
     content = <<-EOF
 #define something something_else


### PR DESCRIPTION
C functions with a cast, e.g.:

``` C
rb_define_method(cKlass, "method_name", (METHOD)function_name, 0);
```

are now accepted by the C parser (RDoc::Parser::C). It's just a change in the regular expression. A test is included.

This is necessary in projects that use C++, as G++ doesn't recognize functions correctly without the `METHOD` cast.
