### PR TITLE
Make --quiet --no-ignore-invalid still exit for invalid options 

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -1029,18 +1029,22 @@ Usage: #{opt.program_name} [options] [names...]
       deprecated.each do |opt|
         $stderr.puts 'option ' << opt << ' is deprecated: ' << DEPRECATED[opt]
       end
+    end
 
-      unless invalid.empty? then
-        invalid = "invalid options: #{invalid.join ', '}"
+    unless invalid.empty? then
+      invalid = "invalid options: #{invalid.join ', '}"
 
-        if ignore_invalid then
+      if ignore_invalid then
+        unless quiet then
           $stderr.puts invalid
           $stderr.puts '(invalid options are ignored)'
-        else
-          $stderr.puts opts
-          $stderr.puts invalid
-          exit 1
         end
+      else
+        unless quiet then
+          $stderr.puts opts
+        end
+        $stderr.puts invalid
+        exit 1
       end
     end
 

--- a/test/test_rdoc_options.rb
+++ b/test/test_rdoc_options.rb
@@ -409,6 +409,19 @@ rdoc_include:
     assert_empty out
   end
 
+  def test_parse_ignore_invalid_no_quiet
+    out, err = capture_io do
+      assert_raises SystemExit do
+        @options.parse %w[--quiet --no-ignore-invalid --bogus=arg --bobogus --visibility=extended]
+      end
+    end
+
+    refute_match %r%^Usage: %, err
+    assert_match %r%^invalid options: --bogus=arg, --bobogus, --visibility=extended%, err
+
+    assert_empty out
+  end
+
   def test_parse_main
     out, err = capture_io do
       @options.parse %w[--main MAIN]


### PR DESCRIPTION
--quiet should reduce verbosity, it should not change the
underlying behavior.
