### PR TITLE
Fix outdated `RDoc::Markup::ToHtml.new` usage example

### DIFF
--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -59,7 +59,7 @@
 #
 #   require 'rdoc'
 #
-#   h = RDoc::Markup::ToHtml.new
+#   h = RDoc::Markup::ToHtml.new(RDoc::Options.new)
 #
 #   puts h.convert(input_string)
 #


### PR DESCRIPTION
RDoc 4.0.0 no longer accepts calling `RDoc::Markup::ToHtml.new` without parameters. This pull request fixes an outdated example in the `RDoc::Markup` documentation.
