### PR TITLE
added -v alias for --version instead of --verbose, use -V instead

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -975,9 +975,16 @@ Usage: #{opt.program_name} [options] [names...]
 
       opt.separator nil
 
-      opt.on("--verbose", "-v",
+      opt.on("--verbose", "-V",
              "Display extra progress as RDoc parses") do |value|
         @verbosity = 2
+      end
+
+      opt.separator nil
+
+      opt.on("--version", "-v", "print the version") do
+        puts opt.version
+        exit
       end
 
       opt.separator nil

--- a/test/test_rdoc_options.rb
+++ b/test/test_rdoc_options.rb
@@ -688,6 +688,15 @@ rdoc_include:
     end
 
     assert out.include?(RDoc::VERSION)
+
+    out, _ = capture_io do
+      begin
+        @options.parse %w[-v]
+      rescue SystemExit
+      end
+    end
+
+    assert out.include?(RDoc::VERSION)
   end
 
 end


### PR DESCRIPTION
See #168 for an explanation. This pull request aliases `-v` to `--version` instead of `--verbose` and adds `-V` in place of this. This keeps `rdoc -v` in line with `ri -v` `ruby -v` `irb -v` etc
