### PR TITLE
Support linking [], []=, <<, and >> methods 

### DIFF
--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -18,7 +18,7 @@ class RDoc::CrossReference
   #
   # See CLASS_REGEXP_STR
 
-  METHOD_REGEXP_STR = '([a-z]\w*[!?=]?|%|===)(?:\([\w.+*/=<>-]*\))?'
+  METHOD_REGEXP_STR = '([a-z]\w*[!?=]?|%|===|\[\]=?|<<|>>)(?:\([\w.+*/=<>-]*\))?'
 
   ##
   # Regular expressions matching text that should potentially have

--- a/test/test_rdoc_cross_reference.rb
+++ b/test/test_rdoc_cross_reference.rb
@@ -19,9 +19,10 @@ class TestRDocCrossReference < XrefTestCase
   def test_METHOD_REGEXP_STR
     re = /#{RDoc::CrossReference::METHOD_REGEXP_STR}/
 
-    re =~ '==='
-
-    assert_equal '===', $&
+    %w'=== [] []= << >>'.each do |x|
+      re =~ x
+      assert_equal x, $&
+    end
   end
 
   def test_resolve_C2


### PR DESCRIPTION
This should fix issue 191.

I'm testing this on the Sequel RDoc.  It seems to work fine, though I'm not sure if
it causes other problems.  I didn't come across any issues, though.
