### PR TITLE
Fix bug: make "-T" mean "--no-pager" again

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -197,10 +197,17 @@ The ri pager can be set with the 'RI_PAGER' environment variable or the
 
       opt.separator nil
 
-      opt.on("--[no-]pager", "-T",
+      opt.on("--[no-]pager",
              "Send output directly to stdout,",
              "rather than to a pager.") do |use_pager|
         options[:use_stdout] = !use_pager
+      end
+
+      opt.separator nil
+
+      opt.on("-T",
+             "Synonym for --no-pager") do
+        options[:use_stdout] = true
       end
 
       opt.separator nil


### PR DESCRIPTION
The "-T" option used to mean "--no-pager".  In commit
af4ac4335c4064fead6ebd03eaaed7302f41ae85 it was changed, probably
unintentionally, to mean "--pager".
