### PR TITLE
Ensure @str is a String

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -177,6 +177,7 @@ class RDoc::Markup::AttributeManager
 
   def mask_protected_sequences
     # protect __send__, __FILE__, etc.
+    @str = String(@str)
     @str.gsub!(/__([a-z]+)__/i,
       "_#{PROTECT_ATTR}_#{PROTECT_ATTR}\\1_#{PROTECT_ATTR}_#{PROTECT_ATTR}")
     @str.gsub!(/\\([#{Regexp.escape @protectable.join('')}])/,


### PR DESCRIPTION
I get the below NoMethod Error every time I run `ri`. (version 3.12.2)

```
/Users/gjaldon/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rdoc-3.12.2/lib/rdoc/markup/attribute_manager.rb:180:in `mask_protected_sequences': undefined method `gsub!' for ["read_array"]:Array (NoMethodError)
```

The method expects @str to be a String so just converted @str with String as a quick fix for it to work on my machine. Might be helpful to minimize the chances of others to experience this same bug and to make the method more liberal in the type of object it accepts. 

Btw, add any test for it. Let me know if you'd like me to and if this is of any help. 

Cheers!
