### PR TITLE
Do not strip regexp literal options [fixes #259]

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1231,7 +1231,7 @@ class RDoc::RubyLex
       end
 
       if @ltype == "/"
-        if peek(0) =~ /i|m|x|o|e|s|u|n/
+        while peek(0) =~ /i|m|x|o|e|s|u|n/
           str << getc
         end
       end

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -251,6 +251,15 @@ U
     ]
 
     assert_equal expected, tokens
+
+    tokens = RDoc::RubyLex.tokenize "/hAY/ix", nil
+
+    expected = [
+      @TK::TkREGEXP.new( 0, 1,  0, "/hAY/ix"),
+      @TK::TkNL    .new( 7, 1,  7, "\n"),
+    ]
+
+    assert_equal expected, tokens
   end
 
   def test_class_tokenize_regexp_backref


### PR DESCRIPTION
Ensure that the lexer includes any option, like /foo/i,
when lexing regexp literals.
