### PR TITLE
Use racc > 1.4.10, as 1.4.11 fixes ruby 1.8.7 compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ Depending on your version of ruby, you may need to install ruby rdoc/ri data:
 
   require_ruby_version '>= 1.8.7'
   extra_deps     << ['json',     '~> 1.4']
-  extra_dev_deps << ['racc',     '~> 1.4', '!= 1.4.10']
+  extra_dev_deps << ['racc',     '~> 1.4', '> 1.4.10']
   extra_dev_deps << ['minitest', '~> 4']
 
   extra_rdoc_files << 'Rakefile'


### PR DESCRIPTION
This can be merged after racc 1.4.11 is released

/cc tenderlove/racc#34
