### PR TITLE
Allow optional :all parameter for RDoc::Options#visibility= as synonym for :private

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -325,7 +325,7 @@ class RDoc::Options
   # other visibilities may be overridden on a per-method basis with the :doc:
   # directive.
 
-  attr_accessor :visibility
+  attr_reader :visibility
 
   def initialize # :nodoc:
     init_ivars
@@ -1171,6 +1171,22 @@ Usage: #{opt.program_name} [options] [names...]
       out.map taguri, to_yaml_style do |map|
         encode_with map
       end
+    end
+  end
+
+  # Sets the minimum visibility of a documented method.
+  #
+  # Accepts +:public+, +:protected+, +:private+, +:nodoc+, or +:all+.
+  #
+  # When +:all+ is passed, visibility is set to +:private+, similarly to
+  # RDOCOPT="--all", see #visibility for more information.
+
+  def visibility= visibility
+    case visibility
+    when :all
+      @visibility = :private
+    else
+      @visibility = visibility
     end
   end
 

--- a/test/test_rdoc_options.rb
+++ b/test/test_rdoc_options.rb
@@ -743,5 +743,9 @@ rdoc_include:
     assert out.include?(RDoc::VERSION)
   end
 
+  def test_visibility
+    @options.visibility = :all
+    assert_equal :private, @options.visibility
+  end
 end
 


### PR DESCRIPTION
This feature moves RDoc::Options#visibility= out to a separate method
and takes a synonymous argument of :all for :private.

Since :private is not an obvious name for documenting all methods of
this visibility, we provide this optional synonym. Also, this is similar
to how we can pass "--all" when parsing command-line options.
