### PR TITLE
Update the Minitest version to ~> 5.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,14 +64,14 @@ Depending on your version of ruby, you may need to install ruby rdoc/ri data:
   require_ruby_version '>= 1.8.7'
   extra_deps     << ['json',     '~> 1.4']
   extra_dev_deps << ['racc',     '~> 1.4', '!= 1.4.10']
-  extra_dev_deps << ['minitest', '~> 4']
+  extra_dev_deps << ['minitest', '~> 5']
 
   extra_rdoc_files << 'Rakefile'
   spec_extras['required_rubygems_version'] = '>= 1.3'
   spec_extras['homepage'] = 'http://docs.seattlerb.org/rdoc'
 end
 
-hoe.test_prelude = 'gem "minitest", "~> 4.0"'
+hoe.test_prelude = 'gem "minitest", "~> 5.0"'
 
 def rake(*args)
   sh $0, *args

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 
 begin
-  gem 'minitest', '~> 4.0' unless defined?(Test::Unit)
+  gem 'minitest', '~> 5.0' unless defined?(Test::Unit)
 rescue NoMethodError
   # for ruby tests
 end
@@ -30,7 +30,7 @@ require 'rdoc'
 # * <code>@pwd</code> containing the current working directory
 # * FileUtils, pp, Tempfile, Dir.tmpdir and StringIO
 
-class RDoc::TestCase < MiniTest::Unit::TestCase
+class RDoc::TestCase < Minitest::Test
 
   ##
   # Abstract test-case setup


### PR DESCRIPTION
Hello,

This is just a little pull request that let the users relying on `RDoc::TestCase` use a more up to date version of
Minitest. This would be very nice if this patch could be in 4.1.0. Actually Rails' documentation has an issue with chars such as `?z` (see https://github.com/rails/rails/issues/7172) and 4.0.1 doesn't fix this issue (see [this gist](https://gist.github.com/robin850/32368f4ebd11a8d6e238)) but 4.1.0.preview.3 does.

Then I guess if we don't want to introduce backward incompatibilities, we could allow versions between `~> 4.0` and `~> 5.0` and still rely on `MiniTest::Unit::TestCase` but the latter will throw a deprecation warning.

Let me know if you want me to add anything else to my patch.

Have a nice day.
