### PR TITLE
Explicit block arguments / fix for methods without arguments

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -240,7 +240,15 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       return []
     end
 
-    params = params.gsub(/\s+/, '').split ','
+    if @block_params then
+      # If this method has explicit block parameters, remove any explicit
+      # &block
+      params.sub!(/,?\s*&\w+/, '')
+    else
+      params.sub!(/\&(\w+)/, '\1')
+    end
+
+    params = params.gsub(/\s+/, '').split(',').reject(&:empty?)
 
     params.map { |param| param.sub(/=.*/, '') }
   end

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -334,6 +334,35 @@ method(a, b) { |c, d| ... }
     assert_equal %w[a b c d], m.param_list
   end
 
+  def test_param_list_empty_params_with_block
+    m = RDoc::AnyMethod.new nil, 'method'
+    m.parent = @c1
+
+    m.params = '()'
+    m.block_params = 'a, b'
+
+    assert_equal %w[a b], m.param_list
+  end
+
+  def test_param_list_ampersand_param_block_params
+    m = RDoc::AnyMethod.new nil, 'method'
+    m.parent = @c1
+
+    m.params = '(a, b, &block)'
+    m.block_params = 'c, d'
+
+    assert_equal %w[a b c d], m.param_list
+  end
+
+  def test_param_list_ampersand_param
+    m = RDoc::AnyMethod.new nil, 'method'
+    m.parent = @c1
+
+    m.params = '(a, b, &block)'
+
+    assert_equal %w[a b block], m.param_list
+  end
+
   def test_param_seq
     m = RDoc::AnyMethod.new nil, 'method'
     m.parent = @c1


### PR DESCRIPTION
Without changes proposed with this pull request, rdoc failed to handle method arguments properly for the following cases.

Coverage for

``` ruby
# test method, yields +foo+
def test_method1
  yield(foo)
end
```

reported undocumented '++' parameter (empty parameter name!)

``` ruby
# test method with explicit +block+ argument
def test_method3 &block
  block.call
end
```

reported undocumented '+&block+' parameter, and there were no way to describe it, as parameter names should start with letter, according to rdoc grammar.

``` ruby
# only +baz+ has to be documented here
def test_method4 &block
  yield baz
end
```

reported undocumented '+&block+' parameter, and it shouldn't be documented at all.
