### PR TITLE
Fix top-level class superclass condition

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -303,10 +303,11 @@ class RDoc::Context < RDoc::CodeObject
     end
 
     # fix up superclass
-    superclass = nil if full_name == 'BasicObject'
-    superclass = nil if full_name == 'Object' and defined?(::BasicObject)
-    superclass = '::BasicObject' if
-      defined?(::BasicObject) and full_name == 'Object'
+    if full_name == 'BasicObject' then
+      superclass = nil
+    elsif full_name == 'Object' then
+      superclass = defined?(::BasicObject) ? '::BasicObject' : nil
+    end
 
     # find the superclass full name
     if superclass then


### PR DESCRIPTION
- there was twice the condition `full_name == 'Object' and defined?(::BasicObject)`,
  therefore making the first instruction useless as overwritten by the second.
- The logical behavior, which is also explained in the comment upper is now correctly implemented.
