### PR TITLE
Improve auto setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,7 @@ end
 if need_racc
   Rake::Task["default"].prerequisites.clear
   task :default do
+    rake "check_extra_deps"
     rake "install_plugins"
     rake "newb"
   end


### PR DESCRIPTION
I find that auto "rake newb" feature by "rake" without any arguments when the following case:
- racc gem isn't installed.
- lib/rdoc/rd/block_parser.rb (racc output) exists but it is older than lib/rdoc/rd/block_parser.ry (racc source).
