### PR TITLE
Stop to create directories in default gem directory for test

### DIFF
--- a/test/test_rdoc_rubygems_hook.rb
+++ b/test/test_rdoc_rubygems_hook.rb
@@ -138,9 +138,6 @@ class TestRDocRubygemsHook < Gem::TestCase
     @a.loaded_from =
       File.join Gem::Specification.default_specifications_dir, 'a.gemspec'
 
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
     @hook.generate
 
     refute @hook.rdoc_installed?


### PR DESCRIPTION
It breaks test on system installed RubyGems and normal user
environment with the following error:

```
  1) Error:
test_generate_default_gem(TestRDocRubygemsHook):
Errno::EACCES: Permission denied - /var/lib/gems/2.0.0/doc/a-2
    /usr/lib/ruby/2.0.0/fileutils.rb:245:in `mkdir'
    /usr/lib/ruby/2.0.0/fileutils.rb:245:in `fu_mkdir'
    /usr/lib/ruby/2.0.0/fileutils.rb:219:in `block (2 levels) in mkdir_p'
    /usr/lib/ruby/2.0.0/fileutils.rb:217:in `reverse_each'
    /usr/lib/ruby/2.0.0/fileutils.rb:217:in `block in mkdir_p'
    /usr/lib/ruby/2.0.0/fileutils.rb:203:in `each'
    /usr/lib/ruby/2.0.0/fileutils.rb:203:in `mkdir_p'
    /home/kou/work/ruby/rdoc/test/test_rdoc_rubygems_hook.rb:141:in `test_generate_default_gem'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1301:in `run'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:919:in `block in _run_suite'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:912:in `map'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:912:in `_run_suite'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:899:in `block in _run_suites'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:899:in `map'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:899:in `_run_suites'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:867:in `_run_anything'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1060:in `run_tests'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1047:in `block in _run'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1046:in `each'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1046:in `_run'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:1035:in `run'
    /usr/lib/ruby/2.0.0/minitest/unit.rb:789:in `block in autorun'
```

We don't need to create directories because the test checks that
RubyGems hook isn't ran.
