### PR TITLE
return nil unless `other` is comparable.  Fixes #284

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -164,6 +164,7 @@ class RDoc::Context < RDoc::CodeObject
   # Contexts are sorted by full_name
 
   def <=>(other)
+    return unless other.respond_to? :full_name
     full_name <=> other.full_name
   end
 

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -110,6 +110,9 @@ class RDoc::MethodAttr < RDoc::CodeObject
   # Order by #singleton then #name
 
   def <=>(other)
+    return unless other.respond_to?(:singleton) &&
+                  other.respond_to?(:name)
+
     [     @singleton ? 0 : 1,       name] <=>
     [other.singleton ? 0 : 1, other.name]
   end


### PR DESCRIPTION
Apparently RDoc was relying on `<=>` raising an exception to mean "not comparable" rather than returning nil.  This patch returns nil when they are not comparable.  Ruby trunk raises an exception due to [this ticket](https://bugs.ruby-lang.org/issues/7688).
