### PR TITLE
Fix outdated documentation example for markup.rb

### DIFF
--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -84,7 +84,7 @@
 #
 #   markup.add_special(/\b([A-Z][a-z]+[A-Z]\w+)/, :WIKIWORD)
 #
-#   wh = WikiHtml.new nil, markup
+#   wh = WikiHtml.new RDoc::Options.new, markup
 #   wh.add_tag(:STRIKE, "<strike>", "</strike>")
 #
 #   puts "<body>#{wh.convert ARGF.read}</body>"


### PR DESCRIPTION
ToHTML.new takes two arguments, and the markup object is the second argument.
