### PR TITLE
Fix documentation typo

### DIFF
--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -163,7 +163,7 @@
 #
 # The header's id would be:
 #
-#   <h1 id="method-i-do_fun_things-label-Example">Example</h3>
+#   <h1 id="method-i-do_fun_things-label-Example">Example</h1>
 #
 # The label can be linked-to using <tt>SomeClass@Headers</tt>.  See
 # {Links}[RDoc::Markup@Links] for further details.


### PR DESCRIPTION
Match closing tag h1
