### PR TITLE
Ignore generated doc directory

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -305,6 +305,9 @@ option)
       when "directory" then
         next if rel_file_name == "CVS" || rel_file_name == ".svn"
 
+        created_rid = File.join rel_file_name, "created.rid"
+        next if File.file? created_rid
+
         dot_doc = File.join rel_file_name, RDoc::DOT_DOC_FILENAME
 
         if File.file? dot_doc then

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -430,5 +430,20 @@ class TestRDocRDoc < RDoc::TestCase
     end
   end
 
+  def test_normalized_file_list_removes_created_rid_dir
+    temp_dir do |d|
+      FileUtils.mkdir "doc"
+      flag_file = @rdoc.output_flag_file "doc"
+      file = File.join "doc", "test"
+      FileUtils.touch flag_file
+      FileUtils.touch file
+
+      file_list = ["doc"]
+
+      output = @rdoc.normalized_file_list file_list
+
+      assert_empty output
+    end
+  end
 end
 


### PR DESCRIPTION
Previously, rdoc would parse generated documentation directories. This made
rdoc slow because it would keep processing generated rdoc files.

Now rdoc skips generated documentation directories.

Fixes #305
