### PR TITLE
Changes dependency of rdoc task

### DIFF
--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -291,7 +291,7 @@ class RDoc::Task < Rake::TaskLib
   private
 
   def rdoc_target
-    "#{rdoc_dir}/index.html"
+    "#{rdoc_dir}/created.rid"
   end
 
   def rdoc_task_name

--- a/test/test_rdoc_task.rb
+++ b/test/test_rdoc_task.rb
@@ -46,6 +46,7 @@ class TestRDocTask < RDoc::TestCase
     assert Rake::Task[:rdoc]
     assert Rake::Task[:clobber_rdoc]
     assert Rake::Task[:rerdoc]
+    assert_equal ["html/created.rid"], Rake::Task[:rdoc].prerequisites
   end
 
   def test_tasks_creation_with_custom_name_symbol


### PR DESCRIPTION
Previously, rdoc task would look for "index.html" file to build docs. In --ri
mode, this file is never created.

Now looks for "created.rid", which is generated regardless of the generation
mode.

Fixes #307
