### PR TITLE
backport commits from ruby/ruby trunk.

### DIFF
--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -118,7 +118,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
   end
 
   def == other # :nodoc:
-    super or self.class == other.class and full_name == other.full_name
+    equal?(other) or self.class == other.class and full_name == other.full_name
   end
 
   ##
@@ -184,8 +184,8 @@ class RDoc::MethodAttr < RDoc::CodeObject
       parent != kernel && !searched.include?(kernel)
 
     searched.each do |ancestor|
-      next if parent == ancestor
       next if String === ancestor
+      next if parent == ancestor
 
       other = ancestor.find_method_named('#' << name) ||
               ancestor.find_attribute_named(name)

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -10,6 +10,12 @@ class TestRDocEncoding < RDoc::TestCase
     @tempfile = Tempfile.new 'test_rdoc_encoding'
   end
 
+  def teardown
+    @tempfile.close!
+
+    super
+  end
+
   def test_class_read_file
     @tempfile.write "hi everybody"
     @tempfile.flush

--- a/test/test_rdoc_markup_pre_process.rb
+++ b/test/test_rdoc_markup_pre_process.rb
@@ -17,7 +17,7 @@ class TestRDocMarkupPreProcess < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_class_register

--- a/test/test_rdoc_normal_class.rb
+++ b/test/test_rdoc_normal_class.rb
@@ -15,8 +15,8 @@ class TestRDocNormalClass < XrefTestCase
 
   def test_ancestors_multilevel
     c1 = @top_level.add_class RDoc::NormalClass, 'Outer'
-    c2 = @top_level.add_class RDoc::NormalClass, 'Middle', c1
-    c3 = @top_level.add_class RDoc::NormalClass, 'Inner', c2
+    c2 = @top_level.add_class RDoc::NormalClass, 'Middle', c1.full_name
+    c3 = @top_level.add_class RDoc::NormalClass, 'Inner', c2.full_name
 
     assert_equal [c2, c1, 'Object'], c3.ancestors
   end
@@ -30,8 +30,8 @@ class TestRDocNormalClass < XrefTestCase
     incl = RDoc::Include.new 'Incl', ''
 
     c1 = @top_level.add_class RDoc::NormalClass, 'Outer'
-    c2 = @top_level.add_class RDoc::NormalClass, 'Middle', c1
-    c3 = @top_level.add_class RDoc::NormalClass, 'Inner', c2
+    c2 = @top_level.add_class RDoc::NormalClass, 'Middle', c1.full_name
+    c3 = @top_level.add_class RDoc::NormalClass, 'Inner', c2.full_name
     c3.add_include incl
 
     assert_equal [incl.name, c2], c3.direct_ancestors

--- a/test/test_rdoc_parser.rb
+++ b/test/test_rdoc_parser.rb
@@ -109,7 +109,7 @@ class TestRDocParser < RDoc::TestCase
   def test_class_for_forbidden
     skip 'chmod not supported' if Gem.win_platform?
 
-    Tempfile.open 'forbidden' do |io|
+    Tempfile.create 'forbidden' do |io|
       begin
         File.chmod 0000, io.path
         forbidden = @store.add_file io.path

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -58,7 +58,7 @@ class TestRDocParserC < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_class_can_parse

--- a/test/test_rdoc_parser_changelog.rb
+++ b/test/test_rdoc_parser_changelog.rb
@@ -12,7 +12,7 @@ class TestRDocParserChangeLog < RDoc::TestCase
   end
 
   def teardown
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_class_can_parse

--- a/test/test_rdoc_parser_markdown.rb
+++ b/test/test_rdoc_parser_markdown.rb
@@ -19,7 +19,7 @@ class TestRDocParserMarkdown < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_file

--- a/test/test_rdoc_parser_rd.rb
+++ b/test/test_rdoc_parser_rd.rb
@@ -19,7 +19,7 @@ class TestRDocParserRd < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_file

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -29,8 +29,8 @@ class TestRDocParserRuby < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
-    @tempfile2.close
+    @tempfile.close!
+    @tempfile2.close!
   end
 
   def test_collect_first_comment

--- a/test/test_rdoc_parser_simple.rb
+++ b/test/test_rdoc_parser_simple.rb
@@ -17,7 +17,7 @@ class TestRDocParserSimple < RDoc::TestCase
   def teardown
     super
 
-    @tempfile.close
+    @tempfile.close!
   end
 
   def test_initialize_metadata

--- a/test/test_rdoc_rd_block_parser.rb
+++ b/test/test_rdoc_rd_block_parser.rb
@@ -153,7 +153,7 @@ class TestRDocRdBlockParser < RDoc::TestCase
         blank_line,
         blank_line)
 
-    Tempfile.open %w[parse_include .rd] do |io|
+    Tempfile.create %w[parse_include .rd] do |io|
       io.puts "=begin\ninclude ((*worked*))\n=end"
       io.flush
 

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -252,7 +252,7 @@ class TestRDocRDoc < RDoc::TestCase
     @rdoc.options.encoding = Encoding::ISO_8859_1
     @rdoc.store = RDoc::Store.new
 
-    Tempfile.open 'test.txt' do |io|
+    Tempfile.create 'test.txt' do |io|
       io.write 'hi'
       io.rewind
 
@@ -267,7 +267,7 @@ class TestRDocRDoc < RDoc::TestCase
 
     @rdoc.store = RDoc::Store.new
 
-    Tempfile.open 'test.txt' do |io|
+    Tempfile.create 'test.txt' do |io|
       io.write 'hi'
       io.rewind
 
@@ -382,7 +382,7 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_setup_output_dir_exists_file
-    Tempfile.open 'test_rdoc_rdoc' do |tempfile|
+    Tempfile.create 'test_rdoc_rdoc' do |tempfile|
       path = tempfile.path
 
       e = assert_raises RDoc::Error do


### PR DESCRIPTION
Hi, I cherry-picked following fixes from ruby/ruby trunk.
- r46711
- r46710
- r46709
- r46027
- r44502
- r46143
- r46142

@drbrain Should I support Ruby 1.8 series? If it's yes, I'll added more fixes as same as https://github.com/rubygems/rubygems/commit/a34fb569e41cd87866e644d92a9df4be89b3cad2
