### PR TITLE
Fix singleton method parsing

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -187,15 +187,16 @@ class RDoc::Parser::Ruby < RDoc::Parser
   end
 
   ##
-  # Extracts the visibility information for the visibility token +tk+.
+  # Extracts the visibility information for the visibility token +tk+
+  # and +single+ class type identifier.
   #
   # Returns the visibility type (a string), the visibility (a symbol) and
   # +singleton+ if the methods following should be converted to singleton
   # methods.
 
-  def get_visibility_information tk # :nodoc:
+  def get_visibility_information tk, single # :nodoc:
     vis_type  = tk.name
-    singleton = false
+    singleton = single == SINGLE
 
     vis =
       case vis_type
@@ -1306,7 +1307,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     return unless name
 
     meth = RDoc::AnyMethod.new get_tkread, name
-    meth.singleton = singleton
+    meth.singleton = single == SINGLE ? true : singleton
 
     record_location meth
     meth.offset = offset
@@ -1876,7 +1877,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Determines the visibility in +container+ from +tk+
 
   def parse_visibility(container, single, tk)
-    vis_type, vis, singleton = get_visibility_information tk
+    vis_type, vis, singleton = get_visibility_information tk, single
 
     skip_tkspace_comment false
 

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -3245,7 +3245,25 @@ end
     c_b = c.find_method_named 'b'
 
     assert_equal :private, c_b.visibility
-    refute c_b.singleton
+    assert c_b.singleton
+  end
+
+  def test_singleton_method_via_eigenclass
+    util_parser <<-RUBY
+class C
+   class << self
+     def a() end
+   end
+end
+    RUBY
+
+    @parser.scan
+
+    c   = @store.find_class_named 'C'
+    c_a = c.find_method_named 'a'
+
+    assert_equal :public, c_a.visibility
+    assert c_a.singleton
   end
 
   def test_stopdoc_after_comment


### PR DESCRIPTION
Previously, when defining singleton via eigenclass would
incorrectly set parsed method's #singleton attribute

Spotted in [ruby-core:64157]

Signed-off-by: Aleksandrs Ļedovskis aleksandrs@ledovskis.lv
