### PR TITLE
Skip nil tokens in RDoc::TokenStream#tokens_to_s.

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -88,7 +88,7 @@ module RDoc::TokenStream
   # Returns a string representation of the token stream
 
   def tokens_to_s
-    token_stream.map { |token| token.text }.join ''
+    token_stream.compact.map { |token| token.text }.join ''
   end
 
 end


### PR DESCRIPTION
For reasons I don't know, `token_stream` sometimes contain `nil` elements.
This is handled in `RDoc::TokenStream.to_html` but not in
`RDoc::TokenStream#tokens_to_s`. This adds handling to
`RDoc::TokenStream#tokens_to_s`.
