### PR TITLE
Make +X::Y+ be treated as typewriter text, same as <tt>X::Y</tt> (Fixes #319)

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -130,7 +130,7 @@ class RDoc::Markup::AttributeManager
     # first do matching ones
     tags = @matching_word_pairs.keys.join("")
 
-    re = /(^|\W)([#{tags}])([#:\\]?[\w.\/-]+?\S?)\2(\W|$)/
+    re = /(^|\W)([#{tags}])([#\\]?[\w:.\/-]+?\S?)\2(\W|$)/
 
     1 while str.gsub!(re) do
       attr = @matching_word_pairs[$2]

--- a/test/test_rdoc_markup_attribute_manager.rb
+++ b/test/test_rdoc_markup_attribute_manager.rb
@@ -130,6 +130,9 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
     assert_equal(["cat ", @tt_on, "and", @tt_off, " dog"],
                   @am.flow("cat +and+ dog"))
 
+    assert_equal(["cat ", @tt_on, "X::Y", @tt_off, " dog"],
+                  @am.flow("cat +X::Y+ dog"))
+
     assert_equal(["cat ", @bold_on, "a_b_c", @bold_off, " dog"],
                   @am.flow("cat *a_b_c* dog"))
 


### PR DESCRIPTION
We could use a more specific regexp that only matches :: and not
just : inside the string, but I didn't think it was worth the
additional complexity.
