### PR TITLE
Make labels cross-browser compatible.

### DIFF
--- a/lib/rdoc/markup/to_label.rb
+++ b/lib/rdoc/markup/to_label.rb
@@ -31,7 +31,7 @@ class RDoc::Markup::ToLabel < RDoc::Markup::Formatter
   def convert text
     label = convert_flow @am.flow text
 
-    CGI.escape label
+    CGI.escape(label).gsub('%', '-').sub(/^-/, '')
   end
 
   ##

--- a/test/test_rdoc_markup_heading.rb
+++ b/test/test_rdoc_markup_heading.rb
@@ -9,16 +9,16 @@ class TestRDocMarkupHeading < RDoc::TestCase
   end
 
   def test_aref
-    assert_equal 'label-Hello+Friend%21', @h.aref
+    assert_equal 'label-Hello+Friend-21', @h.aref
   end
 
   def test_label
-    assert_equal 'label-Hello+Friend%21', @h.label
-    assert_equal 'label-Hello+Friend%21', @h.label(nil)
+    assert_equal 'label-Hello+Friend-21', @h.label
+    assert_equal 'label-Hello+Friend-21', @h.label(nil)
 
     context = RDoc::NormalClass.new 'Foo'
 
-    assert_equal 'class-Foo-label-Hello+Friend%21', @h.label(context)
+    assert_equal 'class-Foo-label-Hello+Friend-21', @h.label(context)
   end
 
   def test_plain_html

--- a/test/test_rdoc_markup_to_label.rb
+++ b/test/test_rdoc_markup_to_label.rb
@@ -82,8 +82,8 @@ class TestRDocMarkupToLabel < RDoc::Markup::FormatterTestCase
     assert_equal 'some_method', @to.convert('some_method')
     assert_equal 'some_method', @to.convert('\\some_method')
 
-    assert_equal '%23some_method', @to.convert('#some_method')
-    assert_equal '%23some_method', @to.convert('\\#some_method')
+    assert_equal '23some_method', @to.convert('#some_method')
+    assert_equal '23some_method', @to.convert('\\#some_method')
   end
 
   def test_convert_em
@@ -92,11 +92,11 @@ class TestRDocMarkupToLabel < RDoc::Markup::FormatterTestCase
   end
 
   def test_convert_em_dash # for HTML conversion
-    assert_equal '--', @to.convert('--')
+    assert_equal '-', @to.convert('--')
   end
 
   def test_convert_escape
-    assert_equal 'a+%3E+b', @to.convert('a > b')
+    assert_equal 'a+-3E+b', @to.convert('a > b')
   end
 
   def test_convert_tidylink


### PR DESCRIPTION
Percent-encoded URL fragments prevent Firefox from jumping to their respective anchors (see, e.g., [RDoc's History.txt](http://docs.seattlerb.org/rdoc/History_rdoc.html): None of those links in the table of contents work in Firefox). Wikipedia (MediaWiki) does something similar, with `.` instead of `-`.

There's precedent in `RDoc::{Alias,MethodAttr}#html_name` (54dbcf70) and `RDoc::Context::Section#aref` (431baa1b). This breaks backwards-compatibility, though.
