### PR TITLE
Use a real parser for RDoc::Markup::ToHtml#parseable? (Fixes #320)

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -379,11 +379,12 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   end
 
   ##
-  # Returns true if Ripper is available it can create a sexp from +text+
+  # Returns true if text is valid ruby syntax
 
   def parseable? text
-    text =~ /\b(def|class|module|require) |=>|\{\s?\||do \|/ and
-      text !~ /<%|%>/
+    eval("BEGIN {return true}\n#{text}")
+  rescue SyntaxError
+    false
   end
 
   ##

--- a/test/test_rdoc_markup_to_html_snippet.rb
+++ b/test/test_rdoc_markup_to_html_snippet.rb
@@ -309,7 +309,7 @@ class TestRDocMarkupToHtmlSnippet < RDoc::Markup::FormatterTestCase
   end
 
   def accept_verbatim
-    assert_equal "\n<pre>hi\n  world</pre>\n", @to.res.join
+    assert_equal "\n<pre class=\"ruby\"><span class=\"ruby-identifier\">hi</span>\n  <span class=\"ruby-identifier\">world</span>\n</pre>\n", @to.res.join
     assert_equal 10, @to.characters
   end
 
@@ -427,8 +427,7 @@ class TestRDocMarkupToHtmlSnippet < RDoc::Markup::FormatterTestCase
 
     expected = <<-EXPECTED
 
-<pre>#{inner}
-</pre>
+<pre>#{inner}</pre>
     EXPECTED
 
     assert_equal expected, @to.res.join
@@ -588,8 +587,9 @@ This routine modifies its +comment+ parameter.
     expected = <<-EXPECTED
 <p>Look for directives in a normal comment block:
 
-<pre># :stopdoc:
-#{inner}</pre>
+<pre class=\"ruby\"><span class=\"ruby-comment\"># :stopdoc:</span>
+<span class=\"ruby-comment\">#{inner}</span>
+</pre>
     EXPECTED
 
     actual = @to.convert rdoc
@@ -665,8 +665,9 @@ This routine modifies its +comment+ parameter.
     expected = <<-EXPECTED
 <p>one
 
-<pre>verb1
-verb2</pre>
+<pre class=\"ruby\"><span class=\"ruby-identifier\">verb1</span>
+<span class=\"ruby-identifier\">verb2</span>
+</pre>
 <p>two
 
     EXPECTED


### PR DESCRIPTION
This uses BEGIN {return true} when evaluating the text, which will do
a syntax check, but not actually execute the code.

Using a real ruby parser is a big improvement for two reasons.
First, it highlights valid ruby syntax that was left unhighlighted
by the previous parser.  Second and more important, it doesn't
highlight invalid ruby syntax, which makes it easier to catch
errors in example code in the documentation.  This even fixes some
errors in the tests, where code like "class C end" was considered
valid syntax.

There is some fallout in the tests where code that wasn't highlighted
before is now highlighted, this also fixes those cases so the tests
pass.
