### PR TITLE
Fix multiple comments rendering

### DIFF
--- a/lib/rdoc/class_module.rb
+++ b/lib/rdoc/class_module.rb
@@ -196,6 +196,8 @@ class RDoc::ClassModule < RDoc::Context
   # more like <tt>+=</tt>.
 
   def comment= comment # :nodoc:
+    return if comment.empty? and not @comment.empty?
+
     comment = normalize_comment comment
     comment = "#{comment_to_string @comment}\n---\n#{comment_to_string comment}" unless @comment.empty?
 

--- a/lib/rdoc/class_module.rb
+++ b/lib/rdoc/class_module.rb
@@ -129,12 +129,7 @@ class RDoc::ClassModule < RDoc::Context
 
     original = comment
 
-    comment = case comment
-              when RDoc::Comment then
-                comment.normalize
-              else
-                normalize_comment comment
-              end
+    comment = normalize_comment comment
 
     @comment_location.delete_if { |(_, l)| l == location }
 
@@ -201,14 +196,8 @@ class RDoc::ClassModule < RDoc::Context
   # more like <tt>+=</tt>.
 
   def comment= comment # :nodoc:
-    comment = case comment
-              when RDoc::Comment then
-                comment.normalize
-              else
-                normalize_comment comment
-              end
-
-    comment = "#{@comment}\n---\n#{comment}" unless @comment.empty?
+    comment = normalize_comment comment
+    comment = "#{comment_to_string @comment}\n---\n#{comment_to_string comment}" unless @comment.empty?
 
     super comment
   end
@@ -794,6 +783,32 @@ class RDoc::ClassModule < RDoc::Context
     end
 
     extends.uniq!
+  end
+
+  ##
+  # Returns normalized version of a comment
+  # Works both for String and RDoc::Comment
+
+  def normalize_comment comment
+    case comment
+      when RDoc::Comment then
+        comment.normalize
+      else
+        super comment
+    end
+  end
+
+  ##
+  # Returns string value for a comment
+  # Works both for String and RDoc::Comment
+
+  def comment_to_string comment
+    case comment
+      when RDoc::Comment then
+        comment.text
+      else
+        comment
+    end
   end
 
 end

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -52,6 +52,24 @@ class TestRDocClassModule < XrefTestCase
     assert_equal "comment 1\n---\ncomment 2\n---\n* comment 3", cm.comment
   end
 
+  def test_add_empty_comment_elsewhere
+    tl1 = @store.add_file 'one.rb'
+    tl2 = @store.add_file 'two.rb'
+    tl3 = @store.add_file 'three.rb'
+
+    cm = RDoc::ClassModule.new 'Klass'
+
+    cm.add_comment comment('comment 1'), tl1
+    assert_equal 'comment 1', cm.comment.text
+
+    cm.add_comment comment(''), tl2
+    assert cm.comment.is_a? RDoc::Comment
+    assert_equal 'comment 1', cm.comment.text
+
+    cm.add_comment comment("* comment 3"), tl3
+    assert_equal "comment 1\n---\n* comment 3", cm.comment
+  end
+
   def test_add_comment_duplicate
     tl1 = @store.add_file 'one.rb'
 

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -35,6 +35,23 @@ class TestRDocClassModule < XrefTestCase
     assert_equal 'comment', cm.comment.text
   end
 
+  def test_add_several_comments_text
+    tl1 = @store.add_file 'one.rb'
+    tl2 = @store.add_file 'two.rb'
+    tl3 = @store.add_file 'three.rb'
+
+    cm = RDoc::ClassModule.new 'Klass'
+
+    cm.add_comment comment('comment 1'), tl1
+    assert_equal 'comment 1', cm.comment.text
+
+    cm.add_comment comment('comment 2'), tl2
+    assert_equal "comment 1\n---\ncomment 2", cm.comment
+
+    cm.add_comment comment("* comment 3"), tl3
+    assert_equal "comment 1\n---\ncomment 2\n---\n* comment 3", cm.comment
+  end
+
   def test_add_comment_duplicate
     tl1 = @store.add_file 'one.rb'
 


### PR DESCRIPTION
In classes and modules there is some strange code which leads to problems when comments are added from different places. This leads to some docs like

```
# #<RDoc::Comment:0x007fba8317a5a8>
# ---
# #<RDoc::Comment:0x007fba83a67968>
# ---
# #<RDoc::Comment:0x007fba84106120>
```

In these commits I address this issue as well as the cosmetics problem when empty comments are appended to the same class/module.

I am not sure whether I have to file an issue in the tracker or a couple of tests in the repo will suffice.
