### PR TITLE
Prevent negative IDs in output of #inspect.

### DIFF
--- a/lib/rdoc/alias.rb
+++ b/lib/rdoc/alias.rb
@@ -75,8 +75,8 @@ class RDoc::Alias < RDoc::CodeObject
 
   def inspect # :nodoc:
     parent_name = parent ? parent.name : '(unknown)'
-    "#<%s:0x%x %s.alias_method %s, %s>" % [
-      self.class, object_id,
+    "%s %s.alias_method %s, %s>" % [
+      super[0..-2],
       parent_name, @old_name, @new_name,
     ]
   end

--- a/lib/rdoc/attr.rb
+++ b/lib/rdoc/attr.rb
@@ -87,8 +87,8 @@ class RDoc::Attr < RDoc::MethodAttr
     alias_for = @is_alias_for ? " (alias for #{@is_alias_for.name})" : nil
     visibility = self.visibility
     visibility = "forced #{visibility}" if force_documentation
-    "#<%s:0x%x %s %s (%s)%s>" % [
-      self.class, object_id,
+    "%s %s %s (%s)%s>" % [
+      super[0..-2],
       full_name,
       rw,
       visibility,

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -148,7 +148,7 @@ class RDoc::Comment
   def inspect # :nodoc:
     location = @location ? @location.relative_name : '(unknown)'
 
-    "#<%s:%x %s %p>" % [self.class, object_id, location, @text]
+    "%s %s %p>" % [super[0..-2], location, @text]
   end
 
   ##

--- a/lib/rdoc/constant.rb
+++ b/lib/rdoc/constant.rb
@@ -97,8 +97,8 @@ class RDoc::Constant < RDoc::CodeObject
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %s::%s>" % [
-      self.class, object_id,
+    "%s %s::%s>" % [
+      super[0..-2],
       parent_name, @name,
     ]
   end

--- a/lib/rdoc/context/section.rb
+++ b/lib/rdoc/context/section.rb
@@ -127,7 +127,7 @@ class RDoc::Context::Section
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %p>" % [self.class, object_id, title]
+    "%s %p>" % [super[0..-2], title]
   end
 
   def hash # :nodoc:

--- a/lib/rdoc/markup/special.rb
+++ b/lib/rdoc/markup/special.rb
@@ -29,8 +29,8 @@ class RDoc::Markup::Special
   end
 
   def inspect # :nodoc:
-    "#<RDoc::Markup::Special:0x%x @type=%p, @text=%p>" % [
-      object_id, @type, text.dump]
+    "%s @type=%p, @text=%p>" % [
+      super[0..-2], @type, text.dump]
   end
 
   def to_s # :nodoc:

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -305,8 +305,8 @@ class RDoc::MethodAttr < RDoc::CodeObject
     alias_for = @is_alias_for ? " (alias for #{@is_alias_for.name})" : nil
     visibility = self.visibility
     visibility = "forced #{visibility}" if force_documentation
-    "#<%s:0x%x %s (%s)%s>" % [
-      self.class, object_id,
+    "%s %s (%s)%s>" % [
+      super[0..-2],
       full_name,
       visibility,
       alias_for,

--- a/lib/rdoc/mixin.rb
+++ b/lib/rdoc/mixin.rb
@@ -48,9 +48,8 @@ class RDoc::Mixin < RDoc::CodeObject
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %s.%s %s>" % [
-      self.class,
-      object_id,
+    "%s %s.%s %s>" % [
+      super[0..-2],
       parent_name, self.class.name.downcase, @name,
     ]
   end

--- a/lib/rdoc/normal_class.rb
+++ b/lib/rdoc/normal_class.rb
@@ -38,8 +38,8 @@ class RDoc::NormalClass < RDoc::ClassModule
 
   def inspect # :nodoc:
     superclass = @superclass ? " < #{@superclass}" : nil
-    "<%s:0x%x class %s%s includes: %p extends: %p attributes: %p methods: %p aliases: %p>" % [
-      self.class, object_id,
+    "%s class %s%s includes: %p extends: %p attributes: %p methods: %p aliases: %p>" % [
+      super[0..-2],
       full_name, superclass, @includes, @extends, @attributes, @method_list, @aliases
     ]
   end

--- a/lib/rdoc/normal_module.rb
+++ b/lib/rdoc/normal_module.rb
@@ -9,8 +9,8 @@ class RDoc::NormalModule < RDoc::ClassModule
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x module %s includes: %p extends: %p attributes: %p methods: %p aliases: %p>" % [
-      self.class, object_id,
+    "%s module %s includes: %p extends: %p attributes: %p methods: %p aliases: %p>" % [
+      super[0..-2],
       full_name, @includes, @extends, @attributes, @method_list, @aliases
     ]
   end

--- a/lib/rdoc/require.rb
+++ b/lib/rdoc/require.rb
@@ -20,9 +20,8 @@ class RDoc::Require < RDoc::CodeObject
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x require '%s' in %s>" % [
-      self.class,
-      object_id,
+    "%s require '%s' in %s>" % [
+      super[0..-2],
       @name,
       parent_file_name,
     ]

--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -126,8 +126,8 @@ class RDoc::RubyLex
   # :stopdoc:
 
   def inspect # :nodoc:
-    "#<%s:0x%x pos %d lex_state %p space_seen %p>" % [
-      self.class, object_id,
+    "%s pos %d lex_state %p space_seen %p>" % [
+      super[0..-2],
       @io.pos, @lex_state, @space_seen,
     ]
   end

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -474,7 +474,7 @@ class RDoc::Store
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %s %p>" % [self.class, object_id, @path, module_names.sort]
+    "%s %s %p>" % [super[0..-2], @path, module_names.sort]
   end
 
   ##

--- a/lib/rdoc/top_level.rb
+++ b/lib/rdoc/top_level.rb
@@ -171,8 +171,8 @@ class RDoc::TopLevel < RDoc::Context
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %p modules: %p classes: %p>" % [
-      self.class, object_id,
+    "%s %p modules: %p classes: %p>" % [
+      super[0..-2],
       base_name,
       @modules.map { |n,m| m },
       @classes.map { |n,c| c }


### PR DESCRIPTION
This prevents output of negative object IDs:

https://bugs.ruby-lang.org/issues/13397

I have not tested this closely, but:

1) I hope the test would catch the possible issues.
2) It should not by user visible change ...