### PR TITLE
Add hash rocket '=>' token

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -483,7 +483,7 @@ class RDoc::RubyLex
                   "=", "==", "===",
                   "=~", "<=>",
                   "<", "<=",
-                  ">", ">=", ">>") do
+                  ">", ">=", ">>", "=>") do
       |op, io|
       case @lex_state
       when :EXPR_FNAME, :EXPR_DOT

--- a/lib/rdoc/ruby_token.rb
+++ b/lib/rdoc/ruby_token.rb
@@ -355,6 +355,7 @@ module RDoc::RubyToken
     [:TkNEQ,        TkOp,   "!="],
     [:TkGEQ,        TkOp,   ">="],
     [:TkLEQ,        TkOp,   "<="],
+    [:TkHASHROCKET, TkOp,   "=>"],
     [:TkANDOP,      TkOp,   "&&"],
     [:TkOROP,       TkOp,   "||"],
     [:TkMATCH,      TkOp,   "=~"],

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -90,6 +90,25 @@ end
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_hash_rocket
+    tokens = RDoc::RubyLex.tokenize '{ :class => "foo" }', nil
+
+    expected = [
+      @TK::TkLBRACE    .new( 0, 1,  0, '{'),
+      @TK::TkSPACE     .new( 1, 1,  1, ' '),
+      @TK::TkSYMBOL    .new( 2, 1,  2, ':class'),
+      @TK::TkSPACE     .new( 8, 1,  8, ' '),
+      @TK::TkHASHROCKET.new( 9, 1,  9, '=>'),
+      @TK::TkSPACE     .new(11, 1, 11, ' '),
+      @TK::TkSTRING    .new(12, 1, 12, '"foo"'),
+      @TK::TkSPACE     .new(17, 1, 17, ' '),
+      @TK::TkRBRACE    .new(18, 1, 18, '}'),
+      @TK::TkNL        .new(19, 1, 19, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_heredoc_CR_NL
     tokens = RDoc::RubyLex.tokenize <<-RUBY, nil
 string = <<-STRING\r


### PR DESCRIPTION
You can check this feature as sample file below:

```ruby
# sample code:
#
#     { :a => :b }
#
def meth
end
```

The original RDoc generates:

![original hash rocket highlighting](https://i.gyazo.com/e81e082ba4b05dc7deadbc03eede9a80.png)

```html
<pre class="ruby">
{ <span class="ruby-value">:a</span> =<span class="ruby-operator">&gt;</span> <span class="ruby-value">:b</span> }
</pre>
```

This separated between `=` and `>` as different token types.

RDoc with this Pull Request generates:

![with this Pull Request highlighting](https://i.gyazo.com/338f77439fef6eac6dacb86cc3a7719d.png)

```html
<pre class="ruby">
{ <span class="ruby-value">:a</span> <span class="ruby-operator">=&gt;</span> <span class="ruby-value">:b</span> }
</pre>
```

This provides `=>` as one token.