### PR TITLE
Handle "[]" and "[]=" after "." as method

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -737,6 +737,7 @@ class RDoc::RubyLex
 
     @OP.def_rule("[") do
       |op, io|
+      text = nil
       @indent += 1
       if @lex_state == :EXPR_FNAME
         tk_c = TkfLBRACK
@@ -745,13 +746,25 @@ class RDoc::RubyLex
           tk_c = TkLBRACK
         elsif @lex_state == :EXPR_ARG && @space_seen
           tk_c = TkLBRACK
+        elsif @lex_state == :EXPR_DOT
+          if peek(0) == "]"
+            tk_c = TkIDENTIFIER
+            getc
+            if peek(0) == "="
+              text = "[]="
+            else
+              text = "[]"
+            end
+          else
+            tk_c = TkOp
+          end
         else
           tk_c = TkfLBRACK
         end
         @lex_state = :EXPR_BEG
       end
       @indent_stack.push tk_c
-      Token(tk_c)
+      Token(tk_c, text)
     end
 
     @OP.def_rule("{") do

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -435,5 +435,24 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_square_bracket_as_method
+    tokens = RDoc::RubyLex.tokenize "Array.[](1, 2)", nil
+
+    expected = [
+      @TK::TkCONSTANT  .new(0,  1,  0, "Array"),
+      @TK::TkDOT       .new(5,  1,  5, "."),
+      @TK::TkIDENTIFIER.new(6,  1,  6, "[]"),
+      @TK::TkfLPAREN   .new(8,  1,  8, "("),
+      @TK::TkINTEGER   .new(9,  1,  9, "1"),
+      @TK::TkCOMMA     .new(10, 1, 10, ","),
+      @TK::TkSPACE     .new(11, 1, 11, " "),
+      @TK::TkINTEGER   .new(12, 1, 12, "2"),
+      @TK::TkRPAREN    .new(13, 1, 13, ")"),
+      @TK::TkNL        .new(14, 1, 14, "\n")
+    ]
+
+    assert_equal expected, tokens
+  end
+
 end
 


### PR DESCRIPTION
`[]` after `.` is handled as operator. But, `[]` inside `Array.[]` is method because it is after `.`. This Pull Request fixes it.