### PR TITLE
Handle JSON-style hash key as symbol

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -948,7 +948,7 @@ class RDoc::RubyLex
                   @indent_stack.push token_c
                 end
               else
-                if peek(0) == ':'
+                if peek(0) == ':' and !peek_match?(/^::/)
                   token.concat getc
                   token_c = TkSYMBOL
                 else
@@ -986,7 +986,7 @@ class RDoc::RubyLex
     elsif token[token.size - 1, 1] =~ /[!?]/
       return Token(TkFID, token)
     else
-      if peek(0) == ':'
+      if peek(0) == ':' and !peek_match?(/^::/)
         token.concat getc
         return Token(TkSYMBOL, token)
       else

--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -948,7 +948,12 @@ class RDoc::RubyLex
                   @indent_stack.push token_c
                 end
               else
-                token_c = TkIDENTIFIER
+                if peek(0) == ':'
+                  token.concat getc
+                  token_c = TkSYMBOL
+                else
+                  token_c = TkIDENTIFIER
+                end
               end
 
             elsif DEINDENT_CLAUSE.include?(token)
@@ -981,7 +986,12 @@ class RDoc::RubyLex
     elsif token[token.size - 1, 1] =~ /[!?]/
       return Token(TkFID, token)
     else
-      return Token(TkIDENTIFIER, token)
+      if peek(0) == ':'
+        token.concat getc
+        return Token(TkSYMBOL, token)
+      else
+        return Token(TkIDENTIFIER, token)
+      end
     end
   end
 

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -78,13 +78,13 @@ end
     tokens = RDoc::RubyLex.tokenize '{ class:"foo" }', nil
 
     expected = [
-      @TK::TkLBRACE    .new( 0, 1,  0, '{'),
-      @TK::TkSPACE     .new( 1, 1,  1, ' '),
-      @TK::TkIDENTIFIER.new( 2, 1,  2, 'class'),
-      @TK::TkSYMBOL    .new( 7, 1,  7, ':"foo"'),
-      @TK::TkSPACE     .new(13, 1, 13, ' '),
-      @TK::TkRBRACE    .new(14, 1, 14, '}'),
-      @TK::TkNL        .new(15, 1, 15, "\n"),
+      @TK::TkLBRACE.new( 0, 1,  0, '{'),
+      @TK::TkSPACE .new( 1, 1,  1, ' '),
+      @TK::TkSYMBOL.new( 2, 1,  2, 'class:'),
+      @TK::TkSTRING.new( 8, 1,  8, '"foo"'),
+      @TK::TkSPACE .new(13, 1, 13, ' '),
+      @TK::TkRBRACE.new(14, 1, 14, '}'),
+      @TK::TkNL    .new(15, 1, 15, "\n"),
     ]
 
     assert_equal expected, tokens

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -90,6 +90,21 @@ end
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_double_colon_is_not_hash_symbol
+    tokens = RDoc::RubyLex.tokenize 'self.class::Row', nil
+
+    expected = [
+      @TK::TkSELF      .new( 0, 1,  0, "self"),
+      @TK::TkDOT       .new( 4, 1,  4, "."),
+      @TK::TkIDENTIFIER.new( 5, 1,  5, "class"),
+      @TK::TkCOLON2    .new(10, 1, 10, "::"),
+      @TK::TkCONSTANT  .new(12, 1, 12, "Row"),
+      @TK::TkNL        .new(15, 1, 15, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_heredoc_CR_NL
     tokens = RDoc::RubyLex.tokenize <<-RUBY, nil
 string = <<-STRING\r

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -389,8 +389,7 @@ U
     expected = [
       @TK::TkIDENTIFIER.new( 0, 1,  0, 'scope'),
       @TK::TkSPACE     .new( 5, 1,  5, ' '),
-      @TK::TkIDENTIFIER.new( 6, 1,  6, 'module'),
-      @TK::TkCOLON     .new(12, 1, 12, ':'),
+      @TK::TkSYMBOL    .new( 6, 1,  6, 'module:'),
       @TK::TkSPACE     .new(13, 1, 13, ' '),
       @TK::TkSYMBOL    .new(14, 1, 14, ':v1'),
       @TK::TkNL        .new(17, 1, 17, "\n"),


### PR DESCRIPTION
RDoc handles the JSON-style hash key as identifier and operator `:`, like below:

![separated identifer and :](https://i.gyazo.com/18c3cdad96a8905f51ca12e1ca85ab6f.png)

```html
<pre class="ruby">
{ <span class="ruby-identifier">hiee</span><span class="ruby-operator">:</span> <span class="ruby-value">:aaaa</span> }
{ <span class="ruby-identifier">class</span><span class="ruby-operator">:</span> <span class="ruby-value">:aaaa</span> }
</pre>
```

I think the hash key is a symbol. This Pull Request fixes it like below:

![JSON-style hash key is a symbol](https://i.gyazo.com/f37a64bc4cb29fad455d8c7986cc17e1.png)

```html
<pre class="ruby">
{ <span class="ruby-value">hiee:</span> <span class="ruby-value">:aaaa</span> }
{ <span class="ruby-value">class:</span> <span class="ruby-value">:aaaa</span> }
</pre>
```