### PR TITLE
Stop dropping continuing backslash

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1235,7 +1235,7 @@ class RDoc::RubyLex
         elsif ch == '\\'
           if %w[' /].include? @ltype then
             case ch = getc
-            when "\\", "\n", "'"
+            when "\n", "'"
             when @ltype
               str << ch
             else

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -339,6 +339,17 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_regexp_continuing_backslash
+    tokens = RDoc::RubyLex.tokenize "/(?<!\\\\)\\n\z/", nil
+
+    expected = [
+      @TK::TkREGEXP.new( 0, 1,  0, "/(?<!\\\\)\\n\z/"),
+      @TK::TkNL    .new(12, 1, 12, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_string
     tokens = RDoc::RubyLex.tokenize "'hi'", nil
 


### PR DESCRIPTION
In string or regexp literal, `\` is a escape character and continuing `\` is dropped like below:

```ruby
/\\\\/ # => /\\/
```

This Pull Request stops the dropping:

```ruby
/\\\\/ # => /\\\\/
```
