### PR TITLE
Support %i and %I literal

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -396,7 +396,9 @@ class RDoc::RubyLex
     "r" => "/",
     "w" => "]",
     "W" => "]",
-    "s" => ":"
+    "s" => ":",
+    "i" => "]",
+    "I" => "]"
   }
 
   PERCENT_PAREN = {


### PR DESCRIPTION
The symbols array literal by `%i` and `%I` is not supported:

![broken %i and %I](https://i.gyazo.com/ed528ad31b5404a400b3f8ffaa33cc1b.png)

This Pull Request fixes it:

![correct %i and %I](https://i.gyazo.com/80a0057001dd3b31b38b8c939f72adea.png)