### PR TITLE
Fix for "\n" after backslash escape

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -769,14 +769,11 @@ class RDoc::RubyLex
 
     @OP.def_rule('\\') do
       |op, io|
-      if getc == "\n"
+      if peek(0) == "\n"
         @space_seen = true
         @continue = true
-        Token(TkSPACE)
-      else
-        ungetc
-        Token("\\")
       end
+      Token("\\")
     end
 
     @OP.def_rule('%') do

--- a/test/test_rdoc_markup_to_html.rb
+++ b/test/test_rdoc_markup_to_html.rb
@@ -451,6 +451,22 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
     assert_equal expected, @to.res.join
   end
 
+  def test_accept_verbatim_nl_after_backslash
+    verb = @RM::Verbatim.new("a = 1 if first_flag_var and \\\n", "  this_is_flag_var\n")
+
+    @to.start_accepting
+    @to.accept_verbatim verb
+
+    expected = <<-EXPECTED
+
+<pre class="ruby"><span class="ruby-identifier">a</span> = <span class="ruby-value">1</span> <span class="ruby-keyword">if</span> <span class="ruby-identifier">first_flag_var</span> <span class="ruby-keyword">and</span> \\
+  <span class="ruby-identifier">this_is_flag_var</span>
+</pre>
+    EXPECTED
+
+    assert_equal expected, @to.res.join
+  end
+
   def test_accept_verbatim_pipe
     @options.pipe = true
 


### PR DESCRIPTION
The "\n" after backslash escape is not correctly now, so the code below is broken in HTML.

```ruby
a = 1 if first_flag_var and \
  this_is_flag_var
```

![broken HTML](https://i.gyazo.com/857e4e711de65689fd69b66ddff3fce4.png)

This Pull Request fixes it.

![fixed HTML](https://i.gyazo.com/e398b6c55d3d3964ef1e632606dc35e3.png)