### PR TITLE
Fix handling hash rocket after symbol

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -966,7 +966,7 @@ class RDoc::RubyLex
 
     if @lex_state == :EXPR_FNAME
       @lex_state = :EXPR_END
-      if peek(0) == '='
+      if peek(0) == '=' and peek(1) != '>'
         token.concat getc
       end
     elsif @lex_state == :EXPR_BEG || @lex_state == :EXPR_DOT ||

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -286,6 +286,24 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_hash_rocket
+    tokens = RDoc::RubyLex.tokenize "{ :foo=> 1 }", nil
+
+    expected = [
+      @TK::TkLBRACE    .new( 0, 1,  0, '{'),
+      @TK::TkSPACE     .new( 1, 1,  1, ' '),
+      @TK::TkSYMBOL    .new( 2, 1,  2, ':foo'),
+      @TK::TkHASHROCKET.new( 6, 1,  6, '=>'),
+      @TK::TkSPACE     .new( 8, 1,  8, ' '),
+      @TK::TkINTEGER   .new( 9, 1,  9, '1'),
+      @TK::TkSPACE     .new(10, 1, 10, ' '),
+      @TK::TkRBRACE    .new(11, 1, 11, '}'),
+      @TK::TkNL        .new(12, 1, 12, "\n")
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_regexp
     tokens = RDoc::RubyLex.tokenize "/hay/", nil
 


### PR DESCRIPTION
The method what creates `TkIDENTIFIER`, `identify_identifier`, it takes continuing `=` for method name as symbol because `RDoc::RubyLex` handles some symbols via `TkSYMBEG` and `TkIDENTIFIER`. But it is sometimes broken for hash literal, like below:

```ruby
{ :method_name => :value } # keys is :method_name, success
{ :method_name= => :value } # key is :method_name=, success
{ :method_name=> :value } # key is :method_name, failure
```

This Pull Request fixes the behaviour.