### PR TITLE
Fix percent string literal with operator

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1211,7 +1211,7 @@ class RDoc::RubyLex
     str = if ltype == quoted and %w[" ' /].include? ltype then
             ltype.dup
           else
-            "%#{type or PERCENT_LTYPE.key ltype}#{PERCENT_PAREN_REV[quoted]||quoted}"
+            "%#{type}#{PERCENT_PAREN_REV[quoted]||quoted}"
           end
 
     subtype = nil

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2838,7 +2838,7 @@ end
   def test_sanity_interpolation_curly
     util_parser '%{ #{} }'
 
-    assert_equal '%Q{ #{} }', @parser.get_tk.text
+    assert_equal '%{ #{} }', @parser.get_tk.text
     assert_equal RDoc::RubyToken::TkNL, @parser.get_tk.class
   end
 

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -286,6 +286,17 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_percent_sign_quote
+    tokens = RDoc::RubyLex.tokenize '%%hi%', nil
+
+    expected = [
+      @TK::TkSTRING.new( 0, 1, 0, '%%hi%'),
+      @TK::TkNL    .new( 5, 1, 5, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_regexp
     tokens = RDoc::RubyLex.tokenize "/hay/", nil
 


### PR DESCRIPTION
For example, `%*string*` is changed to `%Q*string*`. It's equivalent string literal to be sure, but this is not good for source code quotation in HTML document.

```ruby
def example
  a_string = %*string*
  the_same_of_above = %Q*string*
end
```

The code above is highlighted below:

```html
<pre>
<span class="ruby-keyword">def</span> <span class="ruby-identifier">example</span>
  <span class="ruby-identifier">a_string</span> = <span class="ruby-string">%Q*string*</span>
  <span class="ruby-identifier">the_same_of_above</span> = <span class="ruby-string">%Q*string*</span>
<span class="ruby-keyword">end</span>
</pre>
```

![%*string* becomes %Q*string*](https://i.gyazo.com/e3795cb586c4854ae5e1488dd28fb696.png)

This Pull Request fixes it:

```html
<pre>
<span class="ruby-keyword">def</span> <span class="ruby-identifier">example</span>
  <span class="ruby-identifier">a_string</span> = <span class="ruby-string">%*string*</span>
  <span class="ruby-identifier">the_same_of_above</span> = <span class="ruby-string">%Q*string*</span>
<span class="ruby-keyword">end</span>
</pre>
```

![%*string* keeps its](https://i.gyazo.com/8936c0574bd8c60e977eb92761173339.png)

It's the same of the original source code.