### PR TITLE
Fix heredoc

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -106,6 +106,8 @@ class RDoc::RubyLex
     @rests = []
     @seek = 0
 
+    @heredoc_queue = []
+
     @indent = 0
     @indent_stack = []
     @lex_state = :EXPR_BEG
@@ -462,21 +464,43 @@ class RDoc::RubyLex
 
     @OP.def_rule("\n") do |op, io|
       print "\\n\n" if RDoc::RubyLex.debug?
-      case @lex_state
-      when :EXPR_BEG, :EXPR_FNAME, :EXPR_DOT
-        @continue = true
-      else
-        @continue = false
-        @lex_state = :EXPR_BEG
-        until (@indent_stack.empty? ||
-               [TkLPAREN, TkLBRACK, TkLBRACE,
-                 TkfLPAREN, TkfLBRACK, TkfLBRACE].include?(@indent_stack.last))
-          @indent_stack.pop
+      unless @heredoc_queue.empty?
+        info = @heredoc_queue[0]
+        if !info[:started] # "\n"
+          info[:started] = true
+          ungetc "\n"
+        elsif info[:heredoc_end].nil? # heredoc body
+          tk, heredoc_end = identify_here_document_body(info[:quoted], info[:lt], info[:indent])
+          info[:heredoc_end] = heredoc_end
+          ungetc "\n"
+        else # heredoc end
+          @heredoc_queue.shift
+          @lex_state = :EXPR_BEG
+          tk = Token(TkHEREDOCEND, info[:heredoc_end])
+          if !@heredoc_queue.empty?
+            @heredoc_queue[0][:started] = true
+            ungetc "\n"
+          end
         end
       end
-      @current_readed = @readed
-      @here_readed.clear
-      Token(TkNL)
+      unless tk
+        case @lex_state
+        when :EXPR_BEG, :EXPR_FNAME, :EXPR_DOT
+          @continue = true
+        else
+          @continue = false
+          @lex_state = :EXPR_BEG
+          until (@indent_stack.empty? ||
+                 [TkLPAREN, TkLBRACK, TkLBRACE,
+                   TkfLPAREN, TkfLBRACK, TkfLBRACE].include?(@indent_stack.last))
+            @indent_stack.pop
+          end
+        end
+        @current_readed = @readed
+        @here_readed.clear
+        tk = Token(TkNL)
+      end
+      tk
     end
 
     @OP.def_rules("*", "**",
@@ -506,8 +530,8 @@ class RDoc::RubyLex
       if @lex_state != :EXPR_END && @lex_state != :EXPR_CLASS &&
          (@lex_state != :EXPR_ARG || @space_seen)
         c = peek(0)
-        if /\S/ =~ c && (/["'`]/ =~ c || /\w/ =~ c || c == "-")
-          tk = identify_here_document
+        if /\S/ =~ c && (/["'`]/ =~ c || /\w/ =~ c || c == "-" || c == "~")
+          tk = identify_here_document(op)
         end
       end
       unless tk
@@ -985,19 +1009,24 @@ class RDoc::RubyLex
     end
   end
 
-  def identify_here_document
+  def identify_here_document(op)
     ch = getc
+    start_token = op
     #    if lt = PERCENT_LTYPE[ch]
-    if ch == "-"
+    if ch == "-" or ch == "~"
+      start_token.concat ch
       ch = getc
       indent = true
     end
     if /['"`]/ =~ ch
+      start_token.concat ch
       user_quote = lt = ch
       quoted = ""
       while (c = getc) && c != lt
         quoted.concat c
       end
+      start_token.concat quoted
+      start_token.concat lt
     else
       user_quote = nil
       lt = '"'
@@ -1005,57 +1034,38 @@ class RDoc::RubyLex
       while (c = getc) && c =~ /\w/
         quoted.concat c
       end
+      start_token.concat quoted
       ungetc
     end
 
+    @heredoc_queue << {
+      quoted: quoted,
+      lt: lt,
+      indent: indent,
+      started: false
+    }
+    @lex_state = :EXPR_BEG
+    Token(RDoc::RubyLex::TkHEREDOCBEG, start_token)
+  end
+
+  def identify_here_document_body(quoted, lt, indent)
     ltback, @ltype = @ltype, lt
-    reserve = []
-    while ch = getc
-      reserve.push ch
-      if ch == "\\"
-        reserve.push ch = getc
-      elsif ch == "\n"
-        break
-      end
-    end
 
-    output_heredoc = reserve.join =~ /\A\r?\n\z/
-
-    if output_heredoc then
-      doc = '<<'
-      doc << '-' if indent
-      doc << "#{user_quote}#{quoted}#{user_quote}\n"
-    else
-      doc = '"'
-    end
-
-    @current_readed = @readed
+    doc = ""
+    heredoc_end = nil
     while l = gets
       l = l.sub(/(:?\r)?\n\z/, "\n")
       if (indent ? l.strip : l.chomp) == quoted
+        heredoc_end = l
         break
       end
       doc << l
     end
+    raise Error, "Missing terminating #{quoted} for string" unless heredoc_end
 
-    if output_heredoc then
-      raise Error, "Missing terminating #{quoted} for string" unless l
-
-      doc << l.chomp
-    else
-      doc << '"'
-    end
-
-    @current_readed = @here_readed
-    @here_readed.concat reserve
-    while ch = reserve.pop
-      ungetc ch
-    end
-
-    token_class = output_heredoc ? RDoc::RubyLex::TkHEREDOC : Ltype2Token[lt]
     @ltype = ltback
-    @lex_state = :EXPR_END
-    Token(token_class, doc)
+    @lex_state = :EXPR_BEG
+    [Token(RDoc::RubyLex::TkHEREDOC, doc), heredoc_end]
   end
 
   def identify_quotation

--- a/lib/rdoc/ruby_token.rb
+++ b/lib/rdoc/ruby_token.rb
@@ -329,6 +329,8 @@ module RDoc::RubyToken
     [:TkCVAR,       TkId],
     [:TkIVAR,       TkId],
     [:TkCONSTANT,   TkId],
+    [:TkHEREDOCBEG, TkId],
+    [:TkHEREDOCEND, TkId],
 
     [:TkINTEGER,    TkVal],
     [:TkFLOAT,      TkVal],

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -89,9 +89,11 @@ end
       @TK::TkIDENTIFIER.new( 4, 1,  4, 'x'),
       @TK::TkNL        .new( 5, 1,  5, "\n"),
       @TK::TkSPACE     .new( 6, 2,  0, '  '),
-      @TK::TkHEREDOC   .new( 8, 2,  2,
-                            %Q{<<E\nLine 1\nLine 2\nE}),
-      @TK::TkNL        .new(27, 5, 28, "\n"),
+
+      @TK::TkHEREDOCBEG.new( 8, 2,  2, '<<E'),
+      @TK::TkNL        .new(11, 2,  6, "\n"),
+      @TK::TkHEREDOC   .new(11, 2,  6, "Line 1\nLine 2\n"),
+      @TK::TkHEREDOCEND.new(27, 5, 26, "E\n"),
       @TK::TkEND       .new(28, 6,  0, 'end'),
       @TK::TkNL        .new(31, 6, 28, "\n"),
     ]
@@ -147,10 +149,12 @@ Line 2\r
       @TK::TkSPACE     .new( 6, 1,  6, ' '),
       @TK::TkASSIGN    .new( 7, 1,  7, '='),
       @TK::TkSPACE     .new( 8, 1,  8, ' '),
-      @TK::TkHEREDOC   .new( 9, 1,  9,
-                            %Q{<<-STRING\nLine 1\nLine 2\n  STRING}),
-      @TK::TkSPACE     .new(44, 4, 45, "\r"),
-      @TK::TkNL        .new(45, 4, 46, "\n"),
+      @TK::TkHEREDOCBEG.new( 9, 1,  9, '<<-STRING'),
+      @TK::TkSPACE     .new(18, 1, 18, "\r"),
+      @TK::TkNL        .new(19, 1, 19, "\n"),
+      @TK::TkHEREDOC   .new(19, 1, 19,
+                            %Q{Line 1\nLine 2\n}),
+      @TK::TkHEREDOCEND.new(45, 4, 36, "  STRING\n"),
     ]
 
     assert_equal expected, tokens
@@ -169,10 +173,12 @@ Line 2
       @TK::TkSPACE     .new( 6, 1,  6, ' '),
       @TK::TkASSIGN    .new( 7, 1,  7, '='),
       @TK::TkSPACE     .new( 8, 1,  8, ' '),
-      @TK::TkSTRING    .new( 9, 1,  9, %Q{"Line 1\nLine 2\n"}),
-      @TK::TkDOT       .new(41, 4, 42, '.'),
-      @TK::TkIDENTIFIER.new(42, 4, 43, 'chomp'),
-      @TK::TkNL        .new(47, 4, 48, "\n"),
+      @TK::TkHEREDOCBEG.new( 9, 1,  9, '<<-STRING'),
+      @TK::TkDOT       .new(18, 1, 18, '.'),
+      @TK::TkIDENTIFIER.new(19, 1, 19, 'chomp'),
+      @TK::TkNL        .new(24, 1, 24, "\n"),
+      @TK::TkHEREDOC   .new(24, 1, 24, "Line 1\nLine 2\n"),
+      @TK::TkHEREDOCEND.new(47, 4, 39, "  STRING\n"),
     ]
 
     assert_equal expected, tokens
@@ -191,9 +197,12 @@ Line 2
       @TK::TkSPACE     .new( 6, 1,  6, ' '),
       @TK::TkASSIGN    .new( 7, 1,  7, '='),
       @TK::TkSPACE     .new( 8, 1,  8, ' '),
-      @TK::TkHEREDOC   .new( 9, 1,  9,
-                            %Q{<<-STRING\nLine 1\nLine 2\n  STRING}),
-      @TK::TkNL        .new(41, 4, 42, "\n"),
+
+
+      @TK::TkHEREDOCBEG.new( 9, 1,  9, '<<-STRING'),
+      @TK::TkNL        .new(18, 1, 18, "\n"),
+      @TK::TkHEREDOC   .new(18, 1, 18, "Line 1\nLine 2\n"),
+      @TK::TkHEREDOCEND.new(41, 4, 33, "  STRING\n")
     ]
 
     assert_equal expected, tokens
@@ -223,8 +232,10 @@ U
       @TK::TkSPACE     .new( 1, 1,  1, ' '),
       @TK::TkIDENTIFIER.new( 2, 1,  2, 'b'),
       @TK::TkSPACE     .new( 3, 1,  3, ' '),
-      @TK::TkHEREDOC   .new( 4, 1,  4, %Q{<<-U\n%N\nU}),
-      @TK::TkNL        .new(13, 3, 14, "\n"),
+      @TK::TkHEREDOCBEG.new( 4, 1,  4, '<<-U'),
+      @TK::TkNL        .new( 8, 1,  8, "\n"),
+      @TK::TkHEREDOC   .new( 8, 1,  8, "%N\n"),
+      @TK::TkHEREDOCEND.new(13, 3, 12, "U\n")
     ]
 
     assert_equal expected, tokens


### PR DESCRIPTION
The here-documents in middle of line are replaced with string literal. It's useful for IRB, but it doesn't fit for documentation.

For example,

```ruby
def example
  puts [<<~TILDE, <<-HYPHEN, <<~'TILDE', <<-'HYPHEN', <<'AAA', <<"BBB", <<-`CCC`]
    a
      b
      c
    d
  TILDE
    1
      2
      3
    4
  HYPHEN
    w
      x
      y
    z
  TILDE
    1
      2
      3
    4
  HYPHEN
aaa
aa
a
AAA
bbb
bb
b
BBB
echo 'a'
echo 'b'
echo 'c'
CCC
end
```

MRI processes this code and outputs correctly. This is highlighted below:

```html
<pre>
<span class="ruby-keyword">def</span> <span class="ruby-identifier">example</span>
  <span class="ruby-identifier">puts</span> [<span class="ruby-operator">&lt;&lt;</span><span class="ruby-operator">~</span><span class="ruby-constant">TILDE</span>, <span class="ruby-string">&quot;    a
      b
      c
    d
  TILDE
    1
      2
      3
    4
&quot;</span>, <span class="ruby-operator">&lt;&lt;</span><span class="ruby-operator">~</span><span class="ruby-string">&#39;TILDE&#39;</span>, <span class="ruby-string">&quot;    w
      x
      y
    z
  TILDE
    1
      2
      3
    4
&quot;</span>, <span class="ruby-string">&quot;aaa
aa
a
&quot;</span>, <span class="ruby-string">&quot;bbb
bb
b
&quot;</span>, <span class="ruby-value">&quot;echo &#39;a&#39;
echo &#39;b&#39;
echo &#39;c&#39;
&quot;</span>]
<span class="ruby-keyword">end</span>
</pre>
```

![extracted here-documents](https://i.gyazo.com/b43f39d709d492f8e4b7b0899b13deae.png)

I think this is broken document.

This Pull Request fixes it:

```html
<pre>
<span class="ruby-keyword">def</span> <span class="ruby-identifier">example</span>
  <span class="ruby-identifier">puts</span> [<span class="ruby-identifier">&lt;&lt;~TILDE</span>, <span class="ruby-identifier">&lt;&lt;-HYPHEN</span>, <span class="ruby-identifier">&lt;&lt;~&#39;TILDE&#39;</span>, <span class="ruby-identifier">&lt;&lt;-&#39;HYPHEN&#39;</span>, <span class="ruby-identifier">&lt;&lt;&#39;AAA&#39;</span>, <span class="ruby-identifier">&lt;&lt;&quot;BBB&quot;</span>, <span class="ruby-identifier">&lt;&lt;-`CCC`</span>]
<span class="ruby-value">    a
      b
      c
    d
</span><span class="ruby-identifier">  TILDE
</span><span class="ruby-value">    1
      2
      3
    4
</span><span class="ruby-identifier">  HYPHEN
</span><span class="ruby-value">    w
      x
      y
    z
</span><span class="ruby-identifier">  TILDE
</span><span class="ruby-value">    1
      2
      3
    4
</span><span class="ruby-identifier">  HYPHEN
</span><span class="ruby-value">aaa
aa
a
</span><span class="ruby-identifier">AAA
</span><span class="ruby-value">bbb
bb
b
</span><span class="ruby-identifier">BBB
</span><span class="ruby-value">echo &#39;a&#39;
echo &#39;b&#39;
echo &#39;c&#39;
</span><span class="ruby-identifier">CCC
</span><span class="ruby-keyword">end</span></pre>
```

![correct code quotation](https://i.gyazo.com/520eabfdbf468427a2d80948a5d2c621.png)
