### PR TITLE
Fix n-ary detecting condition for rational and imaginary

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1107,7 +1107,7 @@ class RDoc::RubyLex
 
     num = op
 
-    if peek(0) == "0" && peek(1) !~ /[.eE]/
+    if peek(0) == "0" && peek(1) !~ /[.eEri]/
       num << getc
 
       case peek(0)

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -486,7 +486,7 @@ U
   end
 
   def test_rational_imaginary_tokenize
-    tokens = RDoc::RubyLex.tokenize '1.11r + 2.34i + 5.55ri', nil
+    tokens = RDoc::RubyLex.tokenize '1.11r + 2.34i + 5.55ri + 0i', nil
 
     expected = [
       @TK::TkRATIONAL .new( 0, 1,  0, '1.11r'),
@@ -498,7 +498,11 @@ U
       @TK::TkPLUS     .new(14, 1, 14, '+'),
       @TK::TkSPACE    .new(15, 1, 15, ' '),
       @TK::TkIMAGINARY.new(16, 1, 16, '5.55ri'),
-      @TK::TkNL       .new(22, 1, 22, "\n"),
+      @TK::TkSPACE    .new(22, 1, 22, ' '),
+      @TK::TkPLUS     .new(23, 1, 23, '+'),
+      @TK::TkSPACE    .new(24, 1, 24, ' '),
+      @TK::TkIMAGINARY.new(25, 1, 25, '0i'),
+      @TK::TkNL       .new(27, 1, 27, "\n"),
     ]
 
     assert_equal expected, tokens


### PR DESCRIPTION
The `0i` as imaginary and `0r` as rational are confusable with n-ary notation, such as `0x1F` as hexadecimal, `0o37` and `037` as octal, `0b011111` as binary and others.