### PR TITLE
Fix postfix if after escaped newline

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -112,6 +112,7 @@ class RDoc::RubyLex
     @indent_stack = []
     @lex_state = :EXPR_BEG
     @space_seen = false
+    @escaped_nl = false
 
     @continue = false
     @line = ""
@@ -491,7 +492,7 @@ class RDoc::RubyLex
           @continue = true
         else
           @continue = false
-          @lex_state = :EXPR_BEG
+          @lex_state = :EXPR_BEG unless @escaped_nl
           until (@indent_stack.empty? ||
                  [TkLPAREN, TkLBRACK, TkLBRACE,
                    TkfLPAREN, TkfLBRACK, TkfLBRACE].include?(@indent_stack.last))
@@ -502,6 +503,7 @@ class RDoc::RubyLex
         @here_readed.clear
         tk = Token(TkNL)
       end
+      @escaped_nl = false
       tk
     end
 
@@ -870,6 +872,7 @@ class RDoc::RubyLex
       if peek(0) == "\n"
         @space_seen = true
         @continue = true
+        @escaped_nl = true
       end
       Token("\\")
     end

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -428,6 +428,44 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_postfix_if_after_escaped_newline
+    tokens = RDoc::RubyLex.tokenize <<'RUBY', nil
+def a
+  1 if true
+  1 \
+    if true
+end
+RUBY
+
+    expected = [
+      @TK::TkDEF       .new( 0, 1, 0,  "def"),
+      @TK::TkSPACE     .new( 3, 1, 3,  " "),
+      @TK::TkIDENTIFIER.new( 4, 1, 4,  "a"),
+      @TK::TkNL        .new( 5, 1, 5,  "\n"),
+      @TK::TkSPACE     .new( 6, 2, 0,  "  "),
+      @TK::TkINTEGER   .new( 8, 2, 2,  "1"),
+      @TK::TkSPACE     .new( 9, 2, 3,  " "),
+      @TK::TkIF_MOD    .new(10, 2, 4,  "if"),
+      @TK::TkSPACE     .new(12, 2, 6,  " "),
+      @TK::TkTRUE      .new(13, 2, 7,  "true"),
+      @TK::TkNL        .new(17, 2, 6,  "\n"),
+      @TK::TkSPACE     .new(18, 3, 0,  "  "),
+      @TK::TkINTEGER   .new(20, 3, 2,  "1"),
+      @TK::TkSPACE     .new(21, 3, 3,  " "),
+      @TK::TkBACKSLASH .new(22, 3, 4,  "\\"),
+      @TK::TkNL        .new(23, 3, 18, "\n"),
+      @TK::TkSPACE     .new(24, 4, 0,  "    "),
+      @TK::TkIF_MOD    .new(28, 4, 4,  "if"),
+      @TK::TkSPACE     .new(30, 4, 6,  " "),
+      @TK::TkTRUE      .new(31, 4, 7,  "true"),
+      @TK::TkNL        .new(35, 4, 24, "\n"),
+      @TK::TkEND       .new(36, 5, 0,  "end"),
+      @TK::TkNL        .new(39, 5, 36, "\n")
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_string_escape
     tokens = RDoc::RubyLex.tokenize '"\\n"', nil
     assert_equal @TK::TkSTRING.new( 0, 1,  0, "\"\\n\""), tokens.first


### PR DESCRIPTION
In the `identify_identifier` method, if `@lex_state != :EXPR_BEG && @lex_state != :EXPR_FNAME`, `TkIF` becomes `TkIF_MOD`. So when `"\n"` comes after escaped backslash, doesn't set `:EXPR_BEG` to `@lex_state` with this commit. This commit fixes correctly handling `TkIF_MOD` after escaped newline.