### PR TITLE
Fix postfix if/unless/while/until after heredoc

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1132,7 +1132,7 @@ class RDoc::RubyLex
       indent: indent,
       started: false
     }
-    @lex_state = :EXPR_BEG
+    @lex_state = :EXPR_END
     Token(RDoc::RubyLex::TkHEREDOCBEG, start_token)
   end
 

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2499,6 +2499,35 @@ EXPTECTED
     assert_equal markup_code, expected
   end
 
+  def test_parse_statements_postfix_if_after_heredocbeg
+    @filename = 'file.rb'
+    util_parser <<RUBY
+class Foo
+  def blah()
+    <<~EOM if true
+    EOM
+  end
+end
+RUBY
+
+    expected = <<EXPTECTED
+  <span class="ruby-keyword">def</span> <span class="ruby-identifier">blah</span>()
+    <span class="ruby-identifier">&lt;&lt;~EOM</span> <span class="ruby-keyword">if</span> <span class="ruby-keyword">true</span>
+<span class="ruby-value"></span><span class="ruby-identifier">    EOM
+</span>  <span class="ruby-keyword">end</span>
+EXPTECTED
+    expected = expected.rstrip
+
+    @parser.scan
+
+    foo = @top_level.classes.first
+    assert_equal 'Foo', foo.full_name
+
+    blah = foo.method_list.first
+    markup_code = blah.markup_code.sub(/^.*\n/, '')
+    assert_equal markup_code, expected
+  end
+
   def test_parse_require_dynamic_string
     content = <<-RUBY
 prefix = 'path'


### PR DESCRIPTION
The postfix `if`/`unless`/`while`/`until` are detected by what `@lex_state` is `:EXPR_END`. So sets `:EXPR_END` on `@lex_state` when `TkHEREDOCBEG` is created.