### PR TITLE
Fix escape behavior in single quote string literal

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1337,7 +1337,7 @@ class RDoc::RubyLex
             when @ltype
               str << ch
             else
-              ungetc
+              str << ch
             end
           else
             str << read_escape

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -417,6 +417,17 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_single_quote_escape
+    tokens = RDoc::RubyLex.tokenize %q{'\\\\ \\' \\&'}, nil
+
+    expected = [
+      @TK::TkSTRING.new( 0, 1,  0, %q{'\\\\ \\' \\&'}),
+      @TK::TkNL    .new(10, 1, 10, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_string
     tokens = RDoc::RubyLex.tokenize "'hi'", nil
 


### PR DESCRIPTION
Remove addtion unnecessary `\` after escape character `\`.