### PR TITLE
Support safe navigation operator

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -668,16 +668,16 @@ class RDoc::RubyLex
       end
     end
 
-    @OP.def_rule(".") do
+    @OP.def_rules(".", "&.") do
       |op, io|
       @lex_state = :EXPR_BEG
       if peek(0) =~ /[0-9]/
         ungetc
         identify_number
       else
-        # for "obj.if" etc.
+        # for "obj.if" or "obj&.if" etc.
         @lex_state = :EXPR_DOT
-        Token(TkDOT)
+        Token(op)
       end
     end
 

--- a/lib/rdoc/ruby_token.rb
+++ b/lib/rdoc/ruby_token.rb
@@ -401,6 +401,7 @@ module RDoc::RubyToken
 
     [:TkASSIGN,     Token,  "="],
     [:TkDOT,        Token,  "."],
+    [:TkSAFENAV,    Token,  "&."],
     [:TkLPAREN,     Token,  "("],  #(exp)
     [:TkLBRACK,     Token,  "["],  #[arry]
     [:TkLBRACE,     Token,  "{"],  #{hash}

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -132,6 +132,19 @@ end
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_safe_nav_operator
+    tokens = RDoc::RubyLex.tokenize 'receiver&.meth', nil
+
+    expected = [
+      @TK::TkIDENTIFIER.new( 0, 1,  0, "receiver"),
+      @TK::TkSAFENAV   .new( 8, 1,  8, "&."),
+      @TK::TkIDENTIFIER.new(10, 1, 10, "meth"),
+      @TK::TkNL        .new(14, 1, 14, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_hash_rocket
     tokens = RDoc::RubyLex.tokenize '{ :class => "foo" }', nil
 


### PR DESCRIPTION
The safe navigation operator is an operator from the name, but it's a variety of dot token for method calling. So `TkSAFENAV` class inherited `Token` class instead of `TkOp` class.