### PR TITLE
Fix for symbol detection when nested method

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1073,7 +1073,7 @@ class RDoc::RubyLex
         token.concat getc
       end
     elsif @lex_state == :EXPR_BEG || @lex_state == :EXPR_DOT ||
-          @lex_state == :EXPR_ARG
+          @lex_state == :EXPR_ARG || @lex_state == :EXPR_MID
       @lex_state = :EXPR_ARG
     else
       @lex_state = :EXPR_END

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -520,6 +520,21 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_symbol_for_nested_method
+    tokens = RDoc::RubyLex.tokenize 'return untrace_var :name', nil
+
+    expected = [
+      @TK::TkRETURN    .new( 0, 1,  0, "return"),
+      @TK::TkSPACE     .new( 6, 1,  6, " "),
+      @TK::TkIDENTIFIER.new( 7, 1,  7, "untrace_var"),
+      @TK::TkSPACE     .new(18, 1, 18, " "),
+      @TK::TkSYMBOL    .new(19, 1, 19, ":name"),
+      @TK::TkNL        .new(24, 1, 24, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_unary_minus
     ruby_lex = RDoc::RubyLex.new("-1", nil)
     assert_equal("-1", ruby_lex.token.value)


### PR DESCRIPTION
When nested method as identifer detected, `@lex_state` is `:EXPR_MID` and it becomes `:EXPR_END`. However, in `:` token processing, `TkSYMBEG` is generated only when `@lex_state` is not `:EXPR_END`. So symbol for nested method becomes `TkCOLON` as distinct from `TkSYMBEG`.

This Pull Request fixes the behavior.

Before:

![before](https://i.gyazo.com/72bad2bbb60ec47fdc5d57b7d15f9326.png)

The symbol, `:name`, it consists `TkCOLON` and `TkIDENTIFIER`.

After(fixed):

![after(fixed)](https://i.gyazo.com/a22e752ffbf6ec20d9fd04745ab21383.png)

The `:name` is a symbol.
