### PR TITLE
Handle TkPLUS or TkMINUS and number as TkINTEGER

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -376,6 +376,10 @@ class RDoc::RubyLex
       else
         tk = tk1
       end
+    elsif (TkPLUS === tk or TkMINUS === tk) and peek(0) =~ /\d/ then
+      tk1 = token
+      set_token_position tk.seek, tk.line_no, tk.char_no
+      tk = Token(tk1.class, tk.text + tk1.text)
     end
     #      Tracer.off
     tk

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -339,6 +339,19 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_number_with_sign_character
+    tokens = RDoc::RubyLex.tokenize "+3--3r", nil
+
+    expected = [
+      @TK::TkINTEGER .new(0, 1, 0, "+3"),
+      @TK::TkMINUS   .new(2, 1, 2, "-"),
+      @TK::TkRATIONAL.new(3, 1, 3, "-3r"),
+      @TK::TkNL      .new(6, 1, 6, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_string
     tokens = RDoc::RubyLex.tokenize "'hi'", nil
 


### PR DESCRIPTION
For example, lexical analyser splitted sign character and follow number such as `-5r` to `-` and `5r`, `+1.08` to `+` and `1.08`. But this `-` or `+` is a part of number and not operator. So this Pull Request joins it.