### PR TITLE
Fix regexp literal in oneliner

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1502,6 +1502,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       end
       tk = get_tk
     end
+    @scanner.first_in_method_statement = true
 
     get_tkread_clean(/\s+/, ' ')
   end

--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -45,6 +45,7 @@ class RDoc::RubyLex
 
   attr_accessor :continue
   attr_accessor :lex_state
+  attr_accessor :first_in_method_statement
   attr_reader :reader
 
   class << self
@@ -112,6 +113,7 @@ class RDoc::RubyLex
     @indent_stack = []
     @lex_state = :EXPR_BEG
     @space_seen = false
+    @first_in_method_statement = false
 
     @continue = false
     @line = ""
@@ -352,6 +354,7 @@ class RDoc::RubyLex
       begin
         tk = @OP.match(self)
         @space_seen = tk.kind_of?(TkSPACE)
+        @first_in_method_statement = false if !@space_seen && @first_in_method_statement
       rescue SyntaxError => e
         raise Error, "syntax error: #{e.message}" if
           @exception_on_syntax_error
@@ -727,7 +730,7 @@ class RDoc::RubyLex
       if :EXPR_FNAME == @lex_state or :EXPR_DOT == @lex_state
         @lex_state = :EXPR_ARG
         Token(TkId, op)
-      elsif @lex_state == :EXPR_BEG || @lex_state == :EXPR_MID
+      elsif @lex_state == :EXPR_BEG || @lex_state == :EXPR_MID || @first_in_method_statement
         identify_string(op)
       elsif peek(0) == '='
         getc

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2499,6 +2499,28 @@ EXPTECTED
     assert_equal markup_code, expected
   end
 
+  def test_parse_statements_method_oneliner_with_regexp
+    util_parser <<RUBY
+class Foo
+  def blah() /bar/ end
+end
+RUBY
+
+    expected = <<EXPTECTED
+<span class="ruby-keyword">def</span> <span class="ruby-identifier">blah</span>() <span class="ruby-regexp">/bar/</span> <span class="ruby-keyword">end</span>
+EXPTECTED
+    expected = expected.rstrip
+
+    @parser.scan
+
+    foo = @top_level.classes.first
+    assert_equal 'Foo', foo.full_name
+
+    blah = foo.method_list.first
+    markup_code = blah.markup_code.sub(/^.*\n/, '')
+    assert_equal expected, markup_code
+  end
+
   def test_parse_require_dynamic_string
     content = <<-RUBY
 prefix = 'path'


### PR DESCRIPTION
Regexp literal is detected by what `@lex_state` is `:EXPR_BEG` or `:EXPR_MID`. But when regexp literal is after method name in oneliner, `@lex_state` is `:EXPR_END` and the regexp literal becomes broken tokens.

This Pull Request fixes it.