### PR TITLE
Support quoted symbol for JSON-style hash literal

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -112,6 +112,7 @@ class RDoc::RubyLex
     @indent_stack = []
     @lex_state = :EXPR_BEG
     @space_seen = false
+    @after_question = false
 
     @continue = false
     @line = ""
@@ -379,6 +380,8 @@ class RDoc::RubyLex
         tk = tk1
       end
     end
+    @after_question = false if @after_question and !(TkQUESTION === tk)
+
     #      Tracer.off
     tk
   end
@@ -593,6 +596,7 @@ class RDoc::RubyLex
       |op, io|
       if @lex_state == :EXPR_END
         @lex_state = :EXPR_BEG
+        @after_question = true
         Token(TkQUESTION)
       else
         ch = getc
@@ -1359,7 +1363,10 @@ class RDoc::RubyLex
         end
       end
 
-      if subtype
+      if peek(0) == ':' and !peek_match?(/^::/) and :EXPR_BEG == @lex_state and !@after_question
+        str.concat getc
+        return Token(TkSYMBOL, str)
+      elsif subtype
         Token(DLtype2Token[ltype], str)
       else
         Token(Ltype2Token[ltype], str)

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -558,6 +558,36 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_symbol_with_quote
+    tokens = RDoc::RubyLex.tokenize <<RUBY, nil
+a.include?()?"a":"b"
+{"t":1,'t2':2}
+RUBY
+
+    expected = [
+      @TK::TkIDENTIFIER.new( 0, 1,  0, "a"),
+      @TK::TkDOT       .new( 1, 1,  1, "."),
+      @TK::TkFID       .new( 2, 1,  2, "include?"),
+      @TK::TkLPAREN    .new(10, 1, 10, "("),
+      @TK::TkRPAREN    .new(11, 1, 11, ")"),
+      @TK::TkQUESTION  .new(12, 1, 12, "?"),
+      @TK::TkSTRING    .new(13, 1, 13, "\"a\""),
+      @TK::TkCOLON     .new(16, 1, 16, ":"),
+      @TK::TkSTRING    .new(17, 1, 17, "\"b\""),
+      @TK::TkNL        .new(20, 1, 20, "\n"),
+      @TK::TkLBRACE    .new(21, 2,  0, "{"),
+      @TK::TkSYMBOL    .new(22, 2,  1, "\"t\":"),
+      @TK::TkINTEGER   .new(26, 2,  5, "1"),
+      @TK::TkCOMMA     .new(27, 2,  6, ","),
+      @TK::TkSYMBOL    .new(28, 2,  7, "'t2':"),
+      @TK::TkINTEGER   .new(33, 2, 12, "2"),
+      @TK::TkRBRACE    .new(34, 2, 13, "}"),
+      @TK::TkNL        .new(35, 2, 21, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_unary_minus
     ruby_lex = RDoc::RubyLex.new("-1", nil)
     assert_equal("-1", ruby_lex.token.value)


### PR DESCRIPTION
Like below:

{ 'first': 1, "second": 2 }