### PR TITLE
Fix % literal with the same sign of original

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1306,7 +1306,7 @@ class RDoc::RubyLex
     @ltype = ltype
     @quoted = quoted
 
-    str = if ltype == quoted and %w[" ' /].include? ltype then
+    str = if ltype == quoted and %w[" ' / `].include? ltype and type.nil? then
             ltype.dup
           else
             "%#{type}#{PERCENT_PAREN_REV[quoted]||quoted}"

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -358,6 +358,39 @@ U
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_percent_r_with_slash
+    tokens = RDoc::RubyLex.tokenize '%r/hi/', nil
+
+    expected = [
+      @TK::TkREGEXP.new( 0, 1,  0, '%r/hi/'),
+      @TK::TkNL    .new( 6, 1, 6, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
+  def test_class_tokenize_percent_large_q
+    tokens = RDoc::RubyLex.tokenize '%Q/hi/', nil
+
+    expected = [
+      @TK::TkSTRING.new( 0, 1,  0, '%Q/hi/'),
+      @TK::TkNL    .new( 6, 1, 6, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
+  def test_class_tokenize_percent_large_q_with_double_quote
+    tokens = RDoc::RubyLex.tokenize '%Q"hi"', nil
+
+    expected = [
+      @TK::TkSTRING.new( 0, 1,  0, '%Q"hi"'),
+      @TK::TkNL    .new( 6, 1, 6, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_percent_w
     tokens = RDoc::RubyLex.tokenize '%w[hi]', nil
 


### PR DESCRIPTION
In `identify_string method`, `%` literal is detected by literal type and quote sign. So `%r/regexp/` is treated as `/regexp/`, because literal type is regexp and quote sign is `/`, it's the same. This commit fix it by checking `type` argument what is given only when `%` literal.