### PR TITLE
Context#each_section yields only #display? items

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -762,7 +762,7 @@ class RDoc::Context < RDoc::CodeObject
     attributes.default = []
 
     sort_sections.each do |section|
-      yield section, constants[section].sort, attributes[section].sort
+      yield section, constants[section].select(&:display?).sort, attributes[section].select(&:display?).sort
     end
   end
 

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -26,8 +26,6 @@
   </section>
 
   <% klass.each_section do |section, constants, attributes| %>
-  <% constants = constants.select { |const| const.display? } %>
-  <% attributes = attributes.select { |attr| attr.display? } %>
   <section id="<%= section.aref %>" class="documentation-section">
     <% if section.title then %>
     <header class="documentation-section-title">

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -481,6 +481,32 @@ class TestRDocContext < XrefTestCase
     assert_equal expected_attrs, attrs
   end
 
+  def test_each_section_only_display
+    sects  = []
+    consts = []
+    attrs  = []
+
+    @c7.each_section do |section, constants, attributes|
+      sects  << section
+      consts << constants
+      attrs  << attributes
+    end
+
+    assert_equal [nil], sects.map { |section| section.title }
+
+    expected_consts = [
+      @c7.constants.select(&:display?).sort
+    ]
+
+    assert_equal expected_consts, consts
+
+    expected_attrs = [
+      @c7.attributes.select(&:display?).sort
+    ]
+
+    assert_equal expected_attrs, attrs
+  end
+
   def test_each_section_enumerator
     assert_kind_of Enumerator, @c1.each_section
   end

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -162,7 +162,7 @@ class TestRDocStore < XrefTestCase
 
   def test_all_classes_and_modules
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7
       Child
       M1 M1::M2
       Parent
@@ -213,7 +213,7 @@ class TestRDocStore < XrefTestCase
 
   def test_classes
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7
       Child
       Parent
     ]

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -82,6 +82,18 @@ class C6
   def prot6() end
 end
 
+class C7
+  attr_reader :attr_reader
+  attr_reader :attr_reader_nodoc # :nodoc:
+  attr_writer :attr_writer
+  attr_writer :attr_writer_nodoc # :nodoc:
+  attr_accessor :attr_accessor
+  attr_accessor :attr_accessor_nodoc # :nodoc:
+
+  CONST = :const
+  CONST_NODOC = :const_nodoc # :nodoc:
+end
+
 module M1
   def m
   end

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -52,6 +52,7 @@ class XrefTestCase < RDoc::TestCase
     @c3_h1 = @xref_data.find_module_named 'C3::H1'
     @c3_h2 = @xref_data.find_module_named 'C3::H2'
     @c6    = @xref_data.find_module_named 'C6'
+    @c7    = @xref_data.find_module_named 'C7'
 
     @m1    = @xref_data.find_module_named 'M1'
     @m1_m  = @m1.method_list.first


### PR DESCRIPTION
`Context#each_section` yields all constants and attributes, but RDoc treats only displayed items for documentation. The Darkfish template, `lib/rdoc/generator/template/darkfish/class.rhtml`, it [retrieves items only what `#display?` is true inside `#each_section`](https://github.com/ruby/rdoc/blob/a92b02ee7e717f5d291afbf549d02230fbd492db/lib/rdoc/generator/template/darkfish/class.rhtml#L29-L30). It's strange behavior. I think `#each_section` should return only displayed items.

This Pull Request fixes it.