### PR TITLE
homepage in the gemspec points at non-existent page

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 RDoc produces HTML and command-line documentation for Ruby projects.
 RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentation from the command-line.
   DESCRIPTION
-  s.homepage = "https://rdoc.github.io/rdoc"
+  s.homepage = "https://ruby.github.io/rdoc"
   s.licenses = ["Ruby"]
 
   s.bindir = "exe"


### PR DESCRIPTION
The homepage is also located under ruby organization now.