### PR TITLE
Do not require rdoc from rdoc.gemspec

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -52,4 +52,5 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.add_development_dependency("racc", "> 1.4.10")
   s.add_development_dependency("kpeg")
   s.add_development_dependency("minitest", "~> 4")
+  s.add_development_dependency("json")
 end

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -1,6 +1,4 @@
-# -*- encoding: utf-8 -*-
-$:.unshift File.expand_path("../lib", __FILE__)
-require 'rdoc'
+require_relative "lib/rdoc"
 
 Gem::Specification.new do |s|
   s.name = "rdoc"


### PR DESCRIPTION
Use require_relative instead.

When running under a Bundler environment (e.g., 'bundle exec rake -T'),
RubyGems first activates the RDoc installed globally through the require
statement in rdoc.gemspec. This is problematic since Bundler then tries
to activate the gemspec defined in rdoc.gemspec. They don't match and
this causes an error like this:

	bundler: failed to load command: rake (/tmp/rdoc/.bundle/gems/ruby/2.5.0/bin/rake)
	Gem::LoadError: You have already activated rdoc 5.1.0, but your Gemfile requires rdoc 6.0.0.beta1. Since rdoc is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports rdoc as a default gem.
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:317:in `check_for_activated_spec!'
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:32:in `block in setup'
	  /opt/ruby/trunk/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	  /opt/ruby/trunk/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:27:in `map'
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:27:in `setup'
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler.rb:101:in `setup'
	  /opt/ruby/trunk/lib/ruby/gems/2.5.0/gems/bundler-1.15.4/lib/bundler/setup.rb:9:in `<top (required)>'
	  /opt/ruby/trunk/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:60:in `require'
	  /opt/ruby/trunk/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:60:in `require'