### PR TITLE
Support constant visibility

### DIFF
--- a/lib/rdoc/constant.rb
+++ b/lib/rdoc/constant.rb
@@ -36,7 +36,7 @@ class RDoc::Constant < RDoc::CodeObject
     @value = value
 
     @is_alias_for = nil
-    @visibility   = nil
+    @visibility   = :public
 
     self.comment = comment
   end
@@ -136,7 +136,7 @@ class RDoc::Constant < RDoc::CodeObject
     initialize array[1], nil, array[5]
 
     @full_name     = array[2]
-    @visibility    = array[3]
+    @visibility    = array[3] || :public
     @is_alias_for  = array[4]
     #                      5 handled above
     #                      6 handled below

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -1079,6 +1079,7 @@ class RDoc::Context < RDoc::CodeObject
     return if [:private, :nodoc].include? min_visibility
     remove_invisible_in @method_list, min_visibility
     remove_invisible_in @attributes, min_visibility
+    remove_invisible_in @constants, min_visibility
   end
 
   ##
@@ -1162,6 +1163,17 @@ class RDoc::Context < RDoc::CodeObject
   def set_visibility_for(methods, visibility, singleton = false)
     methods_matching methods, singleton do |m|
       m.visibility = visibility
+    end
+  end
+
+  ##
+  # Given an array +names+ of constants, set the visibility of each constant to
+  # +visibility+
+
+  def set_constant_visibility_for(names, visibility)
+    names.each do |name|
+      constant = @constants_hash[name] or next
+      constant.visibility = visibility
     end
   end
 

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -24,6 +24,7 @@ $TOKEN_DEBUG ||= nil
 # * aliases
 # * private, public, protected
 # * private_class_function, public_class_function
+# * private_constant, public_constant
 # * module_function
 # * attr, attr_reader, attr_writer, attr_accessor
 # * extra accessors given on the command line
@@ -1084,6 +1085,9 @@ class RDoc::Parser::Ruby < RDoc::Parser
          'public_class_method', 'module_function' then
       parse_visibility container, single, tk
       return true
+    when 'private_constant', 'public_constant'
+      parse_constant_visibility container, single, tk
+      return true
     when 'attr' then
       parse_attr container, single, tk, comment
     when /^attr_(reader|writer|accessor)$/ then
@@ -1886,6 +1890,22 @@ class RDoc::Parser::Ruby < RDoc::Parser
     else
       update_visibility container, vis_type, vis, singleton
     end
+  end
+
+  ##
+  # Parses a Module#private_constant or Module#public_constant call from +tk+.
+
+  def parse_constant_visibility(container, single, tk)
+    args = parse_symbol_arg
+    case tk.name
+    when 'private_constant'
+      vis = :private
+    when 'public_constant'
+      vis = :public
+    else
+      raise RDoc::Error, 'Unreachable'
+    end
+    container.set_constant_visibility_for args, vis
   end
 
   ##

--- a/test/test_rdoc_constant.rb
+++ b/test/test_rdoc_constant.rb
@@ -86,7 +86,7 @@ class TestRDocConstant < XrefTestCase
     assert_equal top_level,      loaded.file
     assert_equal 'Klass::CONST', loaded.full_name
     assert_equal 'CONST',        loaded.name
-    assert_nil                   loaded.visibility
+    assert_equal :public,        loaded.visibility
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
   end
@@ -114,7 +114,7 @@ class TestRDocConstant < XrefTestCase
     assert_equal top_level,      loaded.file
     assert_equal 'Klass::CONST', loaded.full_name
     assert_equal 'CONST',        loaded.name
-    assert_nil                   loaded.visibility
+    assert_equal :public,        loaded.visibility
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
 
@@ -146,7 +146,7 @@ class TestRDocConstant < XrefTestCase
     assert_equal top_level,      loaded.file
     assert_equal 'Klass::CONST', loaded.full_name
     assert_equal 'CONST',        loaded.name
-    assert_nil                   loaded.visibility
+    assert_equal :public,        loaded.visibility
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
 

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -719,6 +719,7 @@ class TestRDocContext < XrefTestCase
 
     assert_equal [@pub, @prot, @priv], @vis.method_list
     assert_equal [@apub, @aprot, @apriv], @vis.attributes
+    assert_equal [@cpub, @cpriv], @vis.constants
   end
 
   def test_remove_invisible_nodoc
@@ -728,6 +729,7 @@ class TestRDocContext < XrefTestCase
 
     assert_equal [@pub, @prot, @priv], @vis.method_list
     assert_equal [@apub, @aprot, @apriv], @vis.attributes
+    assert_equal [@cpub, @cpriv], @vis.constants
   end
 
   def test_remove_invisible_protected
@@ -737,6 +739,7 @@ class TestRDocContext < XrefTestCase
 
     assert_equal [@pub, @prot], @vis.method_list
     assert_equal [@apub, @aprot], @vis.attributes
+    assert_equal [@cpub], @vis.constants
   end
 
   def test_remove_invisible_public
@@ -746,6 +749,7 @@ class TestRDocContext < XrefTestCase
 
     assert_equal [@pub], @vis.method_list
     assert_equal [@apub], @vis.attributes
+    assert_equal [@cpub], @vis.constants
   end
 
   def test_remove_invisible_public_force
@@ -755,11 +759,13 @@ class TestRDocContext < XrefTestCase
     @prot.force_documentation = true
     @apriv.force_documentation = true
     @aprot.force_documentation = true
+    @cpriv.force_documentation = true
 
     @vis.remove_invisible :public
 
     assert_equal [@pub, @prot, @priv], @vis.method_list
     assert_equal [@apub, @aprot, @apriv], @vis.attributes
+    assert_equal [@cpub, @cpriv], @vis.constants
   end
 
   def test_remove_invisible_in_protected
@@ -922,6 +928,9 @@ class TestRDocContext < XrefTestCase
     @aprot = RDoc::Attr.new nil, 'prot', 'RW', nil
     @apriv = RDoc::Attr.new nil, 'priv', 'RW', nil
 
+    @cpub  = RDoc::Constant.new 'CONST_PUBLIC', nil, nil
+    @cpriv = RDoc::Constant.new 'CONST_PRIVATE', nil, nil
+
     @vis = RDoc::NormalClass.new 'Vis'
     @vis.add_method @pub
     @vis.add_method @prot
@@ -931,11 +940,16 @@ class TestRDocContext < XrefTestCase
     @vis.add_attribute @aprot
     @vis.add_attribute @apriv
 
+    @vis.add_constant @cpub
+    @vis.add_constant @cpriv
+
     @prot.visibility = :protected
     @priv.visibility = :private
 
     @aprot.visibility = :protected
     @apriv.visibility = :private
+
+    @cpriv.visibility = :private
   end
 
 end

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -3537,6 +3537,34 @@ end
     assert_equal 2, public_method_count
   end
 
+  def test_scan_constant_visibility
+    util_parser <<-RUBY
+class C
+   CONST_A = 123
+
+   CONST_B = 234
+   private_constant :CONST_B
+
+   CONST_C = 345
+   public_constant :CONST_C
+end
+    RUBY
+
+    @parser.scan
+
+    c = @store.find_class_named 'C'
+    const_a, const_b, const_c, const_d = c.constants.sort_by(&:name)
+
+    assert_equal 'CONST_A', const_a.name
+    assert_equal :public, const_a.visibility
+
+    assert_equal 'CONST_B', const_b.name
+    assert_equal :private, const_b.visibility
+
+    assert_equal 'CONST_C', const_c.name
+    assert_equal :public, const_c.visibility
+  end
+
   def test_singleton_method_via_eigenclass
     util_parser <<-RUBY
 class C


### PR DESCRIPTION
Parse Module#private_constant and Module#public_constant calls and set
the visibility for the constants appropriately.

Also let RDoc::Context#remove_invisible filter constants as well as
methods and attributes, so that private constants won't be rendered.