### PR TITLE
Supports multi-line constant body with escaped newline

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -927,6 +927,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
         end
       when TkCOLON2, TkCOLON3 then
         rhs_name << '::'
+      when TkBACKSLASH then
+        get_tk if TkNL === peek_tk
       when nil then
         break
       end

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2286,6 +2286,9 @@ class Foo
   SIXTH_CONSTANT = #{sixth_constant}
 
   SEVENTH_CONSTANT = proc { |i| begin i end }
+
+  EIGHTH_CONSTANT = "a" \\
+                    "b"
 end
 EOF
 
@@ -2330,6 +2333,11 @@ EOF
     constant = constants[6]
     assert_equal 'SEVENTH_CONSTANT', constant.name
     assert_equal "proc { |i| begin i end }", constant.value
+    assert_equal @top_level, constant.file
+
+    constant = constants[7]
+    assert_equal 'EIGHTH_CONSTANT', constant.name
+    assert_equal "\"a\" \\\n\"b\"", constant.value
     assert_equal @top_level, constant.file
   end
 


### PR DESCRIPTION
In `parse_constant_body` method, `TkNL` is used as terminator of constant body, but `TkBACKSLASH` can be escape character for `TkNL` in Ruby syntax.

This Pull Request fixes it.