### PR TITLE
Fix constant assignment as alias with Hash

### DIFF
--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1358,6 +1358,33 @@ A::B::C = 1
     assert_equal 'comment', c.comment
   end
 
+  def test_parse_constant_with_bracket
+    util_parser <<-RUBY
+class Klass
+end
+
+class Klass2
+  CONSTANT = Klass
+end
+
+class Klass3
+  CONSTANT_2 = {}
+  CONSTANT_2[1] = Klass
+end
+    RUBY
+
+    @parser.scan
+
+    klass = @store.find_class_named 'Klass'
+    klass2 = @store.find_class_named 'Klass2'
+    klass3 = @store.find_class_named 'Klass3'
+    constant = klass2.find_module_named 'CONSTANT'
+    constant2 = klass3.find_module_named 'CONSTANT_2'
+    assert_equal klass, klass2.constants.first.is_alias_for
+    refute_equal klass, klass3.constants.first.is_alias_for
+    assert_nil klass3.find_module_named 'CONSTANT_2'
+  end
+
   def test_parse_extend_or_include_extend
     klass = RDoc::NormalClass.new 'C'
     klass.parent = @top_level


### PR DESCRIPTION
In constant assignment with class/module name, it behaves as alias.

```ruby
class Klass
end

class Klass2
  CONSTANT = Klass
end
```

`Klass2::CONSTANT` is an alias of `Klass`.

But, some consntants are `Hash`, RDoc treats it as alias.

```ruby
class Klass
end

class Klass3
  CONSTANT_2 = {}
  CONSTANT_2[1] = Klass
end
```

`Klass3::CONSTANT_2` is an alias of `Klass` for RDoc, it's bug.

This Pull Request fixes it.