### PR TITLE
 	Fix handling "rescue" inside paren 

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1588,6 +1588,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def parse_rescue
     skip_tkspace false
 
+    nest = 0
     while tk = get_tk
       case tk
       when TkNL, TkSEMICOLON then
@@ -1596,6 +1597,11 @@ class RDoc::Parser::Ruby < RDoc::Parser
         skip_tkspace false
 
         get_tk if TkNL === peek_tk
+      when TkLPAREN, TkfLPAREN then
+        nest += 1
+      when TkRPAREN then
+        nest -= 1
+        break if nest < 0
       end
 
       skip_tkspace false

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -3573,6 +3573,25 @@ end
     assert_equal :public, const_c.visibility
   end
 
+  def test_document_after_rescue_inside_paren
+    util_parser <<-RUBY
+class C
+  attr_accessor :sample if (1.inexistent_method rescue false)
+  # first
+  # second
+  def a
+  end
+end
+    RUBY
+
+    @parser.scan
+
+    c = @store.find_class_named 'C'
+
+    c_a = c.find_method_named 'a'
+    assert_equal "first\nsecond", c_a.comment.text
+  end
+
   def test_singleton_method_via_eigenclass
     util_parser <<-RUBY
 class C


### PR DESCRIPTION
The `parse_rescue` method detects the end of class list for catch, but it doesn't support postfix `rescue` inside paren.

This Pull Request fixes it.