### PR TITLE
Fix JSON-style Hash literal for args of method

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1380,16 +1380,18 @@ class RDoc::RubyLex
 
       if peek(0) == ':' and !peek_match?(/^::/) and :EXPR_BEG == @lex_state and !@after_question
         str.concat getc
-        return Token(TkSYMBOL, str)
+        @lex_state = :EXPR_ARG if peek_match?(/\s*:/)
+        Token(TkSYMBOL, str)
       elsif subtype
+        @lex_state = :EXPR_END
         Token(DLtype2Token[ltype], str)
       else
+        @lex_state = :EXPR_END
         Token(Ltype2Token[ltype], str)
       end
     ensure
       @ltype = nil
       @quoted = nil
-      @lex_state = :EXPR_END
     end
   end
 

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -927,6 +927,22 @@ RUBY
     assert_equal expected, tokens
   end
 
+  def test_class_tokenize_symbol_for_method
+    tokens = RDoc::RubyLex.tokenize 'meth("key": :val)', nil
+
+    expected = [
+      @TK::TkIDENTIFIER.new( 0, 1,  0, 'meth'),
+      @TK::TkLPAREN    .new( 4, 1,  4, '('),
+      @TK::TkSYMBOL    .new( 5, 1,  5, '"key":'),
+      @TK::TkSPACE     .new(11, 1, 11, ' '),
+      @TK::TkSYMBOL    .new(12, 1, 12, ':val'),
+      @TK::TkRPAREN    .new(16, 1, 16, ')'),
+      @TK::TkNL        .new(17, 1, 17, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
   def test_class_tokenize_particular_kind_of_symbols
     tokens = RDoc::RubyLex.tokenize '{ Thomas: :Thomas, Dave!: :Dave!, undef: :undef }', nil
 


### PR DESCRIPTION
A value of JSON-style Hash literal needs `EXPR_ARG` for `@lex_state`, so a key of JSON-style Hash literal set it.