### PR TITLE
Use "bundle exec" in .travis.yml for JRuby test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rvm:
 env:
   global:
     NOBENCHMARK=1
-script: rake
+script: bundle exec rake
 matrix:
   allow_failures:
     - rvm: jruby-9.1.13.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ env:
   global:
     NOBENCHMARK=1
 script: bundle exec rake
-matrix:
-  allow_failures:
-    - rvm: jruby-9.1.13.0

--- a/test/test_rdoc_markup_to_html.rb
+++ b/test/test_rdoc_markup_to_html.rb
@@ -452,6 +452,9 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def test_accept_verbatim_nl_after_backslash
+    # TODO: Remove "skip" after the issue is resolved: https://github.com/jruby/jruby/issues/4787
+    # This "skip" is for strange behavior around escaped newline on JRuby
+    skip if defined? JRUBY_VERSION
     verb = @RM::Verbatim.new("a = 1 if first_flag_var and \\\n", "  this_is_flag_var\n")
 
     @to.start_accepting


### PR DESCRIPTION
JRuby test succeeded on Travis CI finally and I made sure that [`use-ripper` branch](https://github.com/ruby/rdoc/pull/512) with these commits too.

The `test_accept_verbatim_nl_after_backslash` is failed on JRuby because Ripper on JRuby fails to lexical analyse around escaped newline. I filed a issue for it: jruby/jruby#4787. The `skip` should be removed after the issue is resolved.