### PR TITLE
Removed magic comment for encoding.

### DIFF
--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: false
 
 ##

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 begin
   require_relative "lib/rdoc"
 rescue LoadError

--- a/test/test_rdoc_markup_pre_process.rb
+++ b/test/test_rdoc_markup_pre_process.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: false
 
 require 'rdoc/test_case'

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: false
 
 require 'rdoc/test_case'

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: false
 
 require 'rdoc/test_case'


### PR DESCRIPTION
 default encoding was utf-8 after Ruby 2.0.0.