### PR TITLE
Remove unnecessary comment for HTML class table

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -10,21 +10,8 @@ module RDoc::TokenStream
 
   ##
   # Converts +token_stream+ to HTML wrapping various tokens with
-  # <tt><span></tt> elements.  The following tokens types are wrapped in spans
-  # with the given class names:
-  #
-  # TkCONSTANT :: 'ruby-constant'
-  # TkKW       :: 'ruby-keyword'
-  # TkIVAR     :: 'ruby-ivar'
-  # TkOp       :: 'ruby-operator'
-  # TkId       :: 'ruby-identifier'
-  # TkNode     :: 'ruby-node'
-  # TkCOMMENT  :: 'ruby-comment'
-  # TkREGEXP   :: 'ruby-regexp'
-  # TkSTRING   :: 'ruby-string'
-  # TkVal      :: 'ruby-value'
-  #
-  # Other token types are not wrapped in spans.
+  # <tt><span></tt> elements. Some tokens types are wrapped in spans
+  # with the given class names. Other token types are not wrapped in spans.
 
   def self.to_html token_stream
     token_stream.map do |t|


### PR DESCRIPTION
It's the same of implementations, and the implimentation became to complex. So I think what it is unnecessary comment for document.