### PR TITLE
Skip the same of outside of nested namespace

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -376,7 +376,11 @@ class RDoc::Parser::Ruby < RDoc::Parser
       unless :on_const == name_t[:kind] || :on_ident == name_t[:kind]
         raise RDoc::Error, "Invalid class or module definition: #{given_name}"
       end
-      given_name << '::' << name_t[:text]
+      if prev_container == container and !ignore_constants
+        given_name = name_t[:text]
+      else
+        given_name << '::' << name_t[:text]
+      end
     end
 
     skip_tkspace false

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1377,6 +1377,35 @@ end
     refute_includes module_a.classes_hash, 'A'
   end
 
+  def test_parse_constant_the_same_of_outside
+    util_parser <<-RUBY
+module A
+  class B
+    class C
+    end
+  end
+
+  def self.foo
+    A::B::C
+  end
+end
+    RUBY
+
+    expected = <<EXPECTED
+<span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier">foo</span>
+  <span class="ruby-constant">A</span><span class="ruby-operator">::</span><span class="ruby-constant">B</span><span class="ruby-operator">::</span><span class="ruby-constant">C</span>
+<span class="ruby-keyword">end</span>
+EXPECTED
+    expected = expected.rstrip
+
+    @parser.scan
+
+    module_a = @store.find_module_named 'A'
+    foo = module_a.method_list.first
+    markup_code = foo.markup_code.sub(/^.*\n/, '')
+    assert_equal expected, markup_code
+  end
+
   def test_parse_constant_with_bracket
     util_parser <<-RUBY
 class Klass

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1360,6 +1360,23 @@ A::B::C = 1
     assert_equal 'comment', c.comment
   end
 
+  def test_parse_class_the_same_of_outside
+    util_parser <<-RUBY
+module A
+  class A::B
+  end
+end
+    RUBY
+
+    @parser.scan
+
+    assert_includes @store.modules_hash, 'A'
+    module_a = @store.find_module_named 'A'
+    refute_empty module_a.classes_hash
+    assert_includes module_a.classes_hash, 'B'
+    refute_includes module_a.classes_hash, 'A'
+  end
+
   def test_parse_constant_with_bracket
     util_parser <<-RUBY
 class Klass


### PR DESCRIPTION
In the code below, the fullname of `A::B` is `A::B`, but it's treated as `A::A::A::B` now.

```ruby
module A
  class A::B
  end
end
```

This Pull Request fixes it, and https://github.com/ruby/rdoc/issues/516, https://github.com/ruby/rdoc/issues/364, https://github.com/zzak/sdoc/issues/88.