### PR TITLE
Fix variable expansion in yield

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -276,8 +276,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       # &block
       params.sub!(/,?\s*&\w+/, '')
 
-      block = @block_params.gsub(/\s*\#.*/, '')
-      block = block.tr("\n", " ").squeeze(" ")
+      block = @block_params.tr("\n", " ").squeeze(" ")
       if block[0] == ?(
         block.sub!(/^\(/, '').sub!(/\)/, '')
       end

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -89,6 +89,15 @@ method(a, b) { |c, d| ... }
     assert_equal '', @c2_a.markup_code
   end
 
+  def test_markup_code_with_variable_expansion
+    m = RDoc::AnyMethod.new nil, 'method'
+    m.parent = @c1
+    m.block_params = '"Hello, #{world}", yield_arg'
+    m.params = 'a'
+
+    assert_equal '(a) { |"Hello, #{world}", yield_arg| ... }', m.param_seq
+  end
+
   def test_marshal_dump
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'


### PR DESCRIPTION
The [`AnyMethod#param_seq` removes string after `"#"`](https://github.com/ruby/rdoc/blob/9c4cb93bd4a8d8621d937568b8648596d8f3ad98/lib/rdoc/any_method.rb#L279) as comment, but [comment token is removed in `Parser::Ruby#parse_method_or_yield_parameters`](https://github.com/ruby/rdoc/blob/9c4cb93bd4a8d8621d937568b8648596d8f3ad98/lib/rdoc/parser/ruby.rb#L1531-L1532).

This Pull Request fixes it.

This is a part of problems of https://github.com/ruby/rdoc/issues/410.