### PR TITLE
Remove obsoleted Ruby code.

### DIFF
--- a/lib/rdoc/ruby_token.rb
+++ b/lib/rdoc/ruby_token.rb
@@ -21,11 +21,6 @@ module RDoc::RubyToken
   EXPR_DOT = :EXPR_DOT
   EXPR_CLASS = :EXPR_CLASS
 
-  # for ruby 1.4X
-  if !defined?(Symbol)
-    Symbol = Integer
-  end
-
   def set_token_position(seek, line, char)
     @prev_seek = seek
     @prev_line_no = line


### PR DESCRIPTION
RDoc::RubyToken::Symbol was parsed as Symbol class and its content is Integer.

To check this PR, see @classes_hash in RDoc::Store. It has only one `Symbol` class.
@classes_hash at rdoc 5.1.0 has two Symbol class like below.

 ```
{
  "Symbol" => <Symbol@NormalClass>,
  "RDoc::RubyToken::Symbol" => <RDoc::RubyToken::Symbol@Normalclass but its name will be "Symbol" and its content will be Integer's one>
}
```