### PR TITLE
Fix CodeFence with unintended Array for format

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -1161,7 +1161,7 @@ CodeFence = &{ github? }
               @Newline
             )+ > Ticks3 @Sp @Newline*
             { verbatim = RDoc::Markup::Verbatim.new text
-              verbatim.format = format.intern if format
+              verbatim.format = format.intern if format.instance_of?(String)
               verbatim
             }
 

--- a/test/test_rdoc_markdown.rb
+++ b/test/test_rdoc_markdown.rb
@@ -973,6 +973,14 @@ and an extra note.[^2]
     assert_equal '<b>_emphasis_</b>', @parser.strong('_emphasis_')
   end
 
+  def test_code_fence_with_unintended_array
+    doc = parse '```<ruby>```'
+
+    expected = doc(verb('<ruby>'))
+
+    assert_equal expected, doc
+  end
+
   def parse text
     @parser.parse text
   end


### PR DESCRIPTION
The rule [``( !"`" Nonspacechar )+``](https://github.com/ruby/rdoc/blob/902dd94d2cb6fdd4142763fdcf8d6d688bd4cc97/lib/rdoc/markdown.kpeg#L1158) for `format` variable becomes `Array` but `#intern` is called for `format` variable and it means `format` variable is expected as `String`, so this commit adds checking `instance_of?(String)`.

This fixes https://github.com/ruby/rdoc/issues/417, https://github.com/izwick-schachter/atd/issues/18 and the same bug of YARD because YARD uses RDoc internal Markdown engine.