### PR TITLE
Support did_you_mean

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -939,7 +939,7 @@ or the PAGER environment variable.
         else
           false
         end
-      rescue
+      rescue LoadError
         false
       end
     end

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -47,13 +47,24 @@ class RDoc::RI::Driver
 
   class NotFoundError < Error
 
+    def initialize(klass, suggestions = nil) # :nodoc:
+      @klass = klass
+      @suggestions = suggestions
+    end
+
     ##
     # Name that wasn't found
 
-    alias name message
+    def name
+      @klass
+    end
 
     def message # :nodoc:
-      "Nothing known about #{super}"
+      str = "Nothing known about #{@klass}"
+      if @suggestions and !@suggestions.empty?
+        str += "\nDid you mean?  #{@suggestions.join("\n               ")}"
+      end
+      str
     end
   end
 
@@ -917,13 +928,38 @@ or the PAGER environment variable.
     display out
   end
 
+  def check_did_you_mean # :nodoc:
+    if defined? DidYouMean::SpellChecker
+      true
+    else
+      begin
+        require 'did_you_mean'
+        if defined? DidYouMean::SpellChecker
+          true
+        else
+          false
+        end
+      rescue
+        false
+      end
+    end
+  end
+
   ##
   # Expands abbreviated klass +klass+ into a fully-qualified class.  "Zl::Da"
   # will be expanded to Zlib::DataError.
 
   def expand_class klass
-    ary = classes.keys.grep(Regexp.new("\\A#{klass.gsub(/(?=::|\z)/, '[^:]*')}\\z"))
-    raise NotFoundError, klass if ary.length != 1 && ary.first != klass
+    class_names = classes.keys
+    ary = class_names.grep(Regexp.new("\\A#{klass.gsub(/(?=::|\z)/, '[^:]*')}\\z"))
+    if ary.length != 1 && ary.first != klass
+      if check_did_you_mean
+        suggestions = DidYouMean::SpellChecker.new(dictionary: class_names).correct(klass)
+        raise NotFoundError.new(klass, suggestions)
+      else
+        raise NotFoundError, klass
+      end
+    end
     ary.first
   end
 
@@ -1235,7 +1271,21 @@ or the PAGER environment variable.
   def lookup_method name
     found = load_methods_matching name
 
-    raise NotFoundError, name if found.empty?
+    if found.empty?
+      if check_did_you_mean
+        methods = []
+        _, _, method_name = parse_name name
+        find_methods name do |store, klass, ancestor, types, method|
+          methods.push(*store.class_methods[klass]) if [:class, :both].include? types
+          methods.push(*store.instance_methods[klass]) if [:instance, :both].include? types
+        end
+        methods = methods.uniq
+        suggestions = DidYouMean::SpellChecker.new(dictionary: methods).correct(method_name)
+        raise NotFoundError.new(name, suggestions)
+      else
+        raise NotFoundError, name
+      end
+    end
 
     filter_methods found, name
   end

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -969,6 +969,27 @@ Foo::Bar#bother
     assert_equal 'nonexistent', e.name
   end
 
+  def test_did_you_mean
+    skip 'skip test with did_you_men' unless defined? DidYouMean::SpellChecker
+
+    util_ancestors_store
+
+    e = assert_raises RDoc::RI::Driver::NotFoundError do
+      @driver.lookup_method 'Foo.i_methdo'
+    end
+    assert_equal "Nothing known about Foo.i_methdo\nDid you mean?  i_method", e.message
+
+    e = assert_raises RDoc::RI::Driver::NotFoundError do
+      @driver.lookup_method 'Foo#i_methdo'
+    end
+    assert_equal "Nothing known about Foo#i_methdo\nDid you mean?  i_method", e.message
+
+    e = assert_raises RDoc::RI::Driver::NotFoundError do
+      @driver.lookup_method 'Foo::i_methdo'
+    end
+    assert_equal "Nothing known about Foo::i_methdo\nDid you mean?  c_method", e.message
+  end
+
   def test_formatter
     tty = Object.new
     def tty.tty?() true; end


### PR DESCRIPTION
Ruby 2.3 or later, did_you_mean gem is adopted as standard library. The did_you_mean gem can be used as a library via `DidYouMean::SpellChecker` at 1.0.3 or later, so checks that the class is defined and uses it. And then, this feature will become enabled if the gem 1.0.3 or later is installed.

This closes https://github.com/ruby/rdoc/issues/45.