### PR TITLE
Add trunk to appveyor, change ubygems to rubygems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,11 +62,11 @@ parsed_files = PARSER_FILES.map do |parser_file|
     if parser_file =~ /\.ry\z/ # need racc
       racc = Gem.bin_path 'racc', 'racc'
       rb_file = parser_file.gsub(/\.ry\z/, ".rb")
-      ruby "-rubygems #{racc} -l -o #{rb_file} #{parser_file}"
+      ruby "-rrubygems #{racc} -l -o #{rb_file} #{parser_file}"
     elsif parser_file =~ /\.kpeg\z/ # need kpeg
       kpeg = Gem.bin_path 'kpeg', 'kpeg'
       rb_file = parser_file.gsub(/\.kpeg\z/, ".rb")
-      ruby "-rubygems #{kpeg} -fsv -o #{rb_file} #{parser_file}"
+      ruby "-rrubygems #{kpeg} -fsv -o #{rb_file} #{parser_file}"
     end
   end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,32 @@
 ---
+init:
+  # To avoid duplicated executables in PATH, see https://github.com/ruby/spec/pull/468
+  - set PATH=C:\ruby%RUBY_VERSION%\bin;C:\msys64\usr\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32;C:\Program Files;C:\Windows
+  # Loads trunk build and updates MSYS2 / MinGW to most recent gcc compiler
+  - if %ruby_version%==_trunk (
+      appveyor DownloadFile %APPVEYOR_URL%/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
+      7z x C:\ruby_trunk.7z -oC:\ruby_trunk)
+
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem install bundler --no-document
   - bundle install
+
 build: off
+
 test_script:
   - rake
+
+on_finish:
+  - ruby -v
+
 deploy: off
+
 environment:
   NOBENCHMARK: 1
   matrix:
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
-    - ruby_version: "23"
-    - ruby_version: "23-x64"
-    - ruby_version: "24"
-    - ruby_version: "24-x64"
+    - ruby_version: 22
+    - ruby_version: 22-x64
+    - ruby_version: 23
+    - ruby_version: 23-x64
+    - ruby_version: 24
+    - ruby_version: 24-x64
+    - ruby_version: _trunk


### PR DESCRIPTION
I'd like to see Appveyor testing for RDoc.

I've added a trunk test, this a rolling build done twice a day on Appveyor, so it's often a newer build than rvm ruby-head.

Test results on my fork [here](https://ci.appveyor.com/project/MSP-Greg/rdoc).

Also, since trunk no longer has `ubygems.rb`, removed that.