### PR TITLE
Remove RDoc::Parser.process_directive

### DIFF
--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -88,31 +88,6 @@ class RDoc::Parser
   end
 
   ##
-  # Processes common directives for CodeObjects for the C and Ruby parsers.
-  #
-  # Applies +directive+'s +value+ to +code_object+, if appropriate
-
-  def self.process_directive code_object, directive, value
-    warn "RDoc::Parser::process_directive is deprecated and wil be removed in RDoc 4.  Use RDoc::Markup::PreProcess#handle_directive instead" if $-w
-
-    case directive
-    when 'nodoc' then
-      code_object.document_self = nil # notify nodoc
-      code_object.document_children = value.downcase != 'all'
-    when 'doc' then
-      code_object.document_self = true
-      code_object.force_documentation = true
-    when 'yield', 'yields' then
-      # remove parameter &block
-      code_object.params.sub!(/,?\s*&\w+/, '') if code_object.params
-
-      code_object.block_params = value
-    when 'arg', 'args' then
-      code_object.params = value
-    end
-  end
-
-  ##
   # Checks if +file+ is a zip file in disguise.  Signatures from
   # http://www.garykessler.net/library/file_sigs.html
 


### PR DESCRIPTION
This is deprecated, and deprecated messages [is outputed for 6 years](https://github.com/ruby/rdoc/commit/cd5799656c566bd7f497e33279c2b32804cd7eb2#diff-782d50e7ab80f147b1796539d8bc4cd0R109).