### PR TITLE
Remove needless library lock with gem methods.

### DIFF
--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -6,16 +6,6 @@
 require 'strscan'
 
 ##
-# For RDoc::Text#snippet
-
-begin
-  gem 'json'
-rescue NameError => e # --disable-gems
-  raise unless e.name == :gem
-rescue Gem::LoadError
-end
-
-##
 # Methods for manipulating comment text
 
 module RDoc::Text


### PR DESCRIPTION
This code inserted at https://github.com/ruby/rdoc/commit/978cd909829806527a2f76e1cf98e64cc5dc8e49

But current rdoc/text.rb implementation did not use JSON library.