### PR TITLE
Support :args: directive before method

### DIFF
--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -150,7 +150,7 @@ class RDoc::Markup::PreProcess
 
     case directive
     when 'arg', 'args' then
-      return "#{prefix}:#{directive}: #{param}\n" unless code_object
+      return "#{prefix}:#{directive}: #{param}\n" unless code_object && code_object.kind_of?(RDoc::AnyMethod)
 
       code_object.params = param
 

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -574,14 +574,15 @@ class RDoc::Parser::Ruby < RDoc::Parser
   #
   # This routine modifies its +comment+ parameter.
 
-  def look_for_directives_in context, comment
-    @preprocess.handle comment, context do |directive, param|
+  def look_for_directives_in container, comment
+    @preprocess.handle comment, container do |directive, param|
       case directive
       when 'method', 'singleton-method',
            'attr', 'attr_accessor', 'attr_reader', 'attr_writer' then
         false # handled elsewhere
       when 'section' then
-        context.set_current_section param, comment.dup
+        break unless container.kind_of?(RDoc::Context)
+        container.set_current_section param, comment.dup
         comment.text = ''
         break
       end
@@ -1290,6 +1291,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     token_listener meth do
       meth.params = ''
 
+      look_for_directives_in meth, comment
       comment.normalize
       comment.extract_call_seq meth
 
@@ -1336,6 +1338,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     return unless name
 
     meth = RDoc::AnyMethod.new get_tkread, name
+    look_for_directives_in meth, comment
     meth.singleton = single == SINGLE ? true : singleton
 
     record_location meth

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1762,6 +1762,28 @@ end
     end
   end
 
+  def test_parse_method_with_args_directive
+    util_parser <<-RUBY
+class C
+  def meth_with_args_after # :args: a, b, c
+  end
+
+  ##
+  # :args: d, e, f
+  def meth_with_args_before
+end
+    RUBY
+
+    @parser.scan
+
+    c = @store.find_class_named 'C'
+
+    assert_equal 'C#meth_with_args_after', c.method_list[0].full_name
+    assert_equal 'a, b, c', c.method_list[0].params
+    assert_equal 'C#meth_with_args_before', c.method_list[1].full_name
+    assert_equal 'd, e, f', c.method_list[1].params
+  end
+
   def test_parse_method_bracket
     util_parser <<-RUBY
 class C


### PR DESCRIPTION
The `:args:` directive is supported only by after `def` keyword line like below:

```ruby
  def method_with_args_comment(*array) # :args: a, b, c
  end
  # => documented as method_with_args_comment(a, b, c)
```

This commit changes to support like below:

```ruby
  ##
  # :args: a, b, c
  def meth(*array)
  end
  # => documented as meth(a, b, c)
```

This fixes https://github.com/ruby/rdoc/issues/433.