### PR TITLE
Handle all definitions per file in Ruby

### DIFF
--- a/lib/rdoc/class_module.rb
+++ b/lib/rdoc/class_module.rb
@@ -136,7 +136,9 @@ class RDoc::ClassModule < RDoc::Context
                 normalize_comment comment
               end
 
-    @comment_location.delete_if { |(_, l)| l == location }
+    if location.parser == RDoc::Parser::C
+      @comment_location.delete_if { |(_, l)| l == location }
+    end
 
     @comment_location << [comment, location]
 

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -42,7 +42,8 @@ class TestRDocClassModule < XrefTestCase
     cm.add_comment '# comment 1', tl1
     cm.add_comment '# comment 2', tl1
 
-    assert_equal [['comment 2', tl1]], cm.comment_location
+    assert_equal [['comment 1', tl1],
+                  ['comment 2', tl1]], cm.comment_location
   end
 
   def test_add_comment_stopdoc

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -357,6 +357,25 @@ VALUE cFoo = rb_define_class("Foo", rb_cObject);
     assert_equal "this is the Foo class", klass.comment.text
   end
 
+  def test_do_classes_duplicate_class
+    content = <<-EOF
+/* Document-class: Foo
+ * first
+ */
+VALUE cFoo = rb_define_class("Foo", rb_cObject);
+/* Document-class: Foo
+ * second
+ */
+VALUE cFoo = rb_define_class("Foo", rb_cObject);
+    EOF
+
+    klass = util_get_class content, 'cFoo'
+    assert_equal 1, klass.comment_location.size
+    first = klass.comment_location.first
+    first_comment = first[0]
+    assert_equal 'first', first_comment.text
+  end
+
   def test_do_classes_struct
     content = <<-EOF
 /* Document-class: Foo


### PR DESCRIPTION
`RDoc::Parser::C` cann't discern each documents per file for one class, so `RDoc::ClassModule` adopts the latest comment per file, however `RDoc::Parser::Ruby` can take each documents per file for one class. This commit changes the behavior only when `RDoc::ClassModule` is for `RDoc::Parser::C`. Of course this works around `RDoc::Parser::C`.

And I checked all CRuby's documents and 2 documents change with this patch because the class/module has re-definition line without document after first definition line with document. Those are [`ERB`](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/erb.rb#L261) (re-definitions without document: [1](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/erb.rb#L272), [2](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/erb.rb#L751), [3](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/erb.rb#L960), [4](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/erb.rb#L1008)) and [`DRb::DRbProtocol`](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/drb/drb.rb#L721) ([re-definition without document](https://github.com/ruby/ruby/blob/25aec0b8352428871b97de41f7da9abff1ab7d90/lib/drb/drb.rb#L1018)). Those documents are lost now, and with this patch, those become to be treated correctly.

ref. https://github.com/ruby/rdoc/commit/ecae6cb52319d6791950fd9a1dc1e2d9ad518b19, https://github.com/ruby/rdoc/commit/d84ada248f8f3c2fffa5f81ce60dfc9a7bc9b8c6, https://github.com/ruby/rdoc/commit/e033904abe51ece5f7857b3767054bbd08f65eaa

This closes https://github.com/ruby/rdoc/issues/180.
