### PR TITLE
Fix for Ruby 2.5 warnings in tests

### DIFF
--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -145,13 +145,11 @@ class TestRDocEncoding < RDoc::TestCase
     assert_equal Encoding::UTF_8, s.encoding
 
     s = "<?xml version='1.0' encoding='UTF-8'?>\n"
-    expected = s.encoding
     RDoc::Encoding.set_encoding s
 
     assert_equal Encoding::UTF_8, s.encoding
 
     s = "<?xml version='1.0' encoding=\"UTF-8\"?>\n"
-    expected = s.encoding
     RDoc::Encoding.set_encoding s
 
     assert_equal Encoding::UTF_8, s.encoding

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -642,6 +642,7 @@ void Init_Blah(void) {
       klass = util_get_class content, 'cDate'
     end
 
+    assert_equal 'Date', klass.full_name
     assert_match ' blah.c ', err
   end
 
@@ -664,6 +665,7 @@ void Init_Blah(void) {
       klass = util_get_class content, 'cDate'
     end
 
+    assert_equal 'Date', klass.full_name
     assert_match ' blah.cpp ', err
   end
 
@@ -686,6 +688,7 @@ void Init_Blah(void) {
       klass = util_get_class content, 'cDate'
     end
 
+    assert_equal 'Date', klass.full_name
     assert_match ' blah.y ', err
   end
 

--- a/test/test_rdoc_require.rb
+++ b/test/test_rdoc_require.rb
@@ -12,13 +12,13 @@ class TestRDocRequire < XrefTestCase
   def test_initialize
     assert_equal 'foo', @req.name
 
-    req = RDoc::Require.new '"foo"', ''
+    RDoc::Require.new '"foo"', ''
     assert_equal 'foo', @req.name
 
-    req = RDoc::Require.new '\'foo\'', ''
+    RDoc::Require.new '\'foo\'', ''
     assert_equal 'foo', @req.name
 
-    req = RDoc::Require.new '|foo|', ''
+    RDoc::Require.new '|foo|', ''
     assert_equal 'foo', @req.name, 'for fortran?'
   end
 


### PR DESCRIPTION
This Pull Reuest removes Ruby 2.5 warnings in tests below:

```
/path/to/rdoc/test/test_rdoc_encoding.rb:148: warning: assigned but unused variable - expected
/path/to/rdoc/test/test_rdoc_parser_c.rb:639: warning: assigned but unused variable - klass
/path/to/rdoc/test/test_rdoc_parser_c.rb:661: warning: assigned but unused variable - klass
/path/to/rdoc/test/test_rdoc_parser_c.rb:683: warning: assigned but unused variable - klass
/path/to/rdoc/test/test_rdoc_require.rb:15: warning: assigned but unused variable - req
```