### PR TITLE
Fix for warnings on Ruby 2.5 in ERB binding

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -313,12 +313,16 @@ class RDoc::Generator::Darkfish
     search_index_rel_prefix = rel_prefix
     search_index_rel_prefix += @asset_rel_path if @file_output
 
-    # suppress 1.9.3 warning
-    asset_rel_prefix = asset_rel_prefix = rel_prefix + @asset_rel_path
+    asset_rel_prefix = rel_prefix + @asset_rel_path
 
     @title = @options.title
 
-    render_template template_file, out_file do |io| binding end
+    render_template template_file, out_file do |io|
+      here = binding
+      # suppress 1.9.3 warning
+      here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+      here
+    end
   rescue => e
     error = RDoc::Error.new \
       "error generating index.html: #{e.message} (#{e.class})"
@@ -343,14 +347,19 @@ class RDoc::Generator::Darkfish
     search_index_rel_prefix = rel_prefix
     search_index_rel_prefix += @asset_rel_path if @file_output
 
-    # suppress 1.9.3 warning
-    asset_rel_prefix = asset_rel_prefix = rel_prefix + @asset_rel_path
-    svninfo          = svninfo          = get_svninfo(current)
+    asset_rel_prefix = rel_prefix + @asset_rel_path
+    svninfo          = get_svninfo(current)
 
     @title = "#{klass.type} #{klass.full_name} - #{@options.title}"
 
     debug_msg "  rendering #{out_file}"
-    render_template template_file, out_file do |io| binding end
+    render_template template_file, out_file do |io|
+      here = binding
+      # suppress 1.9.3 warning
+      here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+      here.local_variable_set(:svninfo, svninfo)
+      here
+    end
   end
 
   ##
@@ -416,8 +425,7 @@ class RDoc::Generator::Darkfish
       search_index_rel_prefix = rel_prefix
       search_index_rel_prefix += @asset_rel_path if @file_output
 
-      # suppress 1.9.3 warning
-      asset_rel_prefix = asset_rel_prefix = rel_prefix + @asset_rel_path
+      asset_rel_prefix = rel_prefix + @asset_rel_path
 
       unless filepage_file then
         if file.text? then
@@ -434,7 +442,14 @@ class RDoc::Generator::Darkfish
       @title += " - #{@options.title}"
       template_file ||= filepage_file
 
-      render_template template_file, out_file do |io| binding end
+      putes template_file.inspect
+      render_template template_file, out_file do |io|
+        here = binding
+        # suppress 1.9.3 warning
+        here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+        here.local_variable_set(:current, current)
+        here
+      end
     end
   rescue => e
     error =
@@ -458,14 +473,19 @@ class RDoc::Generator::Darkfish
     search_index_rel_prefix = rel_prefix
     search_index_rel_prefix += @asset_rel_path if @file_output
 
-    # suppress 1.9.3 warning
-    current          = current          = file
-    asset_rel_prefix = asset_rel_prefix = rel_prefix + @asset_rel_path
+    current          = file
+    asset_rel_prefix = rel_prefix + @asset_rel_path
 
     @title = "#{file.page_name} - #{@options.title}"
 
     debug_msg "  rendering #{out_file}"
-    render_template template_file, out_file do |io| binding end
+    render_template template_file, out_file do |io|
+      here = binding
+      # suppress 1.9.3 warning
+      here.local_variable_set(:current, current)
+      here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+      here
+    end
   end
 
   ##
@@ -483,12 +503,16 @@ class RDoc::Generator::Darkfish
     search_index_rel_prefix = rel_prefix
     search_index_rel_prefix += @asset_rel_path if @file_output
 
-    # suppress 1.9.3 warning
-    asset_rel_prefix = asset_rel_prefix = ''
+    asset_rel_prefix = ''
 
     @title = 'Not Found'
 
-    render_template template_file do |io| binding end
+    render_template template_file do |io|
+      here = binding
+      # suppress 1.9.3 warning
+      here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+      here
+    end
   rescue => e
     error = RDoc::Error.new \
       "error generating servlet_not_found: #{e.message} (#{e.class})"
@@ -540,12 +564,16 @@ class RDoc::Generator::Darkfish
     search_index_rel_prefix = rel_prefix
     search_index_rel_prefix += @asset_rel_path if @file_output
 
-    # suppress 1.9.3 warning
-    asset_rel_prefix = asset_rel_prefix = rel_prefix + @asset_rel_path
+    asset_rel_prefix = rel_prefix + @asset_rel_path
 
     @title = "Table of Contents - #{@options.title}"
 
-    render_template template_file, out_file do |io| binding end
+    render_template template_file, out_file do |io|
+      here = binding
+      # suppress 1.9.3 warning
+      here.local_variable_set(:asset_rel_prefix, asset_rel_prefix)
+      here
+    end
   rescue => e
     error = RDoc::Error.new \
       "error generating table_of_contents.html: #{e.message} (#{e.class})"


### PR DESCRIPTION
`ERB` requires variable context as `Binding` object and `Darkfish` uses `Kernel#binding` for it, but it causes warnings "assigned but unused variable" on Ruby 1.9 or later, so there ware "suppress 1.9.3 warning" code like below:

```ruby
# suppress 1.9.3 warning
variable = variable = expressions
```

The `variable` variable is assigned but unused *at this scope* and used inside `ERB` template, so the double assign of `variable` is for suppress the warning.

This code causes warning "assigned but unused variable" on Ruby 2.5 again. I fixed it with `Binding#local_variable_set` for "use" variable.

This Pull Request removes Ruby 2.5 warnings in tests below:

```
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:317: warning: assigned but unused variable - asset_rel_prefix
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:347: warning: assigned but unused variable - asset_rel_prefix
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:348: warning: assigned but unused variable - svninfo
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:420: warning: assigned but unused variable - asset_rel_prefix
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:402: warning: assigned but unused variable - current
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:462: warning: assigned but unused variable - current
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:463: warning: assigned but unused variable - asset_rel_prefix
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:487: warning: assigned but unused variable - asset_rel_prefix
/path/to/rdoc/lib/rdoc/generator/darkfish.rb:544: warning: assigned but unused variable - asset_rel_prefix
```