### PR TITLE
Avoid a trailing whitespace in generated markdown.rb

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -1137,8 +1137,7 @@ InlineNote = &{ notes? }
              @StartList:a
              ( !"]" Inline:l { a << l } )+
              "]"
-             {
-               ref = [:inline, @note_order.length]
+             { ref = [:inline, @note_order.length]
                @footnotes[ref] = paragraph a
 
                note_for ref


### PR DESCRIPTION
See e.g. ruby/ruby@f05f1ecb2d0e495394efcd93b4f381bae36cc8c5 or ruby/ruby@708afa47eb14bf753c9b021557a302e4445b194e.