### PR TITLE
Fix tag in table_of_contents.html

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -246,7 +246,7 @@ class RDoc::Markup::AttributeManager
   # Processes +str+ converting attributes, HTML and specials
 
   def flow str
-    @str = str
+    @str = str.dup
 
     mask_protected_sequences
 

--- a/test/test_rdoc_markup_attribute_manager.rb
+++ b/test/test_rdoc_markup_attribute_manager.rb
@@ -332,6 +332,14 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
                   @am.flow("\\_cat_<i>dog</i>"))
   end
 
+  def test_lost_tag_for_the_second_time
+    str = "cat <tt>dog</tt>"
+    assert_equal(["cat ", @tt_on, "dog", @tt_off],
+                 @am.flow(str))
+    assert_equal(["cat ", @tt_on, "dog", @tt_off],
+                 @am.flow(str))
+  end
+
   def test_special
     @am.add_special(RDoc::CrossReference::CROSSREF_REGEXP, :CROSSREF)
 


### PR DESCRIPTION
`RDoc::Markup::AttributeManager#convert_html` that is called from `RDoc::Markup::AttributeManager#flow` replaces HTML tags of received `str` with `NULL` characters in HTML generation for each files, and the `NULL` characters are removed in `RDoc::Markup::AttributeManager#split_into_flow`. But the `String` objects are reused for table_of_contents.html generation, so the tags lose at that moment.

This Pull Request fixes it with using duplicated `String` object.