### PR TITLE
Support Ripper::Lexer::State

### DIFF
--- a/lib/rdoc/parser/ripper_state_lex.rb
+++ b/lib/rdoc/parser/ripper_state_lex.rb
@@ -315,10 +315,10 @@ class RDoc::RipperStateLex
     when :on_tstring_beg then
       tk = get_string_tk(tk)
     when :on_backtick then
-      if ((EXPR_FNAME | EXPR_ENDFN) & tk[:state]) != 0
+      if (tk[:state] & (EXPR_FNAME | EXPR_ENDFN)) != 0
         @inner_lex.lex_state = EXPR_ARG unless RIPPER_HAS_LEX_STATE
         tk[:kind] = :on_ident
-        tk[:state] = EXPR_ARG
+        tk[:state] = Ripper::Lexer.const_defined?(:State) ? Ripper::Lexer::State.new(EXPR_ARG) : EXPR_ARG
       else
         tk = get_string_tk(tk)
       end
@@ -558,9 +558,9 @@ class RDoc::RipperStateLex
 
   private def get_op_tk(tk)
     redefinable_operators = %w[! != !~ % & * ** + +@ - -@ / < << <= <=> == === =~ > >= >> [] []= ^ ` | ~]
-    if redefinable_operators.include?(tk[:text]) and EXPR_ARG == tk[:state] then
+    if redefinable_operators.include?(tk[:text]) and tk[:state] == EXPR_ARG then
       @inner_lex.lex_state = EXPR_ARG unless RIPPER_HAS_LEX_STATE
-      tk[:state] = EXPR_ARG
+      tk[:state] = Ripper::Lexer.const_defined?(:State) ? Ripper::Lexer::State.new(EXPR_ARG) : EXPR_ARG
       tk[:kind] = :on_ident
     elsif tk[:text] =~ /^[-+]$/ then
       tk_ahead = get_squashed_tk

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -945,7 +945,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       elsif (:on_kw == tk[:kind] && 'def' == tk[:text]) then
         nest += 1
       elsif (:on_kw == tk[:kind] && %w{do if unless case begin}.include?(tk[:text])) then
-        if (RDoc::RipperStateLex::EXPR_LABEL & tk[:state]) == 0
+        if (tk[:state] & RDoc::RipperStateLex::EXPR_LABEL) == 0
           nest += 1
         end
       elsif [:on_rparen, :on_rbrace, :on_rbracket].include?(tk[:kind]) ||
@@ -1538,7 +1538,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       when :on_comment, :on_embdoc then
         @read.pop
         if :on_nl == end_token[:kind] and "\n" == tk[:text][-1] and
-          (!continue or (RDoc::RipperStateLex::EXPR_LABEL & tk[:state]) != 0) then
+          (!continue or (tk[:state] & RDoc::RipperStateLex::EXPR_LABEL) != 0) then
           if method && method.block_params.nil? then
             unget_tk tk
             read_documentation_modifiers method, modifiers
@@ -1743,7 +1743,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
           end
 
         when 'until', 'while' then
-          if (RDoc::RipperStateLex::EXPR_LABEL & tk[:state]) == 0
+          if (tk[:state] & RDoc::RipperStateLex::EXPR_LABEL) == 0
             nest += 1
             skip_optional_do_after_expression
           end
@@ -1759,7 +1759,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
           skip_optional_do_after_expression
 
         when 'case', 'do', 'if', 'unless', 'begin' then
-          if (RDoc::RipperStateLex::EXPR_LABEL & tk[:state]) == 0
+          if (tk[:state] & RDoc::RipperStateLex::EXPR_LABEL) == 0
             nest += 1
           end
 


### PR DESCRIPTION
In [60665 of Ruby repository](https://github.com/ruby/ruby/commit/3280f54168069d207834d9d15b0fb2ffa17168ce), `Ripper::Lexer::State` is added. It has `#==` and `#&` and `#|`, so the `Ripper::Lexer::State` objects must be placed at left operand, and new value as `lex_state` must be created as a instance of the class.

This fixes CI failure on ruby-head, for example https://travis-ci.org/ruby/rdoc/jobs/299223813.