### PR TITLE
Use frozen_string_literal: true

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,6 +63,11 @@ parsed_files = PARSER_FILES.map do |parser_file|
       racc = Gem.bin_path 'racc', 'racc'
       rb_file = parser_file.gsub(/\.ry\z/, ".rb")
       ruby "#{racc} -l -o #{rb_file} #{parser_file}"
+      open(rb_file, 'r+') do |f|
+        newtext = "# frozen_string_literal: true\n#{f.read}"
+        f.rewind
+        f.write newtext
+      end
     elsif parser_file =~ /\.kpeg\z/ # need kpeg
       kpeg = Gem.bin_path 'kpeg', 'kpeg'
       rb_file = parser_file.gsub(/\.kpeg\z/, ".rb")

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 $DEBUG_RDOC = nil
 
 # :main: README.rdoc

--- a/lib/rdoc/alias.rb
+++ b/lib/rdoc/alias.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Represent an alias, which is an old_name/new_name pair associated with a
 # particular context

--- a/lib/rdoc/anon_class.rb
+++ b/lib/rdoc/anon_class.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An anonymous class like:
 #

--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -244,9 +244,9 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     if @block_params then
       # If this method has explicit block parameters, remove any explicit
       # &block
-      params.sub!(/,?\s*&\w+/, '')
+      params = params.sub(/,?\s*&\w+/, '')
     else
-      params.sub!(/\&(\w+)/, '\1')
+      params = params.sub(/\&(\w+)/, '\1')
     end
 
     params = params.gsub(/\s+/, '').split(',').reject(&:empty?)
@@ -274,11 +274,11 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     if @block_params then
       # If this method has explicit block parameters, remove any explicit
       # &block
-      params.sub!(/,?\s*&\w+/, '')
+      params = params.sub(/,?\s*&\w+/, '')
 
       block = @block_params.tr_s("\n ", " ")
       if block[0] == ?(
-        block.sub!(/^\(/, '').sub!(/\)/, '')
+        block = block.sub(/^\(/, '').sub(/\)/, '')
       end
       params << " { |#{block}| ... }"
     end

--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # AnyMethod is the base class for objects representing methods
 

--- a/lib/rdoc/attr.rb
+++ b/lib/rdoc/attr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An attribute created by \#attr, \#attr_reader, \#attr_writer or
 # \#attr_accessor

--- a/lib/rdoc/class_module.rb
+++ b/lib/rdoc/class_module.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # ClassModule is the base class for objects representing either a class or a
 # module.

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Base class for the RDoc code tree.
 #

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -144,7 +144,7 @@ class RDoc::CodeObject
                    # HACK correct fix is to have #initialize create @comment
                    #      with the correct encoding
                    if String === @comment and @comment.empty? then
-                     @comment.force_encoding comment.encoding
+                     @comment = RDoc::Encoding.change_encoding @comment, comment.encoding
                    end
                    @comment
                  end

--- a/lib/rdoc/code_objects.rb
+++ b/lib/rdoc/code_objects.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # This file was used to load all the RDoc::CodeObject subclasses at once.  Now
 # autoload handles this.
 

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -45,7 +45,7 @@ class RDoc::Comment
 
   def initialize text = nil, location = nil
     @location = location
-    @text     = text
+    @text     = text.nil? ? nil : text.dup
 
     @document   = nil
     @format     = 'rdoc'
@@ -114,10 +114,14 @@ class RDoc::Comment
 
       method.call_seq = seq.chomp
 
-    elsif @text.sub!(/^\s*:?call-seq:(.*?)(^\s*$|\z)/m, '') then
-      seq = $1
-      seq.gsub!(/^\s*/, '')
-      method.call_seq = seq
+    else
+      regexp = /^\s*:?call-seq:(.*?)(^\s*$|\z)/m
+      if regexp =~ @text then
+        @text = @text.sub(regexp, '')
+        seq = $1
+        seq.gsub!(/^\s*/, '')
+        method.call_seq = seq
+      end
     end
 
     method
@@ -133,8 +137,14 @@ class RDoc::Comment
   ##
   # HACK dubious
 
-  def force_encoding encoding
-    @text.force_encoding encoding
+  def encode! encoding
+    # TODO: Remove this condition after Ruby 2.2 EOL
+    if RUBY_VERSION < '2.3.0'
+      @text = @text.force_encoding encoding
+    else
+      @text = String.new @text, encoding: encoding
+    end
+    self
   end
 
   ##
@@ -200,7 +210,7 @@ class RDoc::Comment
   def remove_private
     # Workaround for gsub encoding for Ruby 1.9.2 and earlier
     empty = ''
-    empty.force_encoding @text.encoding
+    empty = RDoc::Encoding.change_encoding empty, @text.encoding
 
     @text = @text.gsub(%r%^\s*([#*]?)--.*?^\s*(\1)\+\+\n?%m, empty)
     @text = @text.sub(%r%^\s*[#*]?--.*%m, '')
@@ -216,7 +226,7 @@ class RDoc::Comment
       @text.nil? and @document
 
     @document = nil
-    @text = text
+    @text = text.nil? ? nil : text.dup
   end
 
   ##

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A comment holds the text comment for a RDoc::CodeObject and provides a
 # unified way of cleaning it up and parsing it into an RDoc::Markup::Document.

--- a/lib/rdoc/constant.rb
+++ b/lib/rdoc/constant.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A constant
 

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'cgi'
 
 ##

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -239,7 +239,7 @@ class RDoc::Context < RDoc::CodeObject
 
       if known then
         known.comment = attribute.comment if known.comment.empty?
-      elsif registered = @methods_hash[attribute.pretty_name << '='] and
+      elsif registered = @methods_hash[attribute.pretty_name + '='] and
             RDoc::Attr === registered then
         registered.rw = 'RW'
       else
@@ -249,7 +249,7 @@ class RDoc::Context < RDoc::CodeObject
     end
 
     if attribute.rw.index 'W' then
-      key = attribute.pretty_name << '='
+      key = attribute.pretty_name + '='
       known = @methods_hash[key]
 
       if known then

--- a/lib/rdoc/context/section.rb
+++ b/lib/rdoc/context/section.rb
@@ -43,7 +43,7 @@ class RDoc::Context::Section
     @parent = parent
     @title = title ? title.strip : title
 
-    @@sequence.succ!
+    @@sequence = @@sequence.succ
     @sequence = @@sequence.dup
 
     @comments = []

--- a/lib/rdoc/context/section.rb
+++ b/lib/rdoc/context/section.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A section of documentation like:
 #

--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # RDoc::CrossReference is a reusable way to create cross references for names.
 

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -23,26 +23,26 @@ module RDoc::Encoding
 
     utf8 = content.sub!(/\A\xef\xbb\xbf/, '')
 
-    RDoc::Encoding.set_encoding content
+    content = RDoc::Encoding.set_encoding content
 
     begin
       encoding ||= Encoding.default_external
       orig_encoding = content.encoding
 
       if not orig_encoding.ascii_compatible? then
-        content.encode! encoding
+        content = content.encode encoding
       elsif utf8 then
-        content.force_encoding Encoding::UTF_8
-        content.encode! encoding
+        content = RDoc::Encoding.change_encoding content, Encoding::UTF_8
+        content = content.encode encoding
       else
         # assume the content is in our output encoding
-        content.force_encoding encoding
+        content = RDoc::Encoding.change_encoding content, encoding
       end
 
       unless content.valid_encoding? then
         # revert and try to transcode
-        content.force_encoding orig_encoding
-        content.encode! encoding
+        content = RDoc::Encoding.change_encoding content, orig_encoding
+        content = content.encode encoding
       end
 
       unless content.valid_encoding? then
@@ -52,10 +52,11 @@ module RDoc::Encoding
     rescue Encoding::InvalidByteSequenceError,
            Encoding::UndefinedConversionError => e
       if force_transcode then
-        content.force_encoding orig_encoding
-        content.encode!(encoding,
-                        :invalid => :replace, :undef => :replace,
-                        :replace => '?')
+        content = RDoc::Encoding.change_encoding content, orig_encoding
+        content = content.encode(encoding,
+                                 :invalid => :replace,
+                                 :undef => :replace,
+                                 :replace => '?')
         return content
       else
         warn "unable to convert #{e.message} for #{filename}, skipping"
@@ -77,15 +78,17 @@ module RDoc::Encoding
     first_line = $1
 
     if first_line =~ /\A# +frozen[-_]string[-_]literal[=:].+$/i
-      string.sub! first_line, ''
+      string = string.sub first_line, ''
     end
+
+    string
   end
 
   ##
   # Sets the encoding of +string+ based on the magic comment
 
   def self.set_encoding string
-    remove_frozen_string_literal string
+    string = remove_frozen_string_literal string
 
     string =~ /\A(?:#!.*\n)?(.*\n)/
 
@@ -94,15 +97,34 @@ module RDoc::Encoding
     name = case first_line
            when /^<\?xml[^?]*encoding=(["'])(.*?)\1/ then $2
            when /\b(?:en)?coding[=:]\s*([^\s;]+)/i   then $1
-           else                                           return
+           else                                           return string
            end
 
-    string.sub! first_line, ''
+    string = string.sub first_line, ''
 
-    remove_frozen_string_literal string
+    string = remove_frozen_string_literal string
 
     enc = Encoding.find name
-    string.force_encoding enc if enc
+    string = RDoc::Encoding.change_encoding string, enc if enc
+
+    string
+  end
+
+  ##
+  # Changes encoding based on +encoding+ without converting and returns new
+  # string
+
+  def self.change_encoding text, encoding
+    if text.kind_of? RDoc::Comment
+      text.encode! encoding
+    else
+      # TODO: Remove this condition after Ruby 2.2 EOL
+      if RUBY_VERSION < '2.3.0'
+        text.force_encoding encoding
+      else
+        String.new text, encoding: encoding
+      end
+    end
   end
 
 end

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 ##
 # This class is a wrapper around File IO and Encoding that helps RDoc load

--- a/lib/rdoc/erb_partial.rb
+++ b/lib/rdoc/erb_partial.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Allows an ERB template to be rendered in the context (binding) of an
 # existing ERB template evaluation.

--- a/lib/rdoc/erbio.rb
+++ b/lib/rdoc/erbio.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'erb'
 
 ##

--- a/lib/rdoc/extend.rb
+++ b/lib/rdoc/extend.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A Module extension to a class with \#extend
 #

--- a/lib/rdoc/generator.rb
+++ b/lib/rdoc/generator.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # RDoc uses generators to turn parsed source code in the form of an
 # RDoc::CodeObject tree into some form of output.  RDoc comes with the HTML

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # -*- mode: ruby; ruby-indent-level: 2; tab-width: 2 -*-
 
 require 'erb'

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'json'
 begin
   require 'zlib'

--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Handle common RDoc::Markup tasks for various CodeObjects
 #

--- a/lib/rdoc/generator/pot.rb
+++ b/lib/rdoc/generator/pot.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Generates a POT file.
 #

--- a/lib/rdoc/generator/pot/message_extractor.rb
+++ b/lib/rdoc/generator/pot/message_extractor.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Extracts message from RDoc::Store
 

--- a/lib/rdoc/generator/pot/po.rb
+++ b/lib/rdoc/generator/pot/po.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Generates a PO format text
 

--- a/lib/rdoc/generator/pot/po.rb
+++ b/lib/rdoc/generator/pot/po.rb
@@ -29,8 +29,8 @@ class RDoc::Generator::POT::PO
   def to_s
     po = ''
     sort_entries.each do |entry|
-      po << "\n" unless po.empty?
-      po << entry.to_s
+      po += "\n" unless po.empty?
+      po += entry.to_s
     end
     po
   end

--- a/lib/rdoc/generator/pot/po_entry.rb
+++ b/lib/rdoc/generator/pot/po_entry.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A PO entry in PO
 

--- a/lib/rdoc/generator/pot/po_entry.rb
+++ b/lib/rdoc/generator/pot/po_entry.rb
@@ -40,11 +40,11 @@ class RDoc::Generator::POT::POEntry
 
   def to_s
     entry = ''
-    entry << format_translator_comment
-    entry << format_extracted_comment
-    entry << format_references
-    entry << format_flags
-    entry << <<-ENTRY
+    entry += format_translator_comment
+    entry += format_extracted_comment
+    entry += format_references
+    entry += format_flags
+    entry += <<-ENTRY
 msgid #{format_message(@msgid)}
 msgstr #{format_message(@msgstr)}
     ENTRY
@@ -75,9 +75,9 @@ msgstr #{format_message(@msgstr)}
 
     formatted_comment = ''
     comment.each_line do |line|
-      formatted_comment << "#{mark} #{line}"
+      formatted_comment += "#{mark} #{line}"
     end
-    formatted_comment << "\n" unless formatted_comment.end_with?("\n")
+    formatted_comment += "\n" unless formatted_comment.end_with?("\n")
     formatted_comment
   end
 
@@ -94,7 +94,7 @@ msgstr #{format_message(@msgstr)}
 
     formatted_references = ''
     @references.sort.each do |file, line|
-      formatted_references << "\#: #{file}:#{line}\n"
+      formatted_references += "\#: #{file}:#{line}\n"
     end
     formatted_references
   end
@@ -111,8 +111,8 @@ msgstr #{format_message(@msgstr)}
 
     formatted_message = '""'
     message.each_line do |line|
-      formatted_message << "\n"
-      formatted_message << "\"#{escape(line)}\""
+      formatted_message += "\n"
+      formatted_message += "\"#{escape(line)}\""
     end
     formatted_message
   end

--- a/lib/rdoc/generator/ri.rb
+++ b/lib/rdoc/generator/ri.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Generates ri data files
 

--- a/lib/rdoc/ghost_method.rb
+++ b/lib/rdoc/ghost_method.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # GhostMethod represents a method referenced only by a comment
 

--- a/lib/rdoc/i18n.rb
+++ b/lib/rdoc/i18n.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # This module provides i18n related features.
 

--- a/lib/rdoc/i18n/locale.rb
+++ b/lib/rdoc/i18n/locale.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A message container for a locale.
 #

--- a/lib/rdoc/i18n/text.rb
+++ b/lib/rdoc/i18n/text.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An i18n supported text.
 #

--- a/lib/rdoc/i18n/text.rb
+++ b/lib/rdoc/i18n/text.rb
@@ -46,9 +46,9 @@ class RDoc::I18n::Text
     parse do |part|
       case part[:type]
       when :paragraph
-        translated_text << locale.translate(part[:paragraph])
+        translated_text += locale.translate(part[:paragraph])
       when :empty_line
-        translated_text << part[:line]
+        translated_text += part[:line]
       else
         raise "should not reach here: unexpected type: #{type}"
       end
@@ -69,14 +69,14 @@ class RDoc::I18n::Text
         if paragraph.empty?
           emit_empty_line_event(line, line_no, &block)
         else
-          paragraph << line
+          paragraph += line
           emit_paragraph_event(paragraph, paragraph_start_line, line_no,
                                &block)
           paragraph = ''
         end
       else
         paragraph_start_line = line_no if paragraph.empty?
-        paragraph << line
+        paragraph += line
       end
     end
 

--- a/lib/rdoc/include.rb
+++ b/lib/rdoc/include.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A Module included in a class with \#include
 #

--- a/lib/rdoc/known_classes.rb
+++ b/lib/rdoc/known_classes.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module RDoc
 
   ##

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -2,6 +2,7 @@
 
 %% header {
 # coding: UTF-8
+# frozen_string_literal: true
 # :markup: markdown
 
 ##

--- a/lib/rdoc/markdown/entities.rb
+++ b/lib/rdoc/markdown/entities.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # HTML entity name map for RDoc::Markdown
 

--- a/lib/rdoc/markdown/literals.kpeg
+++ b/lib/rdoc/markdown/literals.kpeg
@@ -2,6 +2,7 @@
 
 %% header {
 # coding: UTF-8
+# frozen_string_literal: true
 # :markup: markdown
 
 ##

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # RDoc::Markup parses plain text documents and attempts to decompose them into
 # their constituent parts.  Some of these parts are high-level: paragraphs,

--- a/lib/rdoc/markup/attr_changer.rb
+++ b/lib/rdoc/markup/attr_changer.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 class RDoc::Markup
 
   AttrChanger = Struct.new :turn_on, :turn_off # :nodoc:

--- a/lib/rdoc/markup/attr_span.rb
+++ b/lib/rdoc/markup/attr_span.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An array of attributes which parallels the characters in a string.
 

--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Manages changes of attributes in a block of text
 

--- a/lib/rdoc/markup/attributes.rb
+++ b/lib/rdoc/markup/attributes.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # We manage a set of attributes.  Each attribute has a symbol name and a bit
 # value.

--- a/lib/rdoc/markup/blank_line.rb
+++ b/lib/rdoc/markup/blank_line.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An empty line.  This class is a singleton.
 

--- a/lib/rdoc/markup/block_quote.rb
+++ b/lib/rdoc/markup/block_quote.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A quoted section which contains markup items.
 

--- a/lib/rdoc/markup/document.rb
+++ b/lib/rdoc/markup/document.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A Document containing lists, headings, paragraphs, etc.
 

--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Base class for RDoc markup formatters
 #

--- a/lib/rdoc/markup/formatter_test_case.rb
+++ b/lib/rdoc/markup/formatter_test_case.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'minitest/unit'
 
 ##

--- a/lib/rdoc/markup/hard_break.rb
+++ b/lib/rdoc/markup/hard_break.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A hard-break in the middle of a paragraph.
 

--- a/lib/rdoc/markup/heading.rb
+++ b/lib/rdoc/markup/heading.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A heading with a level (1-6) and text
 

--- a/lib/rdoc/markup/include.rb
+++ b/lib/rdoc/markup/include.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A file included at generation time.  Objects of this class are created by
 # RDoc::RD for an extension-less include.

--- a/lib/rdoc/markup/indented_paragraph.rb
+++ b/lib/rdoc/markup/indented_paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An Indented Paragraph of text
 

--- a/lib/rdoc/markup/inline.rb
+++ b/lib/rdoc/markup/inline.rb
@@ -1,2 +1,2 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 warn "requiring rdoc/markup/inline is deprecated and will be removed in RDoc 4." if $-w

--- a/lib/rdoc/markup/list.rb
+++ b/lib/rdoc/markup/list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A List is a homogeneous set of ListItems.
 #

--- a/lib/rdoc/markup/list_item.rb
+++ b/lib/rdoc/markup/list_item.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # An item within a List that contains paragraphs, headings, etc.
 #

--- a/lib/rdoc/markup/paragraph.rb
+++ b/lib/rdoc/markup/paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A Paragraph of text
 

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'strscan'
 
 ##

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -249,7 +249,7 @@ class RDoc::Markup::Parser
 
     min_indent = nil
     generate_leading_spaces = true
-    line = ''
+    line = ''.dup
 
     until @tokens.empty? do
       type, data, column, = get
@@ -257,7 +257,7 @@ class RDoc::Markup::Parser
       if type == :NEWLINE then
         line << data
         verbatim << line
-        line = ''
+        line = ''.dup
         generate_leading_spaces = true
         next
       end

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Handle common directives that can occur in a block of text:
 #

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -105,7 +105,7 @@ class RDoc::Markup::PreProcess
     # regexp helper (square brackets for optional)
     # $1      $2  $3        $4      $5
     # [prefix][\]:directive:[spaces][param]newline
-    text.gsub!(/^([ \t]*(?:#|\/?\*)?[ \t]*)(\\?):(\w+):([ \t]*)(.+)?(\r?\n|$)/) do
+    text = text.gsub(/^([ \t]*(?:#|\/?\*)?[ \t]*)(\\?):(\w+):([ \t]*)(.+)?(\r?\n|$)/) do
       # skip something like ':toto::'
       next $& if $4.empty? and $5 and $5[0, 1] == ':'
 
@@ -123,7 +123,11 @@ class RDoc::Markup::PreProcess
       handle_directive $1, $3, $5, code_object, text.encoding, &block
     end
 
-    comment = text unless comment
+    if comment then
+      comment.text = text
+    else
+      comment = text
+    end
 
     self.class.post_processors.each do |handler|
       handler.call comment, code_object
@@ -212,7 +216,7 @@ class RDoc::Markup::PreProcess
     when 'yield', 'yields' then
       return blankline unless code_object
       # remove parameter &block
-      code_object.params.sub!(/,?\s*&\w+/, '') if code_object.params
+      code_object.params = code_object.params.sub(/,?\s*&\w+/, '') if code_object.params
 
       code_object.block_params = param
 

--- a/lib/rdoc/markup/raw.rb
+++ b/lib/rdoc/markup/raw.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A section of text that is added to the output document as-is
 

--- a/lib/rdoc/markup/rule.rb
+++ b/lib/rdoc/markup/rule.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A horizontal rule with a weight
 

--- a/lib/rdoc/markup/special.rb
+++ b/lib/rdoc/markup/special.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Hold details of a special sequence
 

--- a/lib/rdoc/markup/text_formatter_test_case.rb
+++ b/lib/rdoc/markup/text_formatter_test_case.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Test case for creating new plain-text RDoc::Markup formatters.  See also
 # RDoc::Markup::FormatterTestCase

--- a/lib/rdoc/markup/to_ansi.rb
+++ b/lib/rdoc/markup/to_ansi.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Outputs RDoc markup with vibrant ANSI color!
 

--- a/lib/rdoc/markup/to_bs.rb
+++ b/lib/rdoc/markup/to_bs.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Outputs RDoc markup with hot backspace action!  You will probably need a
 # pager to use this output format.

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'cgi'
 
 ##

--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Subclass of the RDoc::Markup::ToHtml class that supports looking up method
 # names, classes, etc to create links.  RDoc::CrossReference is used to

--- a/lib/rdoc/markup/to_html_snippet.rb
+++ b/lib/rdoc/markup/to_html_snippet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Outputs RDoc markup as paragraphs with inline markup only.
 

--- a/lib/rdoc/markup/to_joined_paragraph.rb
+++ b/lib/rdoc/markup/to_joined_paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Joins the parts of an RDoc::Markup::Paragraph into a single String.
 #

--- a/lib/rdoc/markup/to_label.rb
+++ b/lib/rdoc/markup/to_label.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'cgi'
 
 ##

--- a/lib/rdoc/markup/to_markdown.rb
+++ b/lib/rdoc/markup/to_markdown.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # :markup: markdown
 
 ##

--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Outputs RDoc markup as RDoc markup! (mostly)
 

--- a/lib/rdoc/markup/to_table_of_contents.rb
+++ b/lib/rdoc/markup/to_table_of_contents.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Extracts just the RDoc::Markup::Heading elements from a
 # RDoc::Markup::Document to help build a table of contents

--- a/lib/rdoc/markup/to_test.rb
+++ b/lib/rdoc/markup/to_test.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # This Markup outputter is used for testing purposes.
 

--- a/lib/rdoc/markup/to_tt_only.rb
+++ b/lib/rdoc/markup/to_tt_only.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Extracts sections of text enclosed in plus, tt or code.  Used to discover
 # undocumented parameters.

--- a/lib/rdoc/markup/verbatim.rb
+++ b/lib/rdoc/markup/verbatim.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A section of verbatim text
 

--- a/lib/rdoc/meta_method.rb
+++ b/lib/rdoc/meta_method.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # MetaMethod represents a meta-programmed method
 

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Abstract class representing either a method or an attribute.
 

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -188,7 +188,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
       next if String === ancestor
       next if parent == ancestor
 
-      other = ancestor.find_method_named('#' << name) ||
+      other = ancestor.find_method_named('#' + name) ||
               ancestor.find_attribute_named(name)
 
       return other if other

--- a/lib/rdoc/mixin.rb
+++ b/lib/rdoc/mixin.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A Mixin adds features from a module into another context.  RDoc::Include and
 # RDoc::Extend are both mixins.

--- a/lib/rdoc/normal_class.rb
+++ b/lib/rdoc/normal_class.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A normal class, neither singleton nor anonymous
 

--- a/lib/rdoc/normal_class.rb
+++ b/lib/rdoc/normal_class.rb
@@ -47,9 +47,9 @@ class RDoc::NormalClass < RDoc::ClassModule
   def to_s # :nodoc:
     display = "#{self.class.name} #{self.full_name}"
     if superclass
-      display << ' < ' << (superclass.is_a?(String) ? superclass : superclass.full_name)
+      display += ' < ' + (superclass.is_a?(String) ? superclass : superclass.full_name)
     end
-    display << ' -> ' << is_alias_for.to_s if is_alias_for
+    display += ' -> ' + is_alias_for.to_s if is_alias_for
     display
   end
 

--- a/lib/rdoc/normal_module.rb
+++ b/lib/rdoc/normal_module.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A normal module, like NormalClass
 

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'optparse'
 require 'pathname'
 

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -624,16 +624,16 @@ Usage: #{opt.program_name} [options] [names...]
       end
 
       parsers.sort.each do |parser, regexp|
-        opt.banner << "  - #{parser}: #{regexp.join ', '}\n"
+        opt.banner += "  - #{parser}: #{regexp.join ', '}\n"
       end
-      opt.banner << "  - TomDoc:  Only in ruby files\n"
+      opt.banner += "  - TomDoc:  Only in ruby files\n"
 
-      opt.banner << "\n  The following options are deprecated:\n\n"
+      opt.banner += "\n  The following options are deprecated:\n\n"
 
       name_length = DEPRECATED.keys.sort_by { |k| k.length }.last.length
 
       DEPRECATED.sort_by { |k,| k }.each do |name, reason|
-        opt.banner << "    %*1$2$s  %3$s\n" % [-name_length, name, reason]
+        opt.banner += "    %*1$2$s  %3$s\n" % [-name_length, name, reason]
       end
 
       opt.accept Template do |template|
@@ -1087,7 +1087,7 @@ Usage: #{opt.program_name} [options] [names...]
 
     unless quiet then
       deprecated.each do |opt|
-        $stderr.puts 'option ' << opt << ' is deprecated: ' << DEPRECATED[opt]
+        $stderr.puts 'option ' + opt + ' is deprecated: ' + DEPRECATED[opt]
       end
     end
 

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -1,5 +1,5 @@
 # -*- coding: us-ascii -*-
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 ##
 # A parser is simple a class that subclasses RDoc::Parser and implements #scan

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -865,8 +865,8 @@ class RDoc::Parser::C < RDoc::Parser
 
   def handle_attr(var_name, attr_name, read, write)
     rw = ''
-    rw << 'R' if '1' == read
-    rw << 'W' if '1' == write
+    rw += 'R' if '1' == read
+    rw += 'W' if '1' == write
 
     class_name = @known_classes[var_name]
 
@@ -982,8 +982,8 @@ class RDoc::Parser::C < RDoc::Parser
         if new_definition.empty? then # Default to literal C definition
           new_definition = definition
         else
-          new_definition.gsub!("\:", ":")
-          new_definition.gsub!("\\", '\\')
+          new_definition = new_definition.gsub("\:", ":")
+          new_definition = new_definition.gsub("\\", '\\')
         end
 
         new_definition.sub!(/\A(\s+)/, '')
@@ -1237,7 +1237,7 @@ class RDoc::Parser::C < RDoc::Parser
   # when scanning for classes and methods
 
   def remove_commented_out_lines
-    @content.gsub!(%r%//.*rb_define_%, '//')
+    @content = @content.gsub(%r%//.*rb_define_%, '//')
   end
 
   ##

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'tsort'
 
 ##

--- a/lib/rdoc/parser/changelog.rb
+++ b/lib/rdoc/parser/changelog.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'time'
 
 ##

--- a/lib/rdoc/parser/changelog.rb
+++ b/lib/rdoc/parser/changelog.rb
@@ -29,13 +29,13 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
 
     if last =~ /\)\s*\z/ and continuation =~ /\A\(/ then
       last.sub!(/\)\s*\z/, ',')
-      continuation.sub!(/\A\(/, '')
+      continuation = continuation.sub(/\A\(/, '')
     end
 
     if last =~ /\s\z/ then
       last << continuation
     else
-      last << ' ' << continuation
+      last << ' ' + continuation
     end
   end
 
@@ -162,12 +162,12 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
 
         entry_body = []
       when /^(\t| {8})?\*\s*(.*)/ then # "\t* file.c (func): ..."
-        entry_body << $2
+        entry_body << $2.dup
       when /^(\t| {8})?\s*(\(.*)/ then # "\t(func): ..."
         entry = $2
 
         if entry_body.last =~ /:/ then
-          entry_body << entry
+          entry_body << entry.dup
         else
           continue_entry_body entry_body, entry
         end

--- a/lib/rdoc/parser/markdown.rb
+++ b/lib/rdoc/parser/markdown.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Parse a Markdown format file.  The parsed RDoc::Markup::Document is attached
 # as a file comment.

--- a/lib/rdoc/parser/rd.rb
+++ b/lib/rdoc/parser/rd.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Parse a RD format file.  The parsed RDoc::Markup::Document is attached as a
 # file comment.

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # This file contains stuff stolen outright from:
 #

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -239,8 +239,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
   def collect_first_comment
     skip_tkspace
-    comment = ''
-    comment.force_encoding @encoding if @encoding
+    comment = ''.dup
+    comment = RDoc::Encoding.change_encoding comment, @encoding if @encoding
     first_line = true
     first_comment_tk_kind = nil
 
@@ -341,7 +341,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def get_class_or_module container, ignore_constants = false
     skip_tkspace
     name_t = get_tk
-    given_name = ''
+    given_name = ''.dup
 
     # class ::A -> A is in the top level
     if :on_op == name_t[:kind] and '::' == name_t[:text] then # bug
@@ -378,7 +378,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       if prev_container == container and !ignore_constants
         given_name = name_t[:text]
       else
-        given_name << '::' << name_t[:text]
+        given_name << '::' + name_t[:text]
       end
     end
 
@@ -594,7 +594,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Adds useful info about the parser to +message+
 
   def make_message message
-    prefix = "#{@file_name}:"
+    prefix = "#{@file_name}:".dup
 
     tk = peek_tk
     prefix << "#{tk[:line_no]}:#{tk[:char_no]}:" if tk
@@ -913,7 +913,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     return unless body
 
-    value.replace body
+    con.value = body
     record_location con
     con.line   = line_no
     read_documentation_modifiers con, RDoc::CONSTANT_MODIFIERS
@@ -928,7 +928,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
   def parse_constant_body container, constant, is_array_or_hash # :nodoc:
     nest     = 0
-    rhs_name = ''
+    rhs_name = ''.dup
 
     get_tkread
 
@@ -990,14 +990,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
     column  = tk[:char_no]
     line_no = tk[:line_no]
 
-    text = comment.text
-
-    singleton = !!text.sub!(/(^# +:?)(singleton-)(method:)/, '\1\3')
+    comment.text = comment.text.sub(/(^# +:?)(singleton-)(method:)/, '\1\3')
+    singleton = !!$~
 
     co =
-      if text.sub!(/^# +:?method: *(\S*).*?\n/i, '') then
-        parse_comment_ghost container, text, $1, column, line_no, comment
-      elsif text.sub!(/# +:?(attr(_reader|_writer|_accessor)?): *(\S*).*?\n/i, '') then
+      if (comment.text = comment.text.sub(/^# +:?method: *(\S*).*?\n/i, '')) && !!$~ then
+        parse_comment_ghost container, comment.text, $1, column, line_no, comment
+      elsif (comment.text = comment.text.sub(/# +:?(attr(_reader|_writer|_accessor)?): *(\S*).*?\n/i, '')) && !!$~ then
         parse_comment_attr container, $1, $3, comment
       end
 
@@ -1194,7 +1193,9 @@ class RDoc::Parser::Ruby < RDoc::Parser
     tmp = RDoc::CodeObject.new
     read_documentation_modifiers tmp, RDoc::ATTR_MODIFIERS
 
-    if comment.text.sub!(/^# +:?(attr(_reader|_writer|_accessor)?): *(\S*).*?\n/i, '') then
+    regexp = /^# +:?(attr(_reader|_writer|_accessor)?): *(\S*).*?\n/i
+    if regexp =~ comment.text then
+      comment.text = comment.text.sub(regexp, '')
       rw = case $1
            when 'attr_reader' then 'R'
            when 'attr_writer' then 'W'
@@ -1227,7 +1228,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     skip_tkspace false
 
-    singleton = !!comment.text.sub!(/(^# +:?)(singleton-)(method:)/, '\1\3')
+    comment.text = comment.text.sub(/(^# +:?)(singleton-)(method:)/, '\1\3')
+    singleton = !!$~
 
     name = parse_meta_method_name comment, tk
 
@@ -1643,7 +1645,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def parse_statements(container, single = NORMAL, current_method = nil,
                        comment = new_comment(''))
     raise 'no' unless RDoc::Comment === comment
-    comment.force_encoding @encoding if @encoding
+    comment = RDoc::Encoding.change_encoding comment, @encoding if @encoding
 
     nest = 1
     save_visibility = container.visibility
@@ -1686,12 +1688,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
               comment.empty?
 
             comment = ''
-            comment.force_encoding @encoding if @encoding
+            comment = RDoc::Encoding.change_encoding comment, @encoding if @encoding
           end
 
           while tk and (:on_comment == tk[:kind] or :on_embdoc == tk[:kind]) do
-            comment << tk[:text]
-            comment << "\n" unless "\n" == tk[:text].chars.to_a.last
+            comment += tk[:text]
+            comment += "\n" unless "\n" == tk[:text].chars.to_a.last
 
             if tk[:text].size > 1 && "\n" == tk[:text].chars.to_a.last then
               skip_tkspace false # leading spaces
@@ -1810,7 +1812,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
       unless keep_comment then
         comment = new_comment ''
-        comment.force_encoding @encoding if @encoding
+        comment = RDoc::Encoding.change_encoding comment, @encoding if @encoding
         container.params = nil
         container.block_params = nil
       end

--- a/lib/rdoc/parser/ruby_tools.rb
+++ b/lib/rdoc/parser/ruby_tools.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Collection of methods for writing parsers
 

--- a/lib/rdoc/parser/simple.rb
+++ b/lib/rdoc/parser/simple.rb
@@ -19,7 +19,7 @@ class RDoc::Parser::Simple < RDoc::Parser
 
     preprocess = RDoc::Markup::PreProcess.new @file_name, @options.rdoc_include
 
-    preprocess.handle @content, @top_level
+    @content = preprocess.handle @content, @top_level
   end
 
   ##
@@ -52,7 +52,7 @@ class RDoc::Parser::Simple < RDoc::Parser
   def remove_private_comment comment
     # Workaround for gsub encoding for Ruby 1.9.2 and earlier
     empty = ''
-    empty.force_encoding comment.encoding
+    empty = RDoc::Encoding.change_encoding empty, comment.encoding
 
     comment = comment.gsub(%r%^--\n.*?^\+\+\n?%m, empty)
     comment.sub(%r%^--\n.*%m, empty)

--- a/lib/rdoc/parser/simple.rb
+++ b/lib/rdoc/parser/simple.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Parse a non-source file. We basically take the whole thing as one big
 # comment.

--- a/lib/rdoc/parser/text.rb
+++ b/lib/rdoc/parser/text.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Indicates this parser is text and doesn't contain code constructs.
 #

--- a/lib/rdoc/rd.rb
+++ b/lib/rdoc/rd.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # RDoc::RD implements the RD format from the rdtool gem.
 #

--- a/lib/rdoc/rd/block_parser.ry
+++ b/lib/rdoc/rd/block_parser.ry
@@ -420,7 +420,7 @@ def next_token # :nodoc:
       if @in_verbatim
         [:STRINGLINE, line]
       else
-        @indent_stack.push("\s" << newIndent)
+        @indent_stack.push("\s" + newIndent)
         [:ITEMLISTLINE, rest]
       end
     end
@@ -432,7 +432,7 @@ def next_token # :nodoc:
       if @in_verbatim
         [:STRINGLINE, line]
       else
-        @indent_stack.push("\s" * mark.size << newIndent)
+        @indent_stack.push("\s" * mark.size + newIndent)
         [:ENUMLISTLINE, rest]
       end
     end

--- a/lib/rdoc/rd/inline.rb
+++ b/lib/rdoc/rd/inline.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Inline keeps track of markup and labels to create proper links.
 

--- a/lib/rdoc/rd/inline.rb
+++ b/lib/rdoc/rd/inline.rb
@@ -50,11 +50,11 @@ class RDoc::RD::Inline
   def append more
     case more
     when String then
-      @reference << more
-      @rdoc      << more
+      @reference += more
+      @rdoc      += more
     when RDoc::RD::Inline then
-      @reference << more.reference
-      @rdoc      << more.rdoc
+      @reference += more.reference
+      @rdoc      += more.rdoc
     else
       raise "unknown thingy #{more}"
     end

--- a/lib/rdoc/rd/inline_parser.ry
+++ b/lib/rdoc/rd/inline_parser.ry
@@ -436,7 +436,7 @@ end
 def parse inline
   @inline = inline
   @src = StringScanner.new inline
-  @pre = ""
+  @pre = "".dup
   @yydebug = true
   do_parse.to_s
 end

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc'
 
 require 'find'

--- a/lib/rdoc/require.rb
+++ b/lib/rdoc/require.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A file loaded by \#require
 

--- a/lib/rdoc/ri.rb
+++ b/lib/rdoc/ri.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc'
 
 ##

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'abbrev'
 require 'optparse'
 

--- a/lib/rdoc/ri/formatter.rb
+++ b/lib/rdoc/ri/formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # For RubyGems backwards compatibility
 

--- a/lib/rdoc/ri/paths.rb
+++ b/lib/rdoc/ri/paths.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/ri'
 
 ##

--- a/lib/rdoc/ri/store.rb
+++ b/lib/rdoc/ri/store.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module RDoc::RI
 
   Store = RDoc::Store # :nodoc:

--- a/lib/rdoc/ri/task.rb
+++ b/lib/rdoc/ri/task.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 begin
   gem 'rdoc'
 rescue Gem::LoadError

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rubygems/user_interaction'
 require 'fileutils'
 require 'rdoc'

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc'
 require 'time'
 require 'json'

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -111,7 +111,7 @@ class RDoc::Servlet < WEBrick::HTTPServlet::AbstractServlet
   # GET request entry point.  Fills in +res+ for the path, etc. in +req+.
 
   def do_GET req, res
-    req.path.sub!(/^#{Regexp.escape @mount_path}/o, '') if @mount_path
+    req.path = req.path.sub(/^#{Regexp.escape @mount_path}/o, '') if @mount_path
 
     case req.path
     when '/' then

--- a/lib/rdoc/single_class.rb
+++ b/lib/rdoc/single_class.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A singleton class
 

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # RDoc statistics collector which prints a summary and report of a project's
 # documentation totals.

--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 begin
   require 'io/console/size'
 rescue LoadError

--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -42,7 +42,7 @@ class RDoc::Stats::Normal < RDoc::Stats::Quiet
     if $stdout.tty?
       # Clean the line with whitespaces so that leftover output from the
       # previous line doesn't show up.
-      $stdout.print("\r" << (" " * @last_width) << ("\b" * @last_width) << "\r") if @last_width && @last_width > 0
+      $stdout.print("\r" + (" " * @last_width) + ("\b" * @last_width) + "\r") if @last_width && @last_width > 0
       @last_width = line.size
       $stdout.print("#{line}\r")
     else

--- a/lib/rdoc/stats/quiet.rb
+++ b/lib/rdoc/stats/quiet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Stats printer that prints nothing
 

--- a/lib/rdoc/stats/verbose.rb
+++ b/lib/rdoc/stats/verbose.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # Stats printer that prints everything documented, including the documented
 # status

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'fileutils'
 
 ##

--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # Copyright (c) 2003, 2004 Jim Weirich, 2009 Eric Hodel
 #

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 begin
   gem 'minitest', '~> 4.0' unless defined?(Test::Unit)
 rescue NoMethodError, Gem::LoadError

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -139,9 +139,8 @@ class RDoc::TestCase < MiniTest::Unit::TestCase
   # Enables pretty-print output
 
   def mu_pp obj # :nodoc:
-    s = ''
-    s = PP.pp obj, s
-    s = s.force_encoding Encoding.default_external
+    s = obj.pretty_inspect
+    s = RDoc::Encoding.change_encoding s, Encoding.default_external
     s.chomp
   end
 

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 ##
 # For RDoc::Text#to_html

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -60,7 +60,7 @@ module RDoc::Text
     text.each_line do |line|
       nil while line.gsub!(/(?:\G|\r)((?:.{8})*?)([^\t\r\n]{0,7})\t/) do
         r = "#{$1}#{$2}#{' ' * (8 - $2.size)}"
-        r.force_encoding text.encoding
+        r = RDoc::Encoding.change_encoding r, text.encoding
         r
       end
 
@@ -82,7 +82,7 @@ module RDoc::Text
     end
 
     empty = ''
-    empty.force_encoding text.encoding
+    empty = RDoc::Encoding.change_encoding empty, text.encoding
 
     text.gsub(/^ {0,#{indent}}/, empty)
   end
@@ -149,7 +149,7 @@ module RDoc::Text
     return text if text =~ /^(?>\s*)[^\#]/
 
     empty = ''
-    empty.force_encoding text.encoding
+    empty = RDoc::Encoding.change_encoding empty, text.encoding
 
     text.gsub(/^\s*(#+)/) { $1.tr '#', ' ' }.gsub(/^\s+$/, empty)
   end
@@ -172,14 +172,14 @@ module RDoc::Text
     text = text.gsub %r%Document-method:\s+[\w:.#=!?]+%, ''
 
     space = ' '
-    space.force_encoding encoding if encoding
+    space = RDoc::Encoding.change_encoding space, encoding if encoding
 
     text.sub!  %r%/\*+%       do space * $&.length end
     text.sub!  %r%\*+/%       do space * $&.length end
     text.gsub! %r%^[ \t]*\*%m do space * $&.length end
 
     empty = ''
-    empty.force_encoding encoding if encoding
+    empty = RDoc::Encoding.change_encoding empty, encoding if encoding
     text.gsub(/^\s+$/, empty)
   end
 
@@ -188,7 +188,7 @@ module RDoc::Text
   # trademark symbols in +text+ to properly encoded characters.
 
   def to_html text
-    html = ''.encode text.encoding
+    html = (''.encode text.encoding).dup
 
     encoded = RDoc::Text::TO_HTML_CHARACTERS[text.encoding]
 

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A TokenStream is a list of tokens, gathered during the parse of some entity
 # (say a method). Entities populate these streams by being registered with the

--- a/lib/rdoc/tom_doc.rb
+++ b/lib/rdoc/tom_doc.rb
@@ -222,7 +222,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   # Returns self.
 
   def tokenize text
-    text.sub!(/\A(Public|Internal|Deprecated):\s+/, '')
+    text = text.sub(/\A(Public|Internal|Deprecated):\s+/, '')
 
     setup_scanner text
 

--- a/lib/rdoc/tom_doc.rb
+++ b/lib/rdoc/tom_doc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # :markup: tomdoc
 
 # A parser for TomDoc based on TomDoc 1.0.0-rc1 (02adef9b5a)

--- a/lib/rdoc/top_level.rb
+++ b/lib/rdoc/top_level.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ##
 # A TopLevel context is a representation of the contents of a single file
 

--- a/test/test_rdoc_alias.rb
+++ b/test/test_rdoc_alias.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocAlias < XrefTestCase

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocAnyMethod < XrefTestCase

--- a/test/test_rdoc_attr.rb
+++ b/test/test_rdoc_attr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocAttr < RDoc::TestCase

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocClassModule < XrefTestCase

--- a/test/test_rdoc_code_object.rb
+++ b/test/test_rdoc_code_object.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require File.expand_path '../xref_test_case', __FILE__
 

--- a/test/test_rdoc_code_object.rb
+++ b/test/test_rdoc_code_object.rb
@@ -53,7 +53,7 @@ class TestRDocCodeObject < XrefTestCase
     refute_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     input = 'text'
-    input.force_encoding Encoding::UTF_8
+    input = RDoc::Encoding.change_encoding input, Encoding::UTF_8
 
     @co.comment = input
 
@@ -65,7 +65,7 @@ class TestRDocCodeObject < XrefTestCase
     refute_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     input = ''
-    input.force_encoding Encoding::UTF_8
+    input = RDoc::Encoding.change_encoding input, Encoding::UTF_8
 
     @co.comment = input
 

--- a/test/test_rdoc_comment.rb
+++ b/test/test_rdoc_comment.rb
@@ -207,7 +207,7 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
   def test_force_encoding
-    @comment.force_encoding Encoding::UTF_8
+    @comment = RDoc::Encoding.change_encoding @comment, Encoding::UTF_8
 
     assert_equal Encoding::UTF_8, @comment.text.encoding
   end
@@ -347,7 +347,7 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
 # this is private
     EOS
 
-    comment.force_encoding Encoding::IBM437
+    comment = RDoc::Encoding.change_encoding comment, Encoding::IBM437
 
     comment.remove_private
 
@@ -471,7 +471,7 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
 # This is text again.
     EOS
 
-    comment.force_encoding Encoding::IBM437
+    comment = RDoc::Encoding.change_encoding comment, Encoding::IBM437
 
     comment.remove_private
 
@@ -486,7 +486,7 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
 # This is text again.
     EOS
 
-    comment.force_encoding Encoding::IBM437
+    comment = RDoc::Encoding.change_encoding comment, Encoding::IBM437
 
     comment.remove_private
 

--- a/test/test_rdoc_comment.rb
+++ b/test/test_rdoc_comment.rb
@@ -1,5 +1,5 @@
 # coding: us-ascii
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_constant.rb
+++ b/test/test_rdoc_constant.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocConstant < XrefTestCase

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocContext < XrefTestCase

--- a/test/test_rdoc_context_section.rb
+++ b/test/test_rdoc_context_section.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocContextSection < RDoc::TestCase

--- a/test/test_rdoc_cross_reference.rb
+++ b/test/test_rdoc_cross_reference.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocCrossReference < XrefTestCase

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -37,7 +37,7 @@ class TestRDocEncoding < RDoc::TestCase
 
   def test_class_read_file_encoding_convert
     content = ""
-    content.encode! 'ISO-8859-1'
+    content = RDoc::Encoding.change_encoding content, 'ISO-8859-1'
     content << "# coding: ISO-8859-1\nhi \xE9verybody"
 
     @tempfile.write content
@@ -65,7 +65,7 @@ class TestRDocEncoding < RDoc::TestCase
 
   def test_class_read_file_encoding_fancy
     expected = "# -*- coding: utf-8; fill-column: 74 -*-\nhi everybody"
-    expected.encode! Encoding::UTF_8
+    exptected = RDoc::Encoding.change_encoding expected, Encoding::UTF_8
 
     @tempfile.write expected
     @tempfile.flush
@@ -125,7 +125,7 @@ class TestRDocEncoding < RDoc::TestCase
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
 
     expected = ":\xe3\x82\xb3\xe3\x83\x9e\xe3\x83\xb3\xe3\x83\x89:"
-    expected.force_encoding Encoding::UTF_8
+    expected = RDoc::Encoding.change_encoding expected, Encoding::UTF_8
 
     assert_equal expected, contents
     assert_equal Encoding::UTF_8, contents.encoding
@@ -133,24 +133,24 @@ class TestRDocEncoding < RDoc::TestCase
 
   def test_class_set_encoding
     s = "# coding: UTF-8\n"
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     # sanity check for 1.8
 
     assert_equal Encoding::UTF_8, s.encoding
 
     s = "#!/bin/ruby\n# coding: UTF-8\n"
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal Encoding::UTF_8, s.encoding
 
     s = "<?xml version='1.0' encoding='UTF-8'?>\n"
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal Encoding::UTF_8, s.encoding
 
     s = "<?xml version='1.0' encoding=\"UTF-8\"?>\n"
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal Encoding::UTF_8, s.encoding
   end
@@ -158,13 +158,13 @@ class TestRDocEncoding < RDoc::TestCase
   def test_class_set_encoding_strip
     s = "# coding: UTF-8\n# more comments"
 
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal "# more comments", s
 
     s = "#!/bin/ruby\n# coding: UTF-8\n# more comments"
 
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal "#!/bin/ruby\n# more comments", s
   end
@@ -172,29 +172,29 @@ class TestRDocEncoding < RDoc::TestCase
   def test_class_set_encoding_bad
     s = ""
     expected = s.encoding
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal expected, s.encoding
 
     s = "# vim:set fileencoding=utf-8:\n"
     expected = s.encoding
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal expected, s.encoding
 
     s = "# vim:set fileencoding=utf-8:\n"
     expected = s.encoding
-    RDoc::Encoding.set_encoding s
+    s = RDoc::Encoding.set_encoding s
 
     assert_equal expected, s.encoding
 
     assert_raises ArgumentError do
-      RDoc::Encoding.set_encoding "# -*- encoding: undecided -*-\n"
+      s = RDoc::Encoding.set_encoding "# -*- encoding: undecided -*-\n"
     end
   end
 
   def test_skip_frozen_string_literal
-    expected = "# frozen_string_literal: false\nhi everybody"
+    expected = "# frozen_string_literal: true\nhi everybody"
 
     @tempfile.write expected
     @tempfile.flush
@@ -216,7 +216,7 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_skip_frozen_string_literal_before_coding
-    expected = "# frozen_string_literal: false\n# coding: utf-8\nhi everybody"
+    expected = "# frozen_string_literal: true\n# coding: utf-8\nhi everybody"
 
     @tempfile.write expected
     @tempfile.flush

--- a/test/test_rdoc_extend.rb
+++ b/test/test_rdoc_extend.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocExtend < XrefTestCase

--- a/test/test_rdoc_generator_darkfish.rb
+++ b/test/test_rdoc_generator_darkfish.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorDarkfish < RDoc::TestCase

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -199,7 +199,7 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
 
   def test_generate_utf_8
     text = "5\xB0"
-    text.force_encoding Encoding::ISO_8859_1
+    text = RDoc::Encoding.change_encoding text, Encoding::ISO_8859_1
     @klass.add_comment comment(text), @top_level
 
     @g.generate
@@ -215,7 +215,7 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
 
     klass_record = @klass.search_record[2..-1]
     klass_record[-1] = "<p>5\xc2\xb0\n"
-    klass_record.last.force_encoding Encoding::UTF_8
+    klass_record[-1] = RDoc::Encoding.change_encoding klass_record[-1], Encoding::UTF_8
 
     info = [
       klass_record,

--- a/test/test_rdoc_generator_markup.rb
+++ b/test/test_rdoc_generator_markup.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorMarkup < RDoc::TestCase

--- a/test/test_rdoc_generator_pot.rb
+++ b/test/test_rdoc_generator_pot.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorPOT < RDoc::TestCase

--- a/test/test_rdoc_generator_pot_po.rb
+++ b/test/test_rdoc_generator_pot_po.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorPOTPO < RDoc::TestCase

--- a/test/test_rdoc_generator_pot_po_entry.rb
+++ b/test/test_rdoc_generator_pot_po_entry.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorPOTPOEntry < RDoc::TestCase

--- a/test/test_rdoc_generator_ri.rb
+++ b/test/test_rdoc_generator_ri.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocGeneratorRI < RDoc::TestCase

--- a/test/test_rdoc_i18n_locale.rb
+++ b/test/test_rdoc_i18n_locale.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocI18nLocale < RDoc::TestCase

--- a/test/test_rdoc_i18n_text.rb
+++ b/test/test_rdoc_i18n_text.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocI18nText < RDoc::TestCase

--- a/test/test_rdoc_include.rb
+++ b/test/test_rdoc_include.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocInclude < XrefTestCase

--- a/test/test_rdoc_markdown.rb
+++ b/test/test_rdoc_markdown.rb
@@ -1,5 +1,5 @@
 # coding: UTF-8
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 require 'rdoc/markup/block_quote'

--- a/test/test_rdoc_markdown_test.rb
+++ b/test/test_rdoc_markdown_test.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'minitest/autorun'
 require 'pp'
 

--- a/test/test_rdoc_markup.rb
+++ b/test/test_rdoc_markup.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkup < RDoc::TestCase

--- a/test/test_rdoc_markup_attribute_manager.rb
+++ b/test/test_rdoc_markup_attribute_manager.rb
@@ -171,21 +171,21 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
   end
 
   def test_convert_attrs
-    str = '+foo+'
+    str = '+foo+'.dup
     attrs = RDoc::Markup::AttrSpan.new str.length
 
     @am.convert_attrs str, attrs
 
     assert_equal "\000foo\000", str
 
-    str = '+:foo:+'
+    str = '+:foo:+'.dup
     attrs = RDoc::Markup::AttrSpan.new str.length
 
     @am.convert_attrs str, attrs
 
     assert_equal "\000:foo:\000", str
 
-    str = '+x-y+'
+    str = '+x-y+'.dup
     attrs = RDoc::Markup::AttrSpan.new str.length
 
     @am.convert_attrs str, attrs
@@ -299,17 +299,17 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
     def @am.str()     @str       end
     def @am.str=(str) @str = str end
 
-    @am.str = '<code>foo</code>'
+    @am.str = '<code>foo</code>'.dup
     @am.mask_protected_sequences
 
     assert_equal "<code>foo</code>",       @am.str
 
-    @am.str = '<code>foo\\</code>'
+    @am.str = '<code>foo\\</code>'.dup
     @am.mask_protected_sequences
 
     assert_equal "<code>foo<\x04/code>", @am.str, 'escaped close'
 
-    @am.str = '<code>foo\\\\</code>'
+    @am.str = '<code>foo\\\\</code>'.dup
     @am.mask_protected_sequences
 
     assert_equal "<code>foo\\</code>",     @am.str, 'escaped backslash'

--- a/test/test_rdoc_markup_attribute_manager.rb
+++ b/test/test_rdoc_markup_attribute_manager.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupAttributeManager < RDoc::TestCase

--- a/test/test_rdoc_markup_attributes.rb
+++ b/test/test_rdoc_markup_attributes.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupAttributes < RDoc::TestCase

--- a/test/test_rdoc_markup_document.rb
+++ b/test/test_rdoc_markup_document.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupDocument < RDoc::TestCase

--- a/test/test_rdoc_markup_formatter.rb
+++ b/test/test_rdoc_markup_formatter.rb
@@ -12,7 +12,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
     end
 
     def accept_paragraph paragraph
-      @res << attributes(paragraph.text)
+      @res += attributes(paragraph.text)
     end
 
     def attributes text

--- a/test/test_rdoc_markup_formatter.rb
+++ b/test/test_rdoc_markup_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupFormatter < RDoc::TestCase

--- a/test/test_rdoc_markup_hard_break.rb
+++ b/test/test_rdoc_markup_hard_break.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupHardBreak < RDoc::TestCase

--- a/test/test_rdoc_markup_heading.rb
+++ b/test/test_rdoc_markup_heading.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupHeading < RDoc::TestCase

--- a/test/test_rdoc_markup_include.rb
+++ b/test/test_rdoc_markup_include.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupInclude < RDoc::TestCase

--- a/test/test_rdoc_markup_indented_paragraph.rb
+++ b/test/test_rdoc_markup_indented_paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupIndentedParagraph < RDoc::TestCase

--- a/test/test_rdoc_markup_paragraph.rb
+++ b/test/test_rdoc_markup_paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupParagraph < RDoc::TestCase

--- a/test/test_rdoc_markup_parser.rb
+++ b/test/test_rdoc_markup_parser.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_markup_pre_process.rb
+++ b/test/test_rdoc_markup_pre_process.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_markup_pre_process.rb
+++ b/test/test_rdoc_markup_pre_process.rb
@@ -86,8 +86,7 @@ contents of a string.
     text = "# :main: M\n"
     out = @pp.handle text
 
-    assert_same out, text
-    assert_equal "#\n", text
+    assert_equal "#\n", out
   end
 
   def test_handle_comment
@@ -96,8 +95,7 @@ contents of a string.
 
     out = @pp.handle c
 
-    assert_same out, text
-    assert_equal "#\n", text
+    assert_equal "#\n", out
   end
 
   def test_handle_markup
@@ -129,8 +127,7 @@ contents of a string.
 
     out = @pp.handle text, cd
 
-    assert_same out, text
-    assert_equal "# a b c\n", text
+    assert_equal "# a b c\n", out
     assert_equal "# a b c\n", cd.metadata[:stuff]
   end
 
@@ -138,8 +135,7 @@ contents of a string.
     text = "# :x: y\n"
     out = @pp.handle text
 
-    assert_same out, text
-    assert_equal "# :x: y\n", text
+    assert_equal text, out
   end
 
   def test_handle_directive_blankline

--- a/test/test_rdoc_markup_raw.rb
+++ b/test/test_rdoc_markup_raw.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupRaw < RDoc::TestCase

--- a/test/test_rdoc_markup_to_ansi.rb
+++ b/test/test_rdoc_markup_to_ansi.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToAnsi < RDoc::Markup::TextFormatterTestCase

--- a/test/test_rdoc_markup_to_bs.rb
+++ b/test/test_rdoc_markup_to_bs.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToBs < RDoc::Markup::TextFormatterTestCase

--- a/test/test_rdoc_markup_to_html.rb
+++ b/test/test_rdoc_markup_to_html.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase

--- a/test/test_rdoc_markup_to_html_crossref.rb
+++ b/test/test_rdoc_markup_to_html_crossref.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocMarkupToHtmlCrossref < XrefTestCase

--- a/test/test_rdoc_markup_to_html_snippet.rb
+++ b/test/test_rdoc_markup_to_html_snippet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToHtmlSnippet < RDoc::Markup::FormatterTestCase

--- a/test/test_rdoc_markup_to_html_snippet.rb
+++ b/test/test_rdoc_markup_to_html_snippet.rb
@@ -604,7 +604,7 @@ This routine modifies its +comment+ parameter.
     rdoc = "* text\n" * 2
 
     expected = "<p>text\n"
-    expected.chomp!
+    expected = expected.chomp
     expected << " #{@ellipsis}\n"
 
     actual = @to.convert rdoc

--- a/test/test_rdoc_markup_to_joined_paragraph.rb
+++ b/test/test_rdoc_markup_to_joined_paragraph.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToJoinedParagraph < RDoc::TestCase

--- a/test/test_rdoc_markup_to_label.rb
+++ b/test/test_rdoc_markup_to_label.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToLabel < RDoc::Markup::FormatterTestCase

--- a/test/test_rdoc_markup_to_markdown.rb
+++ b/test/test_rdoc_markup_to_markdown.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToMarkdown < RDoc::Markup::TextFormatterTestCase

--- a/test/test_rdoc_markup_to_rdoc.rb
+++ b/test/test_rdoc_markup_to_rdoc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase

--- a/test/test_rdoc_markup_to_table_of_contents.rb
+++ b/test/test_rdoc_markup_to_table_of_contents.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToTableOfContents < RDoc::Markup::FormatterTestCase

--- a/test/test_rdoc_markup_to_tt_only.rb
+++ b/test/test_rdoc_markup_to_tt_only.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupToTtOnly < RDoc::Markup::FormatterTestCase

--- a/test/test_rdoc_markup_verbatim.rb
+++ b/test/test_rdoc_markup_verbatim.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocMarkupVerbatim < RDoc::TestCase

--- a/test/test_rdoc_method_attr.rb
+++ b/test/test_rdoc_method_attr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocMethodAttr < XrefTestCase

--- a/test/test_rdoc_normal_class.rb
+++ b/test/test_rdoc_normal_class.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocNormalClass < XrefTestCase

--- a/test/test_rdoc_normal_module.rb
+++ b/test/test_rdoc_normal_module.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocNormalModule < XrefTestCase

--- a/test/test_rdoc_options.rb
+++ b/test/test_rdoc_options.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocOptions < RDoc::TestCase

--- a/test/test_rdoc_parser.rb
+++ b/test/test_rdoc_parser.rb
@@ -1,5 +1,5 @@
 # -*- coding: us-ascii -*-
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 =begin

--- a/test/test_rdoc_parser_changelog.rb
+++ b/test/test_rdoc_parser_changelog.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocParserChangeLog < RDoc::TestCase

--- a/test/test_rdoc_parser_changelog.rb
+++ b/test/test_rdoc_parser_changelog.rb
@@ -33,7 +33,7 @@ class TestRDocParserChangeLog < RDoc::TestCase
   def test_continue_entry_body
     parser = util_parser
 
-    entry_body = ['a']
+    entry_body = ['a'.dup]
 
     parser.continue_entry_body entry_body, 'b'
 
@@ -53,7 +53,7 @@ class TestRDocParserChangeLog < RDoc::TestCase
   def test_continue_entry_body_function
     parser = util_parser
 
-    entry_body = ['file: (func1)']
+    entry_body = ['file: (func1)'.dup]
 
     parser.continue_entry_body entry_body, '(func2): blah'
 

--- a/test/test_rdoc_parser_markdown.rb
+++ b/test/test_rdoc_parser_markdown.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocParserMarkdown < RDoc::TestCase

--- a/test/test_rdoc_parser_rd.rb
+++ b/test/test_rdoc_parser_rd.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocParserRd < RDoc::TestCase

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_parser_simple.rb
+++ b/test/test_rdoc_parser_simple.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocParserSimple < RDoc::TestCase

--- a/test/test_rdoc_rd.rb
+++ b/test/test_rdoc_rd.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRd < RDoc::TestCase

--- a/test/test_rdoc_rd_block_parser.rb
+++ b/test/test_rdoc_rd_block_parser.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRdBlockParser < RDoc::TestCase

--- a/test/test_rdoc_rd_inline.rb
+++ b/test/test_rdoc_rd_inline.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRdInline < RDoc::TestCase

--- a/test/test_rdoc_rd_inline_parser.rb
+++ b/test/test_rdoc_rd_inline_parser.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRdInlineParser < RDoc::TestCase

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRDoc < RDoc::TestCase

--- a/test/test_rdoc_require.rb
+++ b/test/test_rdoc_require.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocRequire < XrefTestCase

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRIDriver < RDoc::TestCase

--- a/test/test_rdoc_ri_paths.rb
+++ b/test/test_rdoc_ri_paths.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocRIPaths < RDoc::TestCase

--- a/test/test_rdoc_rubygems_hook.rb
+++ b/test/test_rdoc_rubygems_hook.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rdoc/rubygems_hook'
 

--- a/test/test_rdoc_servlet.rb
+++ b/test/test_rdoc_servlet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocServlet < RDoc::TestCase

--- a/test/test_rdoc_single_class.rb
+++ b/test/test_rdoc_single_class.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocSingleClass < RDoc::TestCase

--- a/test/test_rdoc_stats.rb
+++ b/test/test_rdoc_stats.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocStats < RDoc::TestCase

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocStore < XrefTestCase

--- a/test/test_rdoc_task.rb
+++ b/test/test_rdoc_task.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 begin
   require 'rake'

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -61,7 +61,7 @@ class TestRDocText < RDoc::TestCase
 
   def test_expand_tabs_encoding
     inn = "hello\ns\tdave"
-    inn.force_encoding Encoding::BINARY
+    inn = RDoc::Encoding.change_encoding inn, Encoding::BINARY
 
     out = expand_tabs inn
 
@@ -95,7 +95,7 @@ The comments associated with
   The comments associated with
     TEXT
 
-    text.force_encoding Encoding::US_ASCII
+    text = RDoc::Encoding.change_encoding text, Encoding::US_ASCII
 
     expected = <<-EXPECTED
 
@@ -303,7 +303,7 @@ paragraph will be cut off …
 # The comments associated with
     TEXT
 
-    text.force_encoding Encoding::CP852
+    text = RDoc::Encoding.change_encoding text, Encoding::CP852
 
     expected = <<-EXPECTED
 
@@ -332,7 +332,7 @@ paragraph will be cut off …
     assert_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     text = " \n"
-    text.force_encoding Encoding::US_ASCII
+    text = RDoc::Encoding.change_encoding text, Encoding::US_ASCII
 
     stripped = strip_newlines text
 
@@ -386,7 +386,7 @@ paragraph will be cut off …
  */
     TEXT
 
-    text.force_encoding Encoding::CP852
+    text = RDoc::Encoding.change_encoding text, Encoding::CP852
 
     expected = <<-EXPECTED
 
@@ -410,7 +410,7 @@ paragraph will be cut off …
  */
     TEXT
 
-    text.force_encoding Encoding::BINARY
+    text = RDoc::Encoding.change_encoding text, Encoding::BINARY
 
     expected = <<-EXPECTED
 

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rdoc/test_case'
 

--- a/test/test_rdoc_token_stream.rb
+++ b/test/test_rdoc_token_stream.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocTokenStream < RDoc::TestCase

--- a/test/test_rdoc_tom_doc.rb
+++ b/test/test_rdoc_tom_doc.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'rdoc/test_case'
 
 class TestRDocTomDoc < RDoc::TestCase

--- a/test/test_rdoc_tom_doc.rb
+++ b/test/test_rdoc_tom_doc.rb
@@ -131,7 +131,7 @@ here - something
 
   def test_parse_multiline_paragraph
     text = "Public: Do some stuff\n"
-    text << "On a new line\n"
+    text += "On a new line\n"
 
     expected =
       doc(
@@ -353,7 +353,7 @@ Signature
 
   def test_tokenize_multiline_paragraph
     text = "Public: Do some stuff\n"
-    text << "On a new line\n"
+    text += "On a new line\n"
 
     @td.tokenize text
 

--- a/test/test_rdoc_top_level.rb
+++ b/test/test_rdoc_top_level.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require File.expand_path '../xref_test_case', __FILE__
 
 class TestRDocTopLevel < XrefTestCase

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 XREF_DATA = <<-XREF_DATA
 class C1
 

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 ENV['RDOC_TEST'] = 'yes'
 
 require 'rdoc'


### PR DESCRIPTION
Set `frozen_string_literal: true`.

Ruby 2.2 or earlier only has `String#force_encoding` for changing character encoding set without encode byte sequence, it changes receiver itself. Ruby 2.3 or later has `frozen_striing_literal` magic comment and `String#new` can take encoding keyword parameter for character encoding set without encode byte sequence.

So implements `RDoc::Encoding.change_encoding` and `RDoc::Comment#encode!` to disguise difference between `#force_encoding` and encoding keyword parameter of `#new` on `String`.

This Pull Request changes output of table_of_contents.html, but https://github.com/ruby/rdoc/pull/549 conforms output to the same output.