### PR TITLE
 Remove unnecessary condition of RDoc::TokenStream.to_html

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -23,12 +23,8 @@ module RDoc::TokenStream
               when :on_ivar    then 'ruby-ivar'
               when :on_cvar    then 'ruby-identifier'
               when :on_gvar    then 'ruby-identifier'
-              when '=' != t[:text] && :on_op then
-                if RDoc::RipperStateLex::EXPR_ARG == t[:state] then
-                                    'ruby-identifier'
-                else
-                                    'ruby-operator'
-                end
+              when '=' != t[:text] && :on_op
+                               then 'ruby-operator'
               when :on_tlambda then 'ruby-operator'
               when :on_ident   then 'ruby-identifier'
               when :on_label   then 'ruby-value'

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2674,6 +2674,29 @@ EXPECTED
     assert_equal expected, markup_code
   end
 
+  def test_parse_instance_operation_method
+    util_parser <<-RUBY
+class Foo
+  def self.& end
+end
+    RUBY
+
+    expected = <<EXPECTED
+  <span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier">&amp;</span> <span class="ruby-keyword">end</span>
+<span class="ruby-keyword">end</span>
+EXPECTED
+    expected = expected.rstrip
+
+    @parser.scan
+
+    foo = @top_level.classes.first
+    assert_equal 'Foo', foo.full_name
+
+    blah = foo.method_list.first
+    markup_code = blah.markup_code.sub(/^.*\n/, '')
+    assert_equal expected, markup_code
+  end
+
   def test_parse_statements_postfix_if_after_heredocbeg
     @filename = 'file.rb'
     util_parser <<RUBY


### PR DESCRIPTION
`RDoc::TokenStream.to_html` checks that `:on_op` and `EXPR_ARG` token comes for treating it as identifier but the case never come because `RDoc::RipperStateLex#get_op_tk` set `:on_ident` and `EXPR_ARG` when `:on_op` as identifier before `RDoc::TokenStream.to_html`.