### PR TITLE
Add ruby-title class to method name in HTML

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -14,6 +14,8 @@ module RDoc::TokenStream
   # with the given class names. Other token types are not wrapped in spans.
 
   def self.to_html token_stream
+    starting_title = false
+
     token_stream.map do |t|
       next unless t
 
@@ -53,6 +55,16 @@ module RDoc::TokenStream
       else
         text = t[:text]
       end
+
+      if :on_ident == t[:kind] && starting_title
+        starting_title = false
+        style = 'ruby-identifier ruby-title'
+      end
+
+      if :on_kw == t[:kind] and 'def' == t[:text]
+        starting_title = true
+      end
+
       text = CGI.escapeHTML text
 
       if style then

--- a/test/test_rdoc_markup_to_html.rb
+++ b/test/test_rdoc_markup_to_html.rb
@@ -517,7 +517,7 @@ end
 
     expected = <<-'EXPECTED'
 
-<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier">foo</span>
+<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">foo</span>
   [
     <span class="ruby-string">&#39;\\&#39;</span>,
     <span class="ruby-string">&#39;\&#39;&#39;</span>,
@@ -537,7 +537,7 @@ end
     <span class="ruby-regexp">/#{}/</span>
   ]
 <span class="ruby-keyword">end</span>
-<span class="ruby-keyword">def</span> <span class="ruby-identifier">bar</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">bar</span>
 <span class="ruby-keyword">end</span>
 </pre>
     EXPECTED
@@ -567,7 +567,7 @@ end
 
     expected = <<-'EXPECTED'
 
-<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier">foo</span>
+<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">foo</span>
   [
     <span class="ruby-string">`\\`</span>,
     <span class="ruby-string">`\&#39;\&quot;\``</span>,
@@ -577,7 +577,7 @@ end
     <span class="ruby-node">`#{}`</span>
   ]
 <span class="ruby-keyword">end</span>
-<span class="ruby-keyword">def</span> <span class="ruby-identifier">bar</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">bar</span>
 <span class="ruby-keyword">end</span>
 </pre>
     EXPECTED
@@ -619,7 +619,7 @@ end
 
     %w[| ^ &amp; &lt;=&gt; == === =~ &gt; &gt;= &lt; &lt;= &lt;&lt; &gt;&gt; + - * / % ** ~ +@ -@ [] []= ` !  != !~].each do |html_escaped_op|
       expected += <<-EXPECTED
-<span class="ruby-keyword">def</span> <span class="ruby-identifier">#{html_escaped_op}</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">#{html_escaped_op}</span>
 <span class="ruby-keyword">end</span>
       EXPECTED
     end

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1418,7 +1418,7 @@ end
     RUBY
 
     expected = <<EXPECTED
-<span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier">foo</span>
+<span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier ruby-title">foo</span>
   <span class="ruby-constant">A</span><span class="ruby-operator">::</span><span class="ruby-constant">B</span><span class="ruby-operator">::</span><span class="ruby-constant">C</span>
 <span class="ruby-keyword">end</span>
 EXPECTED
@@ -2655,7 +2655,7 @@ end
 RUBY
 
     expected = <<EXPECTED
-<span class="ruby-keyword">def</span> <span class="ruby-identifier">blah</span>()
+<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">blah</span>()
   <span class="ruby-keyword">for</span> <span class="ruby-identifier">i</span> <span class="ruby-keyword">in</span> (<span class="ruby-identifier">k</span>)<span class="ruby-operator">...</span><span class="ruby-identifier">n</span> <span class="ruby-keyword">do</span>
   <span class="ruby-keyword">end</span>
   <span class="ruby-keyword">for</span> <span class="ruby-identifier">i</span> <span class="ruby-keyword">in</span> (<span class="ruby-identifier">k</span>)<span class="ruby-operator">...</span><span class="ruby-identifier">n</span>
@@ -2686,7 +2686,7 @@ end
 RUBY
 
     expected = <<EXPECTED
-  <span class="ruby-keyword">def</span> <span class="ruby-identifier">blah</span>()
+  <span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">blah</span>()
     <span class="ruby-identifier">&lt;&lt;-EOM</span> <span class="ruby-keyword">if</span> <span class="ruby-keyword">true</span>
 <span class="ruby-value"></span><span class="ruby-identifier">    EOM</span>
   <span class="ruby-keyword">end</span>
@@ -2711,7 +2711,7 @@ end
 RUBY
 
     expected = <<EXPECTED
-<span class="ruby-keyword">def</span> <span class="ruby-identifier">blah</span>() <span class="ruby-regexp">/bar/</span> <span class="ruby-keyword">end</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">blah</span>() <span class="ruby-regexp">/bar/</span> <span class="ruby-keyword">end</span>
 EXPECTED
     expected = expected.rstrip
 


### PR DESCRIPTION
`RDoc::RipperStateLex#get_op_tk` set :on_ident to method name token before `RDoc::TokenStream.to_html`, so the `RDoc::TokenStream.to_html` can detect method name token.

This commit changes behavior of markup to add ruby-title class to method name in HTML.

This was the behavior of SDoc' monkey patch what is removed at https://github.com/zzak/sdoc/pull/112, and RDoc's `RDoc::TokenStream.to_html` can only implement it.