### PR TITLE
Use File.expand_path outside temp_dir

### DIFF
--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -109,17 +109,18 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_normalized_file_list
+    test_path = File.expand_path(__FILE__)
     files = temp_dir do |dir|
       flag_file = @rdoc.output_flag_file dir
 
       FileUtils.touch flag_file
 
-      @rdoc.normalized_file_list [__FILE__, flag_file]
+      @rdoc.normalized_file_list [test_path, flag_file]
     end
 
     files = files.map { |file| File.expand_path file }
 
-    assert_equal [File.expand_path(__FILE__)], files
+    assert_equal [test_path], files
   end
 
   def test_normalized_file_list_not_modified
@@ -189,9 +190,10 @@ class TestRDocRDoc < RDoc::TestCase
   def test_parse_file_include_root
     @rdoc.store = RDoc::Store.new
 
+    test_path = File.expand_path('..', __FILE__)
     top_level = nil
     temp_dir do |dir|
-      @rdoc.options.parse %W[--root #{File.dirname(__FILE__)}]
+      @rdoc.options.parse %W[--root #{test_path}]
 
       open 'include.txt', 'w' do |io|
         io.puts ':include: test.txt'


### PR DESCRIPTION
According to circumstances, `__FILE__` inside `temp_dir` returns invalid path, so uses `File.expand_path('..', __FILE__)` outside `temp_dir` instead of it.

This bug is reproduced by a command below without this commit:

```bash
$ ruby -Ilib:test test/test_rdoc_rdoc.rb -n test_normalized_file_list
```