### PR TITLE
Suppress "assigned but unused variable" warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,8 +104,6 @@ end
 
 desc "Diffs Ruby HEAD with the currently checked-out copy of RDoc."
 task :diff_ruby do
-  options = "-urpN --exclude '*svn*' --exclude '*swp' --exclude '*rbc'"
-
   sh "diff #{diff_options} bin/rdoc #{ruby_dir}/bin/rdoc; true"
   sh "diff #{diff_options} bin/ri #{ruby_dir}/bin/ri; true"
   sh "diff #{diff_options} lib/rdoc.rb #{ruby_dir}/lib/rdoc.rb; true"


### PR DESCRIPTION
Currently `rake -T` warns an unused local variable.

```console
$ bundle exec rake -T
/home/pocke/ghq/github.com/ruby/rdoc/Rakefile:107: warning: assigned but unused variable - options
rake build            # Build rdoc-6.0.0.beta3.gem into the pkg directory
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake clobber_rdoc     # Remove RDoc HTML files
rake diff_rubinius    # Diffs Rubinius HEAD with the currently checked-out copy of RDoc
rake diff_ruby        # Diffs Ruby HEAD with the currently checked-out copy of RDoc
rake generate         # Genrate all files used racc and kpeg
rake install          # Build and install rdoc-6.0.0.beta3.gem into system gems
rake install:local    # Build and install rdoc-6.0.0.beta3.gem into system gems without network access
rake rdoc             # Build RDoc HTML files
rake release[remote]  # Create tag v6.0.0.beta3 and build and push rdoc-6.0.0.beta3.gem to rubygems.org
rake rerdoc           # Rebuild RDoc HTML files
rake test             # Run tests
rake update_rubinius  # Updates Rubinius HEAD with the currently checked-out copy of RDoc
rake update_ruby      # Updates Ruby HEAD with the currently checked-out copy of RDoc
```

This change will suppress the warning.
Note: The removed `options` variable value is same as `diff_options`.