### PR TITLE
Fix test_parse_instance_operation_method for ruby-title

### DIFF
--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2682,7 +2682,7 @@ end
     RUBY
 
     expected = <<EXPECTED
-  <span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier">&amp;</span> <span class="ruby-keyword">end</span>
+  <span class="ruby-keyword">def</span> <span class="ruby-keyword">self</span>.<span class="ruby-identifier ruby-title">&amp;</span> <span class="ruby-keyword">end</span>
 <span class="ruby-keyword">end</span>
 EXPECTED
     expected = expected.rstrip


### PR DESCRIPTION
This fixes CI failure of master.