### PR TITLE
Remove Regexp 'General Category' classes for windows

### DIFF
--- a/lib/rdoc/markdown/literals.kpeg
+++ b/lib/rdoc/markdown/literals.kpeg
@@ -17,7 +17,6 @@
 Alphanumeric      = /\p{Word}/
 AlphanumericAscii = /[A-Za-z0-9]/
 BOM               = "\uFEFF"
-Newline           = /\n|\r\n?|\p{Zl}|\p{Zp}/
+Newline           = /\r?\n|\r\n?/
 NonAlphanumeric   = /\p{^Word}/
-Spacechar         = /\t|\p{Zs}/
-
+Spacechar         = /\t|\p{Blank}/


### PR DESCRIPTION
See [Ruby Core issue 14137](https://bugs.ruby-lang.org/issues/14137).

I checked `\p{Blank}`, and it does match 'fractional' Unicode space characters.

Before PR, I tested on Appveyor with ruby 2.2 thru trunk, and all failed; last passing test done was at beta2.  This PR passed [here](https://ci.appveyor.com/project/MSP-Greg/rdoc/build/4) on Appveyor.

@aycabta  Thanks for the PR's over in YARD.  I build https://msp-greg.github.io/ daily (or more) with trunk, so I'm catching many of the Ripper changes, as YARD is pretty stable and doesn't have a lot or PR's or commits...