### PR TITLE
Do not store current timestamps in gz headers

### DIFF
--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -175,7 +175,7 @@ class RDoc::Generator::JsonIndex
     debug_msg "Writing gzipped search index to %s" % outfile
 
     Zlib::GzipWriter.open(outfile) do |gz|
-      gz.mtime = File.mtime(search_index_file)
+      gz.mtime = 1 # make output reproducible
       gz.orig_name = search_index_file.basename.to_s
       gz.write search_index
       gz.close
@@ -193,7 +193,7 @@ class RDoc::Generator::JsonIndex
         debug_msg "Writing gzipped file to %s" % outfile
 
         Zlib::GzipWriter.open(outfile) do |gz|
-          gz.mtime = File.mtime(dest)
+          gz.mtime = 1 # make output reproducible
           gz.orig_name = dest.basename.to_s
           gz.write data
           gz.close

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -147,12 +147,15 @@ class RDoc::Generator::JsonIndex
 
       JSON.dump data, io, 0
     end
+    unless ENV['SOURCE_DATE_EPOCH'].nil?
+      index_file.utime index_file.atime, Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
+    end
 
     Dir.chdir @template_dir do
       Dir['**/*.js'].each do |source|
         dest = File.join out_dir, source
 
-        FileUtils.install source, dest, :mode => 0644, :verbose => $DEBUG_RDOC
+        FileUtils.install source, dest, :mode => 0644, :preserve => true, :verbose => $DEBUG_RDOC
       end
     end
   end
@@ -175,7 +178,7 @@ class RDoc::Generator::JsonIndex
     debug_msg "Writing gzipped search index to %s" % outfile
 
     Zlib::GzipWriter.open(outfile) do |gz|
-      gz.mtime = 1 # make output reproducible
+      gz.mtime = File.mtime(search_index_file)
       gz.orig_name = search_index_file.basename.to_s
       gz.write search_index
       gz.close
@@ -193,7 +196,7 @@ class RDoc::Generator::JsonIndex
         debug_msg "Writing gzipped file to %s" % outfile
 
         Zlib::GzipWriter.open(outfile) do |gz|
-          gz.mtime = 1 # make output reproducible
+          gz.mtime = File.mtime(dest)
           gz.orig_name = dest.basename.to_s
           gz.write data
           gz.close

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -98,7 +98,11 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
 
     orig_file = Pathname(File.join @pwd, 'lib/rdoc/generator/template/json_index/js/navigation.js')
     generated_file = Pathname(File.join @tmpdir, 'js/navigation.js')
-    assert_equal orig_file.mtime, generated_file.mtime
+
+    # This is dirty hack on JRuby for MiniTest 4
+    assert orig_file.mtime.inspect == generated_file.mtime.inspect,
+      '.js files should be tha same timestamp of original'
+
     assert generated_file.mtime < now, '.js files should be the same timestamp'
 
     generated_search_index = Pathname(File.join @tmpdir, 'js/search_index.js')

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -8,7 +8,7 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
   def setup
     super
 
-    @tmpdir = File.join Dir.tmpdir, "test_rdoc_generator_darkfish_#{$$}"
+    @tmpdir = Dir.mktmpdir "test_rdoc_generator_darkfish_#{$$}_"
     FileUtils.mkdir_p @tmpdir
 
     @options = RDoc::Options.new
@@ -89,11 +89,20 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
   end
 
   def test_generate
+    now = Time.now
     @g.generate
 
     assert_file 'js/searcher.js'
     assert_file 'js/navigation.js'
     assert_file 'js/search_index.js'
+
+    orig_file = Pathname(File.join @pwd, 'lib/rdoc/generator/template/json_index/js/navigation.js')
+    generated_file = Pathname(File.join @tmpdir, 'js/navigation.js')
+    assert_equal orig_file.mtime, generated_file.mtime
+    assert generated_file.mtime < now, '.js files should be the same timestamp'
+
+    generated_search_index = Pathname(File.join @tmpdir, 'js/search_index.js')
+    assert generated_search_index.mtime > (now - 1), 'search_index.js should be generated timestamp'
 
     json = File.read 'js/search_index.js'
 
@@ -135,6 +144,20 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     }
 
     assert_equal expected, index
+  end
+
+  def test_generate_search_index_with_reproducible_builds
+    backup_epoch = ENV['SOURCE_DATE_EPOCH']
+    ruby_birthday = Time.parse 'Wed, 24 Feb 1993 21:00:00 +0900'
+    ENV['SOURCE_DATE_EPOCH'] = ruby_birthday.to_i.to_s
+
+    @g.generate
+
+    assert_file 'js/search_index.js'
+    generated_search_index = Pathname(File.join @tmpdir, 'js/search_index.js')
+    assert_equal ruby_birthday, generated_search_index.mtime
+
+    ENV['SOURCE_DATE_EPOCH'] = backup_epoch
   end
 
   def test_generate_gzipped


### PR DESCRIPTION
to enable reproducible builds of rdoc

Normally, 0 would be the preferred value to indicate "no date"
but that value is handled differently in Zlib::GzipWriter
to put in the current time