### PR TITLE
created.rid: use SOURCE_DATE_EPOCH

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -232,6 +232,9 @@ option)
 
   def update_output_dir(op_dir, time, last = {})
     return if @options.dry_run or not @options.update_output_dir
+    unless ENV['SOURCE_DATE_EPOCH'].nil?
+      time = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
+    end
 
     open output_flag_file(op_dir), "w" do |f|
       f.puts time.rfc2822


### PR DESCRIPTION
use SOURCE_DATE_EPOCH instead of current time in created.rid top line
to enable reproducible builds of ruby docs

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.