### PR TITLE
Bypass ERB's Ruby syntax error

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -178,6 +178,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     @size = 0
     @token_listeners = nil
     @scanner = RDoc::RipperStateLex.parse(content)
+    @content = content
     @scanner_point = 0
     @prev_seek = nil
     @markup = @options.markup
@@ -2067,6 +2068,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
         parse_top_level_statements @top_level
 
       rescue StandardError => e
+        if @content.include?('<%') and @content.include?('%>') then
+          # Maybe, this is ERB.
+          $stderr.puts "\033[2KRDoc detects ERB file. Skips it for compatibility:"
+          $stderr.puts @file_name
+          return
+        end
         bytes = ''
 
         if @scanner_point >= @scanner.size


### PR DESCRIPTION
The legacy lexical analyzer and parser of RDoc 5 process ERB file with no errors because of complex bug. RDoc 6 what uses Ripper causes errors when processes ERB file. It was just bug fix but RDoc lost
compatibility. For example, when installs ActiveRecord 5.1.4 by `gem install activerecord -v 5.1.4`, it uses RDoc internal, so the RDoc crashes if it's RDoc 6.0.0.

This commit provides compatibility behavior with RDoc 5 or older. When an exception occurs inside Ruby parser, confirms that the source code contains `"<%"` and `"%>"` to detect ERB file. Skips it if RDoc guesses that the file is ERB by the logic.

This closes https://github.com/ruby/rdoc/issues/571.