### PR TITLE
Treat '::' token as EXPR_DOT

### DIFF
--- a/lib/rdoc/parser/ripper_state_lex.rb
+++ b/lib/rdoc/parser/ripper_state_lex.rb
@@ -83,6 +83,15 @@ class RDoc::RipperStateLex
       when '&&', '||', '+=', '-=', '*=', '**=',
            '&=', '|=', '^=', '<<=', '>>=', '||=', '&&='
         @lex_state = EXPR_BEG
+      when '::'
+        case @lex_state
+        when EXPR_ARG, EXPR_CMDARG
+          @lex_state = EXPR_DOT
+        when EXPR_FNAME, EXPR_DOT
+          @lex_state = EXPR_ARG
+        else
+          @lex_state = EXPR_BEG
+        end
       else
         case @lex_state
         when EXPR_FNAME, EXPR_DOT
@@ -109,8 +118,10 @@ class RDoc::RipperStateLex
         else
           @lex_state = EXPR_BEG
         end
-      when 'begin'
+      when 'begin', 'case', 'when'
         @lex_state = EXPR_BEG
+      when 'return', 'break'
+        @lex_state = EXPR_MID
       else
         if @lex_state == EXPR_FNAME
           @lex_state = EXPR_END
@@ -245,7 +256,7 @@ class RDoc::RipperStateLex
       case @lex_state
       when EXPR_FNAME
         @lex_state = EXPR_ENDFN
-      when EXPR_CLASS
+      when EXPR_CLASS, EXPR_CMDARG, EXPR_MID
         @lex_state = EXPR_ARG
       else
         @lex_state = EXPR_CMDARG

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -306,6 +306,37 @@ ruby
     assert_equal @top_level, sum.file
   end
 
+  def test_parse_redefined_op_with_constant
+    klass = RDoc::NormalClass.new 'Foo'
+    klass.parent = @top_level
+
+    comment = RDoc::Comment.new '', @top_level
+
+    util_parser <<ruby
+def meth
+  Integer::**()
+  return Integer::**()
+  break Integer::**()
+  case Integer::**()
+  when Integer::**()
+  end
+  while Integer::**()
+  end
+  yield Integer::**()
+  defined? Integer::**()
+  if Integer::**()
+  end
+end
+ruby
+
+    tk = @parser.get_tk
+
+    @parser.parse_method klass, RDoc::Parser::Ruby::NORMAL, tk, comment
+
+    meth = klass.method_list.first
+    assert_equal 'meth',     meth.name
+  end
+
   def test_parse_alias
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level


### PR DESCRIPTION
If `on_op` takes `'::'` with `EXPR_ARG` or `EXPR_CMDARG`, it should be `EXPR_DOT`.

This fixes https://github.com/ruby/rdoc/issues/568.
  