### PR TITLE
Fix method line number

### DIFF
--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -266,6 +266,7 @@ class RDoc::Markup::PreProcess
     end
 
     content = RDoc::Encoding.read_file full_name, encoding, true
+    content = RDoc::Encoding.remove_magic_comment content
 
     # strip magic comment
     content = content.sub(/\A# .*coding[=:].*$/, '').lstrip

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -177,6 +177,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     @size = 0
     @token_listeners = nil
+    content = RDoc::Encoding.remove_magic_comment content
     @scanner = RDoc::RipperStateLex.parse(content)
     @content = content
     @scanner_point = 0

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -31,7 +31,7 @@ class TestRDocEncoding < RDoc::TestCase
     @tempfile.flush
 
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
-    assert_equal "hi everybody", contents
+    assert_equal "# coding: utf-8\nhi everybody", contents
     assert_equal Encoding::UTF_8, contents.encoding
   end
 
@@ -45,7 +45,7 @@ class TestRDocEncoding < RDoc::TestCase
 
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
     assert_equal Encoding::UTF_8, contents.encoding
-    assert_equal "hi \u00e9verybody", contents.sub("\r", '')
+    assert_equal "# coding: ISO-8859-1\nhi \u00e9verybody", contents.sub("\r", '')
   end
 
   def test_class_read_file_encoding_fail
@@ -71,7 +71,7 @@ class TestRDocEncoding < RDoc::TestCase
     @tempfile.flush
 
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
-    assert_equal "hi everybody", contents
+    assert_equal "# -*- coding: utf-8; fill-column: 74 -*-\nhi everybody", contents
     assert_equal Encoding::UTF_8, contents.encoding
   end
 
@@ -81,7 +81,7 @@ class TestRDocEncoding < RDoc::TestCase
 
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::US_ASCII, true
 
-    assert_equal '?', contents
+    assert_equal "# coding: utf-8\n?", contents
     assert_equal Encoding::US_ASCII, contents.encoding
   end
 
@@ -124,106 +124,56 @@ class TestRDocEncoding < RDoc::TestCase
 
     contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
 
-    expected = ":\xe3\x82\xb3\xe3\x83\x9e\xe3\x83\xb3\xe3\x83\x89:"
+    expected = "# coding: ISO-2022-JP\n:\xe3\x82\xb3\xe3\x83\x9e\xe3\x83\xb3\xe3\x83\x89:"
     expected = RDoc::Encoding.change_encoding expected, Encoding::UTF_8
 
     assert_equal expected, contents
     assert_equal Encoding::UTF_8, contents.encoding
   end
 
-  def test_class_set_encoding
+  def test_class_detect_encoding
     s = "# coding: UTF-8\n"
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
     # sanity check for 1.8
 
-    assert_equal Encoding::UTF_8, s.encoding
+    assert_equal Encoding::UTF_8, encoding
 
     s = "#!/bin/ruby\n# coding: UTF-8\n"
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal Encoding::UTF_8, s.encoding
+    assert_equal Encoding::UTF_8, encoding
 
     s = "<?xml version='1.0' encoding='UTF-8'?>\n"
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal Encoding::UTF_8, s.encoding
+    assert_equal Encoding::UTF_8, encoding
 
     s = "<?xml version='1.0' encoding=\"UTF-8\"?>\n"
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal Encoding::UTF_8, s.encoding
-  end
-
-  def test_class_set_encoding_strip
-    s = "# coding: UTF-8\n# more comments"
-
-    s = RDoc::Encoding.set_encoding s
-
-    assert_equal "# more comments", s
-
-    s = "#!/bin/ruby\n# coding: UTF-8\n# more comments"
-
-    s = RDoc::Encoding.set_encoding s
-
-    assert_equal "#!/bin/ruby\n# more comments", s
+    assert_equal Encoding::UTF_8, encoding
   end
 
   def test_class_set_encoding_bad
     s = ""
-    expected = s.encoding
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal expected, s.encoding
-
-    s = "# vim:set fileencoding=utf-8:\n"
-    expected = s.encoding
-    s = RDoc::Encoding.set_encoding s
-
-    assert_equal expected, s.encoding
+    assert_equal nil, encoding
 
     s = "# vim:set fileencoding=utf-8:\n"
-    expected = s.encoding
-    s = RDoc::Encoding.set_encoding s
+    encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal expected, s.encoding
+    assert_equal nil, encoding
+
+    s = "# vim:set fileencoding=utf-8:\n"
+    encoding = RDoc::Encoding.detect_encoding s
+
+    assert_equal nil, encoding
 
     assert_raises ArgumentError do
-      s = RDoc::Encoding.set_encoding "# -*- encoding: undecided -*-\n"
+      s = RDoc::Encoding.detect_encoding "# -*- encoding: undecided -*-\n"
     end
-  end
-
-  def test_skip_frozen_string_literal
-    expected = "# frozen_string_literal: true\nhi everybody"
-
-    @tempfile.write expected
-    @tempfile.flush
-
-    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
-    assert_equal "hi everybody", contents
-    assert_equal Encoding::UTF_8, contents.encoding
-  end
-
-  def test_skip_frozen_string_literal_after_coding
-    expected = "# coding: utf-8\n# frozen-string-literal: false\nhi everybody"
-
-    @tempfile.write expected
-    @tempfile.flush
-
-    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
-    assert_equal "hi everybody", contents
-    assert_equal Encoding::UTF_8, contents.encoding
-  end
-
-  def test_skip_frozen_string_literal_before_coding
-    expected = "# frozen_string_literal: true\n# coding: utf-8\nhi everybody"
-
-    @tempfile.write expected
-    @tempfile.flush
-
-    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
-    assert_equal "hi everybody", contents
-    assert_equal Encoding::UTF_8, contents.encoding
   end
 
   def test_sanity


### PR DESCRIPTION
`RDoc::Encoding.read_file` removes magic comments, after that, Ruby parser processes the content. So method line number is reduced by the amount of the magic comment lines.

This commit fixes it by that changes the behavior of `RDoc::Encoding.read_file` to not remove magic comments.

This closes #425.

...But please wait for merging, this branch outputs strange documents. I'll add some commits to this branch later.
  