### PR TITLE
Fix method name characters

### DIFF
--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -169,7 +169,7 @@ module RDoc::Text
 
     encoding = text.encoding
 
-    text = text.gsub %r%Document-method:\s+[\w:.#=!?]+%, ''
+    text = text.gsub %r%Document-method:\s+[\w:.#=!?|^&<>~+-/*\%@`\[\]]+%, ''
 
     space = ' '
     space = RDoc::Encoding.change_encoding space, encoding if encoding

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -377,6 +377,32 @@ paragraph will be cut off …
     assert_equal expected, strip_stars(text)
   end
 
+  def test_strip_stars_document_method_special
+    text = <<-TEXT
+/*
+ * Document-method: Zlib::GzipFile#mtime=
+ * Document-method: []
+ * Document-method: `
+ * Document-method: |
+ * Document-method: &
+ * Document-method: <=>
+ * Document-method: =~
+ * Document-method: +
+ * Document-method: -
+ * Document-method: +@
+ *
+ * A comment
+ */
+    TEXT
+
+    expected = <<-EXPECTED
+
+   A comment
+    EXPECTED
+
+    assert_equal expected, strip_stars(text)
+  end
+
   def test_strip_stars_encoding
     text = <<-TEXT
 /*


### PR DESCRIPTION
`RDoc::Text#strip_stars` removes unnecessary `Document-method` directive. But the regexp uses only `[\w:.#=!?]`, so it fails with some operator methods. This commit adds other operator characters to the regexp.

This closes #452.
  