### PR TITLE
Use `File.open` instead of `Kernel#open`.

### DIFF
--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -18,7 +18,7 @@ module RDoc::Encoding
   # unknown character in the target encoding will be replaced with '?'
 
   def self.read_file filename, encoding, force_transcode = false
-    content = open filename, "rb" do |f| f.read end
+    content = File.open filename, "rb" do |f| f.read end
     content.gsub!("\r\n", "\n") if RUBY_PLATFORM =~ /mswin|mingw/
 
     utf8 = content.sub!(/\A\xef\xbb\xbf/, '')

--- a/lib/rdoc/erbio.rb
+++ b/lib/rdoc/erbio.rb
@@ -9,7 +9,7 @@ require 'erb'
 #
 #   erbio = RDoc::ERBIO.new '<%= "hello world" %>', nil, nil
 #
-#   open 'hello.txt', 'w' do |io|
+#   File.open 'hello.txt', 'w' do |io|
 #     erbio.result binding
 #   end
 #

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -1217,7 +1217,7 @@ Usage: #{opt.program_name} [options] [names...]
   def write_options
     RDoc.load_yaml
 
-    open '.rdoc_options', 'w' do |io|
+    File.open '.rdoc_options', 'w' do |io|
       io.set_encoding Encoding::UTF_8
 
       YAML.dump self, io

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -139,7 +139,7 @@ class RDoc::Parser
   # Returns the file type from the modeline in +file_name+
 
   def self.check_modeline file_name
-    line = open file_name do |io|
+    line = File.open file_name do |io|
       io.gets
     end
 

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -188,7 +188,7 @@ class RDoc::RDoc
       error "#{dir} exists and is not a directory" unless File.directory? dir
 
       begin
-        open flag_file do |io|
+        File.open flag_file do |io|
           unless force then
             Time.parse io.gets
 
@@ -233,7 +233,7 @@ option)
   def update_output_dir(op_dir, time, last = {})
     return if @options.dry_run or not @options.update_output_dir
 
-    open output_flag_file(op_dir), "w" do |f|
+    File.open output_flag_file(op_dir), "w" do |f|
       f.puts time.rfc2822
       last.each do |n, t|
         f.puts "#{n}\t#{t.rfc2822}"

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -110,7 +110,7 @@ class RDoc::RI::Driver
   def self.dump data_path
     require 'pp'
 
-    open data_path, 'rb' do |io|
+    File.open data_path, 'rb' do |io|
       pp Marshal.load(io.read)
     end
   end

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -539,7 +539,7 @@ class RDoc::Store
   def load_cache
     #orig_enc = @encoding
 
-    open cache_path, 'rb' do |io|
+    File.open cache_path, 'rb' do |io|
       @cache = Marshal.load io.read
     end
 
@@ -596,7 +596,7 @@ class RDoc::Store
   def load_class_data klass_name
     file = class_file klass_name
 
-    open file, 'rb' do |io|
+    File.open file, 'rb' do |io|
       Marshal.load io.read
     end
   rescue Errno::ENOENT => e
@@ -611,7 +611,7 @@ class RDoc::Store
   def load_method klass_name, method_name
     file = method_file klass_name, method_name
 
-    open file, 'rb' do |io|
+    File.open file, 'rb' do |io|
       obj = Marshal.load io.read
       obj.store = self
       obj.parent =
@@ -631,7 +631,7 @@ class RDoc::Store
   def load_page page_name
     file = page_file page_name
 
-    open file, 'rb' do |io|
+    File.open file, 'rb' do |io|
       obj = Marshal.load io.read
       obj.store = self
       obj
@@ -778,7 +778,7 @@ class RDoc::Store
 
     marshal = Marshal.dump @cache
 
-    open cache_path, 'wb' do |io|
+    File.open cache_path, 'wb' do |io|
       io.write marshal
     end
   end
@@ -854,7 +854,7 @@ class RDoc::Store
 
     marshal = Marshal.dump klass
 
-    open path, 'wb' do |io|
+    File.open path, 'wb' do |io|
       io.write marshal
     end
   end
@@ -879,7 +879,7 @@ class RDoc::Store
 
     marshal = Marshal.dump method
 
-    open method_file(full_name, method.full_name), 'wb' do |io|
+    File.open method_file(full_name, method.full_name), 'wb' do |io|
       io.write marshal
     end
   end
@@ -901,7 +901,7 @@ class RDoc::Store
 
     marshal = Marshal.dump page
 
-    open path, 'wb' do |io|
+    File.open path, 'wb' do |io|
       io.write marshal
     end
   end

--- a/test/test_rdoc_parser.rb
+++ b/test/test_rdoc_parser.rb
@@ -19,7 +19,7 @@ class TestRDocParser < RDoc::TestCase
   def test_class_binary_eh_ISO_2022_JP
     iso_2022_jp = File.join Dir.tmpdir, "test_rdoc_parser_#{$$}.rd"
 
-    open iso_2022_jp, 'wb' do |io|
+    File.open iso_2022_jp, 'wb' do |io|
       io.write "# coding: ISO-2022-JP\n"
       io.write ":\e$B%3%^%s%I\e(B:\n"
     end
@@ -31,7 +31,7 @@ class TestRDocParser < RDoc::TestCase
 
   def test_class_binary_eh_marshal
     marshal = File.join Dir.tmpdir, "test_rdoc_parser_#{$$}.marshal"
-    open marshal, 'wb' do |io|
+    File.open marshal, 'wb' do |io|
       io.write Marshal.dump('')
       io.write 'lots of text ' * 500
     end
@@ -92,7 +92,7 @@ class TestRDocParser < RDoc::TestCase
   def test_class_for_executable
     temp_dir do
       content = "#!/usr/bin/env ruby -w\n"
-      open 'app', 'w' do |io| io.write content end
+      File.open 'app', 'w' do |io| io.write content end
       app = @store.add_file 'app'
 
       parser = @RP.for app, 'app', content, @options, :stats
@@ -126,7 +126,7 @@ class TestRDocParser < RDoc::TestCase
     temp_dir do
       content = "# -*- rdoc -*-\n= NEWS\n"
 
-      open 'NEWS', 'w' do |io| io.write content end
+      File.open 'NEWS', 'w' do |io| io.write content end
       app = @store.add_file 'NEWS'
 
       parser = @RP.for app, 'NEWS', content, @options, :stats
@@ -140,7 +140,7 @@ class TestRDocParser < RDoc::TestCase
   def test_can_parse_modeline
     readme_ext = File.join Dir.tmpdir, "README.EXT.#{$$}"
 
-    open readme_ext, 'w' do |io|
+    File.open readme_ext, 'w' do |io|
       io.puts "# README.EXT -  -*- rdoc -*- created at: Mon Aug 7 16:45:54 JST 1995"
       io.puts
       io.puts "This document explains how to make extension libraries for Ruby."
@@ -162,7 +162,7 @@ class TestRDocParser < RDoc::TestCase
   def test_check_modeline
     readme_ext = File.join Dir.tmpdir, "README.EXT.#{$$}"
 
-    open readme_ext, 'w' do |io|
+    File.open readme_ext, 'w' do |io|
       io.puts "# README.EXT -  -*- RDoc -*- created at: Mon Aug 7 16:45:54 JST 1995"
       io.puts
       io.puts "This document explains how to make extension libraries for Ruby."
@@ -176,7 +176,7 @@ class TestRDocParser < RDoc::TestCase
   def test_check_modeline_coding
     readme_ext = File.join Dir.tmpdir, "README.EXT.#{$$}"
 
-    open readme_ext, 'w' do |io|
+    File.open readme_ext, 'w' do |io|
       io.puts "# -*- coding: utf-8 -*-"
     end
 
@@ -188,7 +188,7 @@ class TestRDocParser < RDoc::TestCase
   def test_check_modeline_with_other
     readme_ext = File.join Dir.tmpdir, "README.EXT.#{$$}"
 
-    open readme_ext, 'w' do |io|
+    File.open readme_ext, 'w' do |io|
       io.puts "# README.EXT -  -*- mode: RDoc; indent-tabs-mode: nil -*-"
       io.puts
       io.puts "This document explains how to make extension libraries for Ruby."
@@ -202,7 +202,7 @@ class TestRDocParser < RDoc::TestCase
   def test_check_modeline_no_modeline
     readme_ext = File.join Dir.tmpdir, "README.EXT.#{$$}"
 
-    open readme_ext, 'w' do |io|
+    File.open readme_ext, 'w' do |io|
       io.puts "This document explains how to make extension libraries for Ruby."
     end
 

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -115,7 +115,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_load_options_invalid
     temp_dir do
-      open '.rdoc_options', 'w' do |io|
+      File.open '.rdoc_options', 'w' do |io|
         io.write "a: !ruby.yaml.org,2002:str |\nfoo"
       end
 
@@ -187,7 +187,7 @@ class TestRDocRDoc < RDoc::TestCase
     temp_dir do |dir|
       @rdoc.options.root = Pathname(Dir.pwd)
 
-      open 'test.txt', 'w' do |io|
+      File.open 'test.txt', 'w' do |io|
         io.puts 'hi'
       end
 
@@ -223,7 +223,7 @@ class TestRDocRDoc < RDoc::TestCase
     temp_dir do |dir|
       @rdoc.options.parse %W[--root #{test_path}]
 
-      open 'include.txt', 'w' do |io|
+      File.open 'include.txt', 'w' do |io|
         io.puts ':include: test.txt'
       end
 
@@ -244,7 +244,7 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.options.page_dir = Pathname('pages')
       @rdoc.options.root = Pathname(Dir.pwd)
 
-      open 'pages/test.txt', 'w' do |io|
+      File.open 'pages/test.txt', 'w' do |io|
         io.puts 'hi'
       end
 
@@ -263,7 +263,7 @@ class TestRDocRDoc < RDoc::TestCase
     temp_dir do |dir|
       @rdoc.options.root = Pathname(dir)
 
-      open 'test.txt', 'w' do |io|
+      File.open 'test.txt', 'w' do |io|
         io.puts 'hi'
       end
 
@@ -339,7 +339,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_remove_unparseable_tags_emacs
     temp_dir do
-      open 'TAGS', 'wb' do |io| # emacs
+      File.open 'TAGS', 'wb' do |io| # emacs
         io.write "\f\nlib/foo.rb,43\n"
       end
 
@@ -353,7 +353,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_remove_unparseable_tags_vim
     temp_dir do
-      open 'TAGS', 'w' do |io| # emacs
+      File.open 'TAGS', 'w' do |io| # emacs
         io.write "!_TAG_"
       end
 
@@ -392,7 +392,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_setup_output_dir_exists
     Dir.mktmpdir {|path|
-      open @rdoc.output_flag_file(path), 'w' do |io|
+      File.open @rdoc.output_flag_file(path), 'w' do |io|
         io.puts Time.at 0
         io.puts "./lib/rdoc.rb\t#{Time.at 86400}"
       end
@@ -406,7 +406,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_setup_output_dir_exists_empty_created_rid
     Dir.mktmpdir {|path|
-      open @rdoc.output_flag_file(path), 'w' do end
+      File.open @rdoc.output_flag_file(path), 'w' do end
 
       e = assert_raises RDoc::Error do
         @rdoc.setup_output_dir path, false

--- a/test/test_rdoc_ri_paths.rb
+++ b/test/test_rdoc_ri_paths.rb
@@ -22,7 +22,7 @@ class TestRDocRIPaths < RDoc::TestCase
     specs.each do |spec|
       spec.loaded_from = spec.spec_file
 
-      open spec.spec_file, 'w' do |file|
+      File.open spec.spec_file, 'w' do |file|
         file.write spec.to_ruby_for_cache
       end
 

--- a/test/test_rdoc_servlet.rb
+++ b/test/test_rdoc_servlet.rb
@@ -69,7 +69,7 @@ class TestRDocServlet < RDoc::TestCase
       FileUtils.mkdir 'css'
 
       now = Time.now
-      open 'css/rdoc.css', 'w' do |io| io.write 'h1 { color: red }' end
+      File.open 'css/rdoc.css', 'w' do |io| io.write 'h1 { color: red }' end
       File.utime now, now, 'css/rdoc.css'
 
       @s.asset_dirs[:darkfish] = '.'

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -407,7 +407,7 @@ class TestRDocStore < XrefTestCase
 
     Dir.mkdir @tmpdir
 
-    open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
+    File.open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
       Marshal.dump cache, io
     end
 
@@ -441,7 +441,7 @@ class TestRDocStore < XrefTestCase
 
     Dir.mkdir @tmpdir
 
-    open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
+    File.open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
       Marshal.dump cache, io
     end
 
@@ -490,7 +490,7 @@ class TestRDocStore < XrefTestCase
 
     Dir.mkdir @tmpdir
 
-    open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
+    File.open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
       Marshal.dump cache, io
     end
 
@@ -538,7 +538,7 @@ class TestRDocStore < XrefTestCase
 
     file = @s.method_file @klass.full_name, @meth.full_name
 
-    open file, 'wb' do |io|
+    File.open file, 'wb' do |io|
       io.write "\x04\bU:\x14RDoc::AnyMethod[\x0Fi\x00I" +
                "\"\vmethod\x06:\x06EF\"\x11Klass#method0:\vpublic" +
                "o:\eRDoc::Markup::Document\x06:\v@parts[\x06" +
@@ -633,7 +633,7 @@ class TestRDocStore < XrefTestCase
 
     expected[:ancestors]['Object'] = %w[BasicObject]
 
-    open File.join(@tmpdir, 'cache.ri'), 'rb' do |io|
+    File.open File.join(@tmpdir, 'cache.ri'), 'rb' do |io|
       cache = Marshal.load io.read
 
       assert_equal expected, cache
@@ -701,7 +701,7 @@ class TestRDocStore < XrefTestCase
 
     expected[:ancestors]['Object'] = %w[BasicObject]
 
-    open File.join(@tmpdir, 'cache.ri'), 'rb' do |io|
+    File.open File.join(@tmpdir, 'cache.ri'), 'rb' do |io|
       cache = Marshal.load io.read
 
       assert_equal expected, cache


### PR DESCRIPTION
Ruby core team will warn to use `Kernel#open` in standard libraries of Ruby 2.6/3.0.

NOTE: This is not vulnerability fixes. 