### PR TITLE
Fix separated tests

### DIFF
--- a/test/test_rdoc_generator_darkfish.rb
+++ b/test/test_rdoc_generator_darkfish.rb
@@ -135,7 +135,7 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
   end
 
   def test_install_rdoc_static_file
-    src = Pathname(__FILE__)
+    src = Pathname File.expand_path(__FILE__, @pwd)
     dst = File.join @tmpdir, File.basename(src)
     options = {}
 

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rdoc/test_case'
+require 'timeout'
 
 class TestRDocText < RDoc::TestCase
 


### PR DESCRIPTION
This commit fixes commands below:

```bash
ruby -Ilib:test test/test_rdoc_generator_darkfish.rb
ruby -Ilib:test test/test_rdoc_text.rb
```