### PR TITLE
RDoc::Store#load_class supports RDoc::SingleClass

### DIFF
--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -585,6 +585,8 @@ class RDoc::Store
     case obj
     when RDoc::NormalClass then
       @classes_hash[klass_name] = obj
+    when RDoc::SingleClass then
+      @classes_hash[klass_name] = obj
     when RDoc::NormalModule then
       @modules_hash[klass_name] = obj
     end

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -162,7 +162,7 @@ class TestRDocStore < XrefTestCase
 
   def test_all_classes_and_modules
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1
       Child
       M1 M1::M2
       Parent
@@ -213,7 +213,7 @@ class TestRDocStore < XrefTestCase
 
   def test_classes
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1
       Child
       Parent
     ]
@@ -522,6 +522,15 @@ class TestRDocStore < XrefTestCase
     assert_equal @klass, @s.load_class('Object')
 
     assert_includes @s.classes_hash, 'Object'
+  end
+
+  def test_load_single_class
+    @s.save_class @c8_s1
+    @s.classes_hash.clear
+
+    assert_equal @c8_s1, @s.load_class('C8::S1')
+
+    assert_includes @s.classes_hash, 'C8::S1'
   end
 
   def test_load_method

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -94,6 +94,13 @@ class C7
   CONST_NODOC = :const_nodoc # :nodoc:
 end
 
+class C8
+  class << self
+    class S1
+    end
+  end
+end
+
 module M1
   def m
   end

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -53,6 +53,8 @@ class XrefTestCase < RDoc::TestCase
     @c3_h2 = @xref_data.find_module_named 'C3::H2'
     @c6    = @xref_data.find_module_named 'C6'
     @c7    = @xref_data.find_module_named 'C7'
+    @c8    = @xref_data.find_module_named 'C8'
+    @c8_s1 = @xref_data.find_module_named 'C8::S1'
 
     @m1    = @xref_data.find_module_named 'M1'
     @m1_m  = @m1.method_list.first


### PR DESCRIPTION
RDoc treats `C::S` below as a `RDoc::SingleClass`:

```ruby
class C
  class << self
    class S
    end
  end
end
```

But `RDoc::Store#load_class` didn't support it.

This Pull Request fixes it and closes https://github.com/ruby/rdoc/issues/403.