### PR TITLE
Fix AnyMethod#is_alias_for for nil singleton

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -863,7 +863,13 @@ class RDoc::Context < RDoc::CodeObject
   # Finds a method named +name+ with singleton value +singleton+.
 
   def find_method(name, singleton)
-    @method_list.find { |m| m.name == name && m.singleton == singleton }
+    @method_list.find { |m|
+      if m.singleton
+        m.name == name && m.singleton == singleton
+      else
+        m.name == name && !m.singleton && !singleton
+      end
+    }
   end
 
   ##

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -151,6 +151,19 @@ method(a, b) { |c, d| ... }
     assert                aliased_method.display?
   end
 
+  def test_marshal_load_aliased_method_with_nil_singleton
+    aliased_method = Marshal.load Marshal.dump(@c2_a)
+
+    aliased_method.store = @store
+    aliased_method.is_alias_for = ["C2", nil, "b"]
+
+    assert_equal 'C2#a',  aliased_method.full_name
+    assert_equal 'C2',    aliased_method.parent_name
+    assert_equal '()',    aliased_method.params
+    assert_equal @c2_b,   aliased_method.is_alias_for, 'is_alias_for'
+    assert                aliased_method.display?
+  end
+
   def test_marshal_load_class_method
     class_method = Marshal.load Marshal.dump(@c1.method_list.first)
 

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -559,6 +559,14 @@ class TestRDocContext < XrefTestCase
     assert_equal @c2_c3,     @c2.find_local_symbol('C3')
   end
 
+  def test_find_method
+    loaded_c2 = Marshal.load Marshal.dump @c2
+    assert_equal @c2_a, loaded_c2.find_method('a', false)
+    assert_equal @c2_b, loaded_c2.find_method('b', false)
+    assert_equal @c2_a, loaded_c2.find_method('a', nil)
+    assert_equal @c2_b, loaded_c2.find_method('b', nil)
+  end
+
   def test_find_method_named
     assert_equal true, @c1.find_method_named('m').singleton
   end


### PR DESCRIPTION
Sometimes `AnyMethod#marshal_load` set `nil` singleton to `@is_alias_for`. `AnyMethod#is_alias_for` didn't suppose it.

This is the groundwork for https://github.com/ruby/rdoc/issues/588.