### PR TITLE
Fix `#tokens_to_s` method for token streams

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -107,7 +107,7 @@ module RDoc::TokenStream
   # Returns a string representation of the token stream
 
   def tokens_to_s
-    token_stream.compact.map { |token| token.text }.join ''
+    token_stream.compact.map { |token| token[:text] }.join ''
   end
 
 end

--- a/test/test_rdoc_token_stream.rb
+++ b/test/test_rdoc_token_stream.rb
@@ -39,5 +39,20 @@ class TestRDocTokenStream < RDoc::TestCase
     assert_equal '', RDoc::TokenStream.to_html([])
   end
 
+  def test_tokens_to_s
+    foo = Class.new do
+      include RDoc::TokenStream
+
+      def initialize
+        @token_stream = [
+          { line_no: 0, char_no: 0, kind: :on_ident,   text: "foo" },
+          { line_no: 0, char_no: 0, kind: :on_sp,      text: " " },
+          { line_no: 0, char_no: 0, kind: :on_tstring, text: "'bar'" },
+        ]
+      end
+    end.new
+
+    assert_equal "foo 'bar'", foo.tokens_to_s
+  end
 end
 


### PR DESCRIPTION
Hello,

This pull request is a tiny follow-up to #512 to fix the `tokens_to_s` method for `RDoc::TokenStream`. As the token stream isn't represented by an array of token classes anymore but rather with an array of hashes, the token's text is accessible through a key and not a method.

Have a nice day !