### PR TITLE
Ignore constants discovered in passing

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -407,6 +407,7 @@ class RDoc::Context < RDoc::CodeObject
     mod.section = current_section # TODO declaring context? something is
                                   # wrong here...
     mod.parent = self
+    mod.full_name = nil
     mod.store = @store
 
     unless @done_documenting then
@@ -507,6 +508,13 @@ class RDoc::Context < RDoc::CodeObject
     full_name = child_name name
     mod = @store.modules_hash[full_name] || class_type.new(name)
 
+    add_class_or_module mod, @modules, @store.modules_hash
+  end
+
+  ##
+  # Adds a module by +RDoc::NormalModule+ instance. See also #add_module.
+
+  def add_module_by_normal_module(mod)
     add_class_or_module mod, @modules, @store.modules_hash
   end
 

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -307,7 +307,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
             container.find_module_named rhs_name
           end
 
-    container.add_module_alias mod, constant.name, @top_level if mod
+    container.add_module_alias mod, rhs_name, constant, @top_level
   end
 
   ##

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -117,6 +117,11 @@ class RDoc::Store
   attr_accessor :encoding
 
   ##
+  # The lazy constants alias will be discovered in passing
+
+  attr_reader :unmatched_constant_alias
+
+  ##
   # Creates a new Store of +type+ that will load or save to +path+
 
   def initialize path = nil, type = nil
@@ -152,6 +157,8 @@ class RDoc::Store
 
     @unique_classes = nil
     @unique_modules = nil
+
+    @unmatched_constant_alias = {}
   end
 
   ##

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -1277,7 +1277,8 @@ class TestRDocClassModule < XrefTestCase
     n1 = @xref_data.add_module RDoc::NormalClass, 'N1'
     n1_k2 = n1.add_module RDoc::NormalClass, 'N2'
 
-    n1.add_module_alias n1_k2, 'A1', @xref_data
+    a1 = RDoc::Constant.new 'A1', '', ''
+    n1.add_module_alias n1_k2, n1_k2.name, a1, @xref_data
 
     n1_a1_c = n1.constants.find { |c| c.name == 'A1' }
     refute_nil n1_a1_c
@@ -1301,7 +1302,8 @@ class TestRDocClassModule < XrefTestCase
     n1 = @xref_data.add_module RDoc::NormalModule, 'N1'
     n1_n2 = n1.add_module RDoc::NormalModule, 'N2'
 
-    n1.add_module_alias n1_n2, 'A1', @xref_data
+    a1 = RDoc::Constant.new 'A1', '', ''
+    n1.add_module_alias n1_n2, n1_n2.name, a1, @xref_data
 
     n1_a1_c = n1.constants.find { |c| c.name == 'A1' }
     refute_nil n1_a1_c
@@ -1326,7 +1328,8 @@ class TestRDocClassModule < XrefTestCase
     l1_l2 = l1.add_module RDoc::NormalModule, 'L2'
     o1 = @xref_data.add_module RDoc::NormalModule, 'O1'
 
-    o1.add_module_alias l1_l2, 'A1', @xref_data
+    a1 = RDoc::Constant.new 'A1', '', ''
+    o1.add_module_alias l1_l2, l1_l2.name, a1, @xref_data
 
     o1_a1_c = o1.constants.find { |c| c.name == 'A1' }
     refute_nil o1_a1_c
@@ -1358,7 +1361,8 @@ class TestRDocClassModule < XrefTestCase
     const.record_location top_level
     const.is_alias_for = klass
 
-    top_level.add_module_alias klass, 'A', top_level
+    a = RDoc::Constant.new 'A', '', ''
+    top_level.add_module_alias klass, klass.name, a, top_level
 
     object.add_constant const
 

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -280,7 +280,8 @@ class TestRDocContext < XrefTestCase
   def test_add_module_alias
     tl = @store.add_file 'file.rb'
 
-    c3_c4 = @c2.add_module_alias @c2_c3, 'C4', tl
+    c4 = RDoc::Constant.new 'C4', '', ''
+    c3_c4 = @c2.add_module_alias @c2_c3, @c2_c3.name, c4, tl
 
     alias_constant = @c2.constants.first
 
@@ -298,7 +299,8 @@ class TestRDocContext < XrefTestCase
 
     object = top_level.add_class RDoc::NormalClass, 'Object'
 
-    top_level.add_module_alias klass, 'A', top_level
+    a = RDoc::Constant.new 'A', '', ''
+    top_level.add_module_alias klass, klass.name, a, top_level
 
     refute_empty object.constants
 

--- a/test/test_rdoc_generator_darkfish.rb
+++ b/test/test_rdoc_generator_darkfish.rb
@@ -39,7 +39,7 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
 
     @top_level.add_constant @alias_constant
 
-    @klass.add_module_alias @klass, 'A', @top_level
+    @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
 
     @meth = RDoc::AnyMethod.new nil, 'method'
     @meth_bang = RDoc::AnyMethod.new nil, 'method!'

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -3928,4 +3928,29 @@ end
                                       second_file_content, @options, @stats
   end
 
+  def test_parse_const_third_party
+    util_parser <<-CLASS
+class A
+  true if B
+  true if B::C
+  true if B::C::D
+
+  module B
+  end
+end
+    CLASS
+
+    tk = @parser.get_tk
+
+    @parser.parse_class @top_level, RDoc::Parser::Ruby::NORMAL, tk, @comment
+
+    a = @top_level.classes.first
+    assert_equal 'A', a.full_name
+
+    visible = @store.all_modules.reject { |mod| mod.suppressed? }
+    visible = visible.map { |mod| mod.full_name }
+
+    assert_equal ['A::B'], visible
+  end
+
 end

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -3953,4 +3953,125 @@ end
     assert_equal ['A::B'], visible
   end
 
+  def test_parse_const_alias_defined_elsewhere
+    util_parser <<-CLASS
+module A
+  Aliased = Defined
+end
+
+module A
+  class Defined
+  end
+end
+    CLASS
+
+    @parser.scan
+
+    a = @top_level.modules.first
+    assert_equal 'A', a.full_name
+    aliased = a.constants.first
+    assert_equal 'A::Aliased', aliased.full_name
+    assert_equal [], a.modules.map(&:full_name)
+    assert_equal ['A::Defined', 'A::Aliased'], a.classes.map(&:full_name)
+    assert_equal ['A::Aliased'], a.constants.map(&:full_name)
+
+    visible = @store.all_modules.reject { |mod| mod.suppressed? }
+    visible = visible.map { |mod| mod.full_name }
+
+    assert_equal ['A'], visible
+  end
+
+  def test_parse_const_alias_defined_far_away
+    util_parser <<-CLASS
+module A
+  Aliased = ::B::C::Defined
+end
+
+module B
+  module C
+    class Defined
+    end
+  end
+end
+    CLASS
+
+    @parser.scan
+
+    a = @top_level.modules.first
+    assert_equal 'A', a.full_name
+    assert_empty a.classes
+    assert_empty a.modules
+    assert_equal ['A::Aliased'], a.constants.map(&:full_name)
+
+    defined = @store.find_class_named 'B::C::Defined'
+    assert_equal 'B::C::Defined', defined.full_name
+
+    aliased = @store.find_class_named 'B::C::Aliased'
+    assert_equal 'B::C::Aliased', aliased.full_name
+
+    visible = @store.all_modules.reject { |mod| mod.suppressed? }
+    visible = visible.map { |mod| mod.full_name }
+
+    assert_equal ['A', 'B', 'B::C'], visible
+  end
+
+  def test_parse_const_alias_defined_elsewhere
+    util_parser <<-CLASS
+module A
+  Aliased = Defined
+end
+
+module A
+  class Defined
+  end
+end
+    CLASS
+
+    @parser.scan
+
+    a = @top_level.modules.first
+    assert_equal 'A', a.full_name
+    aliased = a.constants.first
+    assert_equal 'A::Aliased', aliased.full_name
+
+    visible = @store.all_modules.reject { |mod| mod.suppressed? }
+    visible = visible.map { |mod| mod.full_name }
+
+    assert_equal ['A'], visible
+  end
+
+  def test_parse_const_alias_defined_far_away
+    util_parser <<-CLASS
+module A
+  Aliased = ::B::C::Defined
+end
+
+module B
+  module C
+    class Defined
+    end
+  end
+end
+    CLASS
+
+    @parser.scan
+
+    a = @top_level.modules.first
+    assert_equal 'A', a.full_name
+    assert_empty a.classes
+    assert_empty a.modules
+    assert_equal ['A::Aliased'], a.constants.map(&:full_name)
+
+    defined = @store.find_class_named 'B::C::Defined'
+    assert_equal 'B::C::Defined', defined.full_name
+
+    aliased = @store.find_class_named 'B::C::Aliased'
+    assert_equal 'B::C::Aliased', aliased.full_name
+
+    visible = @store.all_modules.reject { |mod| mod.suppressed? }
+    visible = visible.map { |mod| mod.full_name }
+
+    assert_equal ['A', 'B', 'B::C'], visible
+  end
+
 end

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -222,7 +222,8 @@ class TestRDocStore < XrefTestCase
   end
 
   def test_complete
-    @c2.add_module_alias @c2_c3, 'A1', @top_level
+    a1 = RDoc::Constant.new 'A1', '', ''
+    @c2.add_module_alias @c2_c3, @c2_c3.name, a1, @top_level
 
     @store.complete :public
 


### PR DESCRIPTION
This closes https://github.com/ruby/rdoc/issues/209 and https://github.com/ruby/rdoc/issues/298.

ref. https://github.com/rails/rails/issues/14150

I confirmed this patch to keep original behavior for all CRuby documents.