### PR TITLE
Remove date field from gemspec.

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -14,7 +14,6 @@ end
 Gem::Specification.new do |s|
   s.name = "rdoc"
   s.version = RDoc::VERSION
-  s.date = "2017-12-24"
 
   s.authors = [
     "Eric Hodel",


### PR DESCRIPTION
It's automatically assigned when pushing to rubygems.org.

I learn it from https://github.com/ruby/rake/pull/253

