### PR TITLE
Override .document by --exclude option

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -258,7 +258,7 @@ option)
 
     patterns.split.each do |patt|
       candidates = Dir.glob(File.join(in_dir, patt))
-      result.concat normalized_file_list(candidates)
+      result.concat normalized_file_list(candidates, false, @options.exclude)
     end
 
     result

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -36,11 +36,6 @@ class RDoc::RDoc
   GENERATORS = {}
 
   ##
-  # File pattern to exclude
-
-  attr_accessor :exclude
-
-  ##
   # Generator instance used for creating output
 
   attr_accessor :generator
@@ -93,7 +88,6 @@ class RDoc::RDoc
 
   def initialize
     @current       = nil
-    @exclude       = nil
     @generator     = nil
     @last_modified = {}
     @old_siginfo   = nil
@@ -116,7 +110,7 @@ class RDoc::RDoc
   def gather_files files
     files = ["."] if files.empty?
 
-    file_list = normalized_file_list files, true, @exclude
+    file_list = normalized_file_list files, true, @options.exclude
 
     file_list = file_list.uniq
 
@@ -471,8 +465,6 @@ The internal error was:
       handle_pipe
       exit
     end
-
-    @exclude = @options.exclude
 
     unless @options.coverage_report then
       @last_modified = setup_output_dir @options.op_dir, @options.force_update

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -181,6 +181,60 @@ class TestRDocRDoc < RDoc::TestCase
     assert_match %r"#{dev}$",           err
   end
 
+  def test_normalized_file_list_with_dot_doc
+    expected_files = []
+    files = temp_dir do |dir|
+      a = File.expand_path('a.rb')
+      b = File.expand_path('b.rb')
+      c = File.expand_path('c.rb')
+      FileUtils.touch a
+      FileUtils.touch b
+      FileUtils.touch c
+
+      dot_doc = File.expand_path('.document')
+      FileUtils.touch dot_doc
+      open(dot_doc, 'w') do |f|
+        f.puts 'a.rb'
+        f.puts 'b.rb'
+      end
+      expected_files << a
+      expected_files << b
+
+      @rdoc.normalized_file_list [dir]
+    end
+
+    files = files.map { |file| File.expand_path file }
+
+    assert_equal expected_files, files
+  end
+
+  def test_normalized_file_list_with_dot_doc_overridden_by_exclude_option
+    expected_files = []
+    files = temp_dir do |dir|
+      a = File.expand_path('a.rb')
+      b = File.expand_path('b.rb')
+      c = File.expand_path('c.rb')
+      FileUtils.touch a
+      FileUtils.touch b
+      FileUtils.touch c
+
+      dot_doc = File.expand_path('.document')
+      FileUtils.touch dot_doc
+      open(dot_doc, 'w') do |f|
+        f.puts 'a.rb'
+        f.puts 'b.rb'
+      end
+      expected_files << a
+
+      @rdoc.options.exclude = Regexp.new(['b.rb'].join('|'))
+      @rdoc.normalized_file_list [dir]
+    end
+
+    files = files.map { |file| File.expand_path file }
+
+    assert_equal expected_files, files
+  end
+
   def test_parse_file
     @rdoc.store = RDoc::Store.new
 


### PR DESCRIPTION
This closes https://github.com/ruby/rdoc/issues/596.