### PR TITLE
rb_global_function reworked (it should produce private and singleton)

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -487,7 +487,9 @@ class RDoc::Parser::C < RDoc::Parser
                              \s*(-?\w+)\s*\)
                 (?:;\s*/[*/]\s+in\s+(\w+?\.[cy]))?
                 %xm) do |meth_name, function, param_count, source_file|
-      handle_method("method", "rb_mKernel", meth_name, function, param_count,
+      handle_method("private_method", "rb_mKernel", meth_name, function, param_count,
+                    source_file)
+      handle_method("singleton_method", "rb_mKernel", meth_name, function, param_count,
                     source_file)
     end
 


### PR DESCRIPTION
By the source code of Ruby it is clear that `rb_define_global_function` is a `rb_define_module_function` for rb_mKernel, which corresponds to rb_define_private_method and rb_define_singleton_method. 

The main reason for creating this request was that global methods have public visibility.

rb_define_module_function(VALUE module, const char *name, VALUE (*func)(ANYARGS), int argc)