### PR TITLE
Added workaround for Ruby core repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ env:
   global:
     NOBENCHMARK=1
 script: rake
+matrix:
+  allow_failures:
+    - rvm: jruby-9.1.16.0

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -96,7 +96,13 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     assert_file 'js/navigation.js'
     assert_file 'js/search_index.js'
 
-    orig_file = Pathname(File.join @pwd, 'lib/rdoc/generator/template/json_index/js/navigation.js')
+    srcdir = File.expand_path("../../lib/rdoc", __FILE__)
+    if !File.directory? srcdir
+      # for Ruby core repository
+      srcdir = File.expand_path("../../../lib/rdoc", __FILE__)
+    end
+
+    orig_file = Pathname(File.join srcdir, 'generator/template/json_index/js/navigation.js')
     generated_file = Pathname(File.join @tmpdir, 'js/navigation.js')
 
     # This is dirty hack on JRuby for MiniTest 4


### PR DESCRIPTION
Ruby core repository was different directory structure. `@pwd` may differ from the top of the source directory.