### PR TITLE
Cleanup minitest deprecation warnings about assert_nil

### DIFF
--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -133,7 +133,7 @@ method(a, b) { |c, d| ... }
     assert_equal 'Klass#method', loaded.full_name
     assert_equal 'method',       loaded.name
     assert_equal 'param',        loaded.params
-    assert_equal nil,            loaded.singleton # defaults to nil
+    assert_nil                   loaded.singleton # defaults to nil
     assert_equal :public,        loaded.visibility
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
@@ -220,9 +220,9 @@ method(a, b) { |c, d| ... }
     assert_equal 'Klass#method', loaded.full_name
     assert_equal 'method',       loaded.name
     assert_equal 'param',        loaded.params
-    assert_equal nil,            loaded.singleton # defaults to nil
+    assert_nil                   loaded.singleton # defaults to nil
     assert_equal :public,        loaded.visibility
-    assert_equal nil,            loaded.file
+    assert_nil                   loaded.file
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
     assert_nil                   loaded.is_alias_for
@@ -277,7 +277,7 @@ method(a, b) { |c, d| ... }
     assert_equal 'Klass#method', loaded.full_name
     assert_equal 'method',       loaded.name
     assert_equal 'param',        loaded.params
-    assert_equal nil,            loaded.singleton # defaults to nil
+    assert_nil                   loaded.singleton # defaults to nil
     assert_equal :public,        loaded.visibility
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
@@ -480,4 +480,3 @@ method(a, b) { |c, d| ... }
   end
 
 end
-

--- a/test/test_rdoc_attr.rb
+++ b/test/test_rdoc_attr.rb
@@ -139,7 +139,7 @@ class TestRDocAttr < RDoc::TestCase
     assert_equal cm,           loaded.parent
     assert_equal section,      loaded.section
 
-    assert loaded.display?
+    assert                     loaded.display?
   end
 
   def test_marshal_load_version_2
@@ -188,4 +188,3 @@ class TestRDocAttr < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_code_object.rb
+++ b/test/test_rdoc_code_object.rb
@@ -213,7 +213,7 @@ class TestRDocCodeObject < XrefTestCase
   end
 
   def test_file_name
-    assert_equal nil, @co.file_name
+    assert_nil @co.file_name
 
     @co.record_location @store.add_file 'lib/file.rb'
 

--- a/test/test_rdoc_comment.rb
+++ b/test/test_rdoc_comment.rb
@@ -77,7 +77,7 @@ call-seq:
 
     comment.extract_call_seq m
 
-    assert_equal nil, m.call_seq
+    assert_nil m.call_seq
   end
 
   def test_extract_call_seq_no_blank

--- a/test/test_rdoc_constant.rb
+++ b/test/test_rdoc_constant.rb
@@ -118,7 +118,7 @@ class TestRDocConstant < XrefTestCase
     assert_equal cm,             loaded.parent
     assert_equal section,        loaded.section
 
-    assert loaded.display?
+    assert                       loaded.display?
   end
 
   def test_marshal_load_version_0

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -14,10 +14,10 @@ class TestRDocContext < XrefTestCase
     assert_empty @context.in_files
     assert_equal 'unknown', @context.name
     assert_equal '', @context.comment
-    assert_equal nil, @context.parent
+    assert_nil   @context.parent
     assert_equal :public, @context.visibility
     assert_equal 1, @context.sections.length
-    assert_equal nil, @context.temporary_section
+    assert_nil   @context.temporary_section
 
     assert_empty @context.classes_hash
     assert_empty @context.modules_hash
@@ -514,7 +514,7 @@ class TestRDocContext < XrefTestCase
   end
 
   def test_find_attribute_named
-    assert_equal nil,  @c1.find_attribute_named('none')
+    assert_nil         @c1.find_attribute_named('none')
     assert_equal 'R',  @c1.find_attribute_named('attr').rw
     assert_equal 'R',  @c1.find_attribute_named('attr_reader').rw
     assert_equal 'W',  @c1.find_attribute_named('attr_writer').rw
@@ -522,7 +522,7 @@ class TestRDocContext < XrefTestCase
   end
 
   def test_find_class_method_named
-    assert_equal nil, @c1.find_class_method_named('none')
+    assert_nil @c1.find_class_method_named('none')
 
     m = @c1.find_class_method_named('m')
     assert_instance_of RDoc::AnyMethod, m
@@ -530,23 +530,23 @@ class TestRDocContext < XrefTestCase
   end
 
   def test_find_constant_named
-    assert_equal nil,      @c1.find_constant_named('NONE')
+    assert_nil             @c1.find_constant_named('NONE')
     assert_equal ':const', @c1.find_constant_named('CONST').value
   end
 
   def test_find_enclosing_module_named
-    assert_equal nil, @c2_c3.find_enclosing_module_named('NONE')
+    assert_nil        @c2_c3.find_enclosing_module_named('NONE')
     assert_equal @c1, @c2_c3.find_enclosing_module_named('C1')
     assert_equal @c2, @c2_c3.find_enclosing_module_named('C2')
   end
 
   def test_find_file_named
-    assert_equal nil,        @c1.find_file_named('nonexistent.rb')
+    assert_nil               @c1.find_file_named('nonexistent.rb')
     assert_equal @xref_data, @c1.find_file_named(@file_name)
   end
 
   def test_find_instance_method_named
-    assert_equal nil, @c1.find_instance_method_named('none')
+    assert_nil @c1.find_instance_method_named('none')
 
     m = @c1.find_instance_method_named('m')
     assert_instance_of RDoc::AnyMethod, m

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -159,17 +159,17 @@ class TestRDocEncoding < RDoc::TestCase
     s = ""
     encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal nil, encoding
+    assert_nil encoding
 
     s = "# vim:set fileencoding=utf-8:\n"
     encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal nil, encoding
+    assert_nil encoding
 
     s = "# vim:set fileencoding=utf-8:\n"
     encoding = RDoc::Encoding.detect_encoding s
 
-    assert_equal nil, encoding
+    assert_nil encoding
 
     assert_raises ArgumentError do
       s = RDoc::Encoding.detect_encoding "# -*- encoding: undecided -*-\n"

--- a/test/test_rdoc_markup_formatter.rb
+++ b/test/test_rdoc_markup_formatter.rb
@@ -111,15 +111,15 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_equal 'http',        scheme
     assert_equal 'example/foo', url
-    assert_equal nil,           id
+    assert_nil   id
   end
 
   def test_parse_url_anchor
     scheme, url, id = @to.parse_url '#foottext-1'
 
-    assert_equal nil,           scheme
+    assert_nil   scheme
     assert_equal '#foottext-1', url
-    assert_equal nil,           id
+    assert_nil   id
   end
 
   def test_parse_url_link
@@ -127,7 +127,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_equal 'link',       scheme
     assert_equal 'README.txt', url
-    assert_equal nil,          id
+    assert_nil   id
   end
 
   def test_parse_url_link_id
@@ -135,7 +135,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_equal 'link',                 scheme
     assert_equal 'README.txt#label-foo', url
-    assert_equal nil,                    id
+    assert_nil   id
   end
 
   def test_parse_url_rdoc_label
@@ -143,7 +143,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_equal 'link', scheme
     assert_equal '#foo', url
-    assert_equal nil,    id
+    assert_nil   id
 
     scheme, url, id = @to.parse_url 'rdoc-label:foo:bar'
 
@@ -157,13 +157,13 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_equal 'http',               scheme
     assert_equal 'http://example/foo', url
-    assert_equal nil,                  id
+    assert_nil   id
 
     scheme, url, id = @to.parse_url 'https://example/foo'
 
     assert_equal 'https',               scheme
     assert_equal 'https://example/foo', url
-    assert_equal nil,                   id
+    assert_nil   id
   end
 
   def test_convert_tt_special
@@ -173,4 +173,3 @@ class TestRDocMarkupFormatter < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_markup_parser.rb
+++ b/test/test_rdoc_markup_parser.rb
@@ -1068,7 +1068,7 @@ the time
 
     assert_equal [:NEWLINE, "\n", 9, 0], parser.peek_token
 
-    assert_equal nil, parser.skip(:NONE, false)
+    assert_nil parser.skip(:NONE, false)
 
     assert_equal [:NEWLINE, "\n", 9, 0], parser.peek_token
   end

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -327,7 +327,7 @@ VALUE cFoo = boot_defclass("Foo", 0);
 
     klass = util_get_class content, 'cFoo'
     assert_equal "this is the Foo boot class", klass.comment.text
-    assert_equal nil, klass.superclass
+    assert_nil klass.superclass
   end
 
   def test_do_aliases_missing_class
@@ -1377,7 +1377,7 @@ commercial() -> Date <br />
 
     parser.find_modifiers comment, method_obj
 
-    assert_equal nil, method_obj.document_self
+    assert_nil method_obj.document_self
   end
 
   def test_find_modifiers_yields

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -231,8 +231,8 @@ class C; end
     @parser.look_for_directives_in @top_level, comment
 
     section = @top_level.current_section
-    assert_equal nil, section.title
-    assert_equal nil, section.comment
+    assert_nil   section.title
+    assert_nil   section.comment
 
     assert_equal "# how to make a section:\n# # :section: new section\n",
                  comment.text
@@ -1225,7 +1225,7 @@ EOF
     assert_equal @top_level, foo.file
     assert_equal 1,          foo.line
 
-    assert_equal nil,        foo.viewer
+    assert_nil               foo.viewer
     assert_equal true,       foo.document_children
     assert_equal true,       foo.document_self
     assert_equal false,      foo.done_documenting
@@ -1288,21 +1288,21 @@ EOF
     assert_equal @top_level,  foo.file
     assert_equal 1,           foo.line
 
-    assert_equal [],        foo.aliases
-    assert_equal nil,       foo.block_params
-    assert_equal nil,       foo.call_seq
-    assert_equal nil,       foo.is_alias_for
-    assert_equal nil,       foo.viewer
-    assert_equal true,      foo.document_children
-    assert_equal true,      foo.document_self
-    assert_equal '',        foo.params
-    assert_equal false,     foo.done_documenting
-    assert_equal false,     foo.dont_rename_initialize
-    assert_equal false,     foo.force_documentation
-    assert_equal klass,     foo.parent
-    assert_equal false,     foo.singleton
-    assert_equal :public,   foo.visibility
-    assert_equal "\n",      foo.text
+    assert_equal [],          foo.aliases
+    assert_nil                foo.block_params
+    assert_nil                foo.call_seq
+    assert_nil                foo.is_alias_for
+    assert_nil                foo.viewer
+    assert_equal true,        foo.document_children
+    assert_equal true,        foo.document_self
+    assert_equal '',          foo.params
+    assert_equal false,       foo.done_documenting
+    assert_equal false,       foo.dont_rename_initialize
+    assert_equal false,       foo.force_documentation
+    assert_equal klass,       foo.parent
+    assert_equal false,       foo.singleton
+    assert_equal :public,     foo.visibility
+    assert_equal "\n",        foo.text
     assert_equal klass.current_section, foo.section
 
     stream = [
@@ -1605,19 +1605,19 @@ end
     assert_equal 1,           foo.line
 
     assert_equal [],      foo.aliases
-    assert_equal nil,     foo.block_params
-    assert_equal nil,     foo.call_seq
+    assert_nil            foo.block_params
+    assert_nil            foo.call_seq
     assert_equal true,    foo.document_children
     assert_equal true,    foo.document_self
     assert_equal false,   foo.done_documenting
     assert_equal false,   foo.dont_rename_initialize
     assert_equal false,   foo.force_documentation
-    assert_equal nil,     foo.is_alias_for
+    assert_nil            foo.is_alias_for
     assert_equal '',      foo.params
     assert_equal klass,   foo.parent
     assert_equal false,   foo.singleton
     assert_equal 'add_my_method :foo', foo.text
-    assert_equal nil,     foo.viewer
+    assert_nil            foo.viewer
     assert_equal :public, foo.visibility
     assert_equal klass.current_section, foo.section
 
@@ -1815,10 +1815,10 @@ end
     assert_equal 1,           foo.line
 
     assert_equal [],        foo.aliases
-    assert_equal nil,       foo.block_params
-    assert_equal nil,       foo.call_seq
-    assert_equal nil,       foo.is_alias_for
-    assert_equal nil,       foo.viewer
+    assert_nil              foo.block_params
+    assert_nil              foo.call_seq
+    assert_nil              foo.is_alias_for
+    assert_nil              foo.viewer
     assert_equal true,      foo.document_children
     assert_equal true,      foo.document_self
     assert_equal '()',      foo.params
@@ -3070,12 +3070,12 @@ RUBY
 
     @parser.skip_tkspace
 
-    assert_equal nil, @parser.parse_symbol_in_arg
+    assert_nil @parser.parse_symbol_in_arg
     @parser.get_tk # skip ','
 
     @parser.skip_tkspace
 
-    assert_equal nil, @parser.parse_symbol_in_arg
+    assert_nil @parser.parse_symbol_in_arg
   end
 
   def test_parse_statements_alias_method
@@ -3179,7 +3179,7 @@ end
     assert_equal 'category', directive
     assert_equal 'test', value
 
-    assert_equal nil, parser.get_tk
+    assert_nil parser.get_tk
   end
 
   def test_read_directive_allow
@@ -3189,7 +3189,7 @@ end
 
     assert_nil directive
 
-    assert_equal nil, parser.get_tk
+    assert_nil parser.get_tk
   end
 
   def test_read_directive_empty
@@ -3199,7 +3199,7 @@ end
 
     assert_nil directive
 
-    assert_equal nil, parser.get_tk
+    assert_nil parser.get_tk
   end
 
   def test_read_directive_no_comment
@@ -3209,7 +3209,7 @@ end
 
     assert_nil directive
 
-    assert_equal nil, parser.get_tk
+    assert_nil parser.get_tk
   end
 
   def test_read_directive_one_liner
@@ -3286,14 +3286,14 @@ end
     util_parser '"#{"#{"a")}" if b}"'
 
     assert_equal '"#{"#{"a")}" if b}"', @parser.get_tk[:text]
-    assert_equal nil, @parser.get_tk
+    assert_nil @parser.get_tk
   end
 
   def test_sanity_interpolation_curly
     util_parser '%{ #{} }'
 
     assert_equal '%{ #{} }', @parser.get_tk[:text]
-    assert_equal nil, @parser.get_tk
+    assert_nil @parser.get_tk
   end
 
   def test_sanity_interpolation_format

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -1171,7 +1171,7 @@ Foo::Bar#bother
     method = @driver.load_method(@store2, :instance_methods, 'Bar', '#',
                                  'inherit')
 
-    assert_equal nil, method
+    assert_nil method
   end
 
   def test_load_methods_matching
@@ -1276,7 +1276,7 @@ Foo::Bar#bother
 
     assert_equal 'ruby',   klass, 'ruby project'
     assert_equal ':',      type,  'ruby type'
-    assert_equal nil,      meth,  'ruby page'
+    assert_nil             meth,  'ruby page'
   end
 
   def test_parse_name_page_extenson
@@ -1291,26 +1291,26 @@ Foo::Bar#bother
     klass, type, meth = @driver.parse_name 'Foo'
 
     assert_equal 'Foo', klass, 'Foo class'
-    assert_equal nil,   type,  'Foo type'
-    assert_equal nil,   meth,  'Foo method'
+    assert_nil          type,  'Foo type'
+    assert_nil          meth,  'Foo method'
 
     klass, type, meth = @driver.parse_name 'Foo#'
 
     assert_equal 'Foo', klass, 'Foo# class'
     assert_equal '#',   type,  'Foo# type'
-    assert_equal nil,   meth,  'Foo# method'
+    assert_nil          meth,  'Foo# method'
 
     klass, type, meth = @driver.parse_name 'Foo::'
 
     assert_equal 'Foo', klass, 'Foo:: class'
     assert_equal '::',  type,  'Foo:: type'
-    assert_equal nil,   meth,  'Foo:: method'
+    assert_nil          meth,  'Foo:: method'
 
     klass, type, meth = @driver.parse_name 'Foo.'
 
     assert_equal 'Foo', klass, 'Foo. class'
     assert_equal '.',   type,  'Foo. type'
-    assert_equal nil,   meth,  'Foo. method'
+    assert_nil          meth,  'Foo. method'
 
     klass, type, meth = @driver.parse_name 'Foo#Bar'
 
@@ -1335,14 +1335,14 @@ Foo::Bar#bother
     klass, type, meth = @driver.parse_name 'Foo::Bar'
 
     assert_equal 'Foo::Bar', klass, 'Foo::Bar class'
-    assert_equal nil,        type,  'Foo::Bar type'
-    assert_equal nil,        meth,  'Foo::Bar method'
+    assert_nil               type,  'Foo::Bar type'
+    assert_nil               meth,  'Foo::Bar method'
 
     klass, type, meth = @driver.parse_name 'Foo::Bar#'
 
     assert_equal 'Foo::Bar', klass, 'Foo::Bar# class'
     assert_equal '#',        type,  'Foo::Bar# type'
-    assert_equal nil,        meth,  'Foo::Bar# method'
+    assert_nil               meth,  'Foo::Bar# method'
 
     klass, type, meth = @driver.parse_name 'Foo::Bar#baz'
 

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -573,7 +573,7 @@ class TestRDocStore < XrefTestCase
   end
 
   def test_main
-    assert_equal nil, @s.main
+    assert_nil @s.main
 
     @s.main = 'README.txt'
 
@@ -991,7 +991,7 @@ class TestRDocStore < XrefTestCase
   end
 
   def test_title
-    assert_equal nil, @s.title
+    assert_nil @s.title
 
     @s.title = 'rdoc'
 

--- a/test/test_rdoc_top_level.rb
+++ b/test/test_rdoc_top_level.rb
@@ -160,7 +160,7 @@ class TestRDocTopLevel < XrefTestCase
   end
 
   def test_last_modified
-    assert_equal nil, @top_level.last_modified
+    assert_nil @top_level.last_modified
     stat = Object.new
     def stat.mtime() 0 end
     @top_level.file_stat = stat


### PR DESCRIPTION
Quick pull request that replaces all 'assert_equal nil, blah' forms with 'assert_nil blah', per the deprecation warnings in Minitest.