### PR TITLE
Escape metacharacters and reorder in ASCII order Document-method regex

### DIFF
--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -169,7 +169,7 @@ module RDoc::Text
 
     encoding = text.encoding
 
-    text = text.gsub %r%Document-method:\s+[\w:.#=!?|^&<>~+-/*\%@`\[\]]+%, ''
+    text = text.gsub %r%Document-method:\s+[\w!#\%&\*+-\.\/:<=>\?@\[\]\^`\|~]+%, ''
 
     space = ' '
     space = RDoc::Encoding.change_encoding space, encoding if encoding


### PR DESCRIPTION
The Document-method regex was causing a warning -
  rdoc/lib/rdoc/text.rb:172: warning: character class has duplicated range: /Document-method:\s+[\w:.#=!?|^&<>~+-\/*%@`\[\]]+/

Reordering the characters in the character class and conservatively
escaping the metacharacters, especially '.', '?' and '*' corrected
the issue. The unescaped '.' was probably overmatching many sequences.