### PR TITLE
Set the store attribute for newly created modules

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -363,6 +363,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       container ||=
         if ignore_constants then
           c = RDoc::NormalModule.new name_t[:text]
+          c.store = @store
           new_modules << [prev_container, c]
           c
         else


### PR DESCRIPTION
Hi,

A regression has been introduced between RDoc 6.0.1 and 6.0.2 with ef958c22 where a new `RDoc::NormalModule` instance is created without a store associated to it.

This produces an error on generation through SDoc (see zzak/sdoc#124).

I don't know how to reproduce this through the test suite but here are some steps to reproduce it locally:

~~~
$ mkdir -p tmp/lib
$ cd tmp
$ echo "Foo::Bar" >> lib/bar.rb
$ echo "module Foo; end" >> lib/foo.rb
~~~

Then put the following content in a Rakefile:

~~~ruby
require 'rdoc/task'
require 'sdoc'

RDoc::Task.new do |task|
  task.generator = 'sdoc'
end
~~~

Make sure to have `sdoc` installed or in your Gemfile and then run `rake rdoc`. This error isn't reproducible without using SDoc ; the culprit line is [here](https://github.com/zzak/sdoc/blob/6907fabcb287d78135568936c0e5f561370cd649/lib/rdoc/generator/template/rails/_context.rhtml#L39) which reaches [this one](https://github.com/ruby/rdoc/blob/4ff1c1562bd7b38c57ce612211abf970518db4a2/lib/rdoc/class_module.rb#L614) and produces the error:

~~~
undefined method `rdoc' for nil:NilClass
~~~

This issue is pretty weird because parse order actually matters since the nested constant must be referenced before the top level constant definition (i.e. `bar.rb` must be parsed before `foo.rb`). Dunno whether the fix is correct or not but it works. 🤷‍♂️

Have a nice day !