### PR TITLE
Use JRuby 9.1.17.0 and remove JRuby from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ env:
   global:
     NOBENCHMARK=1
 script: rake
-matrix:
-  allow_failures:
-    - rvm: jruby-9.1.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ rvm:
   - 2.4.3
   - 2.5.0
   - ruby-head
-  - jruby-9.1.16.0
+  - jruby-9.1.17.0
 env:
   global:
     NOBENCHMARK=1
 script: rake
 matrix:
   allow_failures:
-    - rvm: jruby-9.1.16.0
+    - rvm: jruby-9.1.17.0


### PR DESCRIPTION
JRuby errors are removed by https://github.com/ruby/rdoc/commit/bccb9374239edf5ccebe3c99bd149c3ca322a15f.