### PR TITLE
Link to a class method when using dot

### DIFF
--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -127,23 +127,41 @@ class RDoc::CrossReference
 
     if /#{CLASS_REGEXP_STR}([.#]|::)#{METHOD_REGEXP_STR}/o =~ name then
       type = $2
-      type = '' if type == '.'  # will find either #method or ::method
-      method = "#{type}#{$3}"
+      if '.' == type # will find either #method or ::method
+        method = $3
+      else
+        method = "#{type}#{$3}"
+      end
       container = @context.find_symbol_module($1)
     elsif /^([.#]|::)#{METHOD_REGEXP_STR}/o =~ name then
       type = $1
-      type = '' if type == '.'
-      method = "#{type}#{$2}"
+      if '.' == type
+        method = $2
+      else
+        method = "#{type}#{$2}"
+      end
       container = @context
     else
+      type = nil
       container = nil
     end
 
     if container then
-      ref = container.find_local_symbol method
-
-      unless ref || RDoc::TopLevel === container then
-        ref = container.find_ancestor_local_symbol method
+      unless RDoc::TopLevel === container then
+        if '.' == type then
+          if 'new' == method then # AnyClassName.new will be class method
+            ref = container.find_local_symbol method
+            ref = container.find_ancestor_local_symbol method unless ref
+          else
+            ref = container.find_local_symbol "::#{method}"
+            ref = container.find_ancestor_local_symbol "::#{method}" unless ref
+            ref = container.find_local_symbol "##{method}" unless ref
+            ref = container.find_ancestor_local_symbol "##{method}" unless ref
+          end
+        else
+          ref = container.find_local_symbol method
+          ref = container.find_ancestor_local_symbol method unless ref
+        end
       end
     end
 

--- a/test/test_rdoc_cross_reference.rb
+++ b/test/test_rdoc_cross_reference.rb
@@ -139,6 +139,15 @@ class TestRDocCrossReference < XrefTestCase
     assert_ref @c2_c3_m, '::C2::C3#m(*)'
   end
 
+  def test_resolve_the_same_name_in_instance_and_class_method
+    assert_ref @c9_a_i_foo, 'C9::A#foo'
+    assert_ref @c9_a_c_bar, 'C9::A::bar'
+    assert_ref @c9_b_c_foo, 'C9::B::foo'
+    assert_ref @c9_b_i_bar, 'C9::B#bar'
+    assert_ref @c9_b_c_foo, 'C9::B.foo'
+    assert_ref @c9_a_c_bar, 'C9::B.bar'
+  end
+
   def test_resolve_method_equals3
     m = RDoc::AnyMethod.new '', '==='
     @c1.add_method m

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -162,7 +162,7 @@ class TestRDocStore < XrefTestCase
 
   def test_all_classes_and_modules
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1 C9 C9::A C9::B
       Child
       M1 M1::M2
       Parent
@@ -213,7 +213,7 @@ class TestRDocStore < XrefTestCase
 
   def test_classes
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6 C7 C8 C8::S1 C9 C9::A C9::B
       Child
       Parent
     ]

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -101,6 +101,18 @@ class C8
   end
 end
 
+class C9
+  class A
+    def foo() end
+    def self.bar() end
+  end
+
+  class B < A
+    def self.foo() end
+    def bar() end
+  end
+end
+
 module M1
   def m
   end

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -56,6 +56,14 @@ class XrefTestCase < RDoc::TestCase
     @c8    = @xref_data.find_module_named 'C8'
     @c8_s1 = @xref_data.find_module_named 'C8::S1'
 
+    @c9         = @xref_data.find_module_named 'C9'
+    @c9_a       = @xref_data.find_module_named 'C9::A'
+    @c9_a_i_foo = @c9_a.method_list.first
+    @c9_a_c_bar = @c9_a.method_list.last
+    @c9_b       = @xref_data.find_module_named 'C9::B'
+    @c9_b_c_foo = @c9_b.method_list.first
+    @c9_b_i_bar = @c9_b.method_list.last
+
     @m1    = @xref_data.find_module_named 'M1'
     @m1_m  = @m1.method_list.first
 


### PR DESCRIPTION
Some classes of standard library have the same name in class method and instance method. For example, `Random::bytes` and `Random#bytes`. In most cases of using dot in documents, it intends class method.

This closes https://github.com/ruby/rdoc/issues/601.

Memo:

This patch changes links of Ruby trunk as of now below:

- doc/NEWS-1.8.7
  - Tempfile.open
- doc/NEWS-1.9.3
  - Random.rand
- doc/NEWS-2.1.0
  - TSort.tsort
  - TSort.tsort_each
  - TSort.strongly_connected_components
  - TSort.each_strongly_connected_component
  - TSort.each_strongly_connected_component_from
- NEWS
  - Random.bytes
- random.c
  - Random.rand
- lib/optparse.rb
  - OptionParser.accept
  - OptionParser.reject
