### PR TITLE
Enable --line-numbers option

### DIFF
--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -65,16 +65,6 @@ end
 
 class RDoc::MethodAttr
 
-  @add_line_numbers = false
-
-  class << self
-    ##
-    # Allows controlling whether <tt>#markup_code</tt> adds line numbers to
-    # the source code.
-
-    attr_accessor :add_line_numbers
-  end
-
   ##
   # Prepend +src+ with line numbers.  Relies on the first line of a source
   # code listing having:
@@ -106,7 +96,7 @@ class RDoc::MethodAttr
   ##
   # Turns the method's token stream into HTML.
   #
-  # Prepends line numbers if +add_line_numbers+ is true.
+  # Prepends line numbers if +options.line_numbers+ is true.
 
   def markup_code
     return '' unless @token_stream
@@ -126,7 +116,7 @@ class RDoc::MethodAttr
     end
     src.gsub!(/^#{' ' * indent}/, '') if indent > 0
 
-    add_line_numbers(src) if RDoc::MethodAttr.add_line_numbers
+    add_line_numbers(src) if options.line_numbers
 
     src
   end

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -85,6 +85,33 @@ method(a, b) { |c, d| ... }
     assert_equal expected, @c2_a.markup_code
   end
 
+  def test_markup_code_with_line_numbers
+    position_comment = "# File #{@file_name}, line 1"
+    tokens = [
+      { :line_no => 1, :char_no => 0, :kind => :on_comment, :text => position_comment },
+      { :line_no => 1, :char_no => position_comment.size, :kind => :on_nl, :text => "\n" },
+      { :line_no => 2, :char_no => 0, :kind => :on_const, :text => 'A' },
+      { :line_no => 2, :char_no => 1, :kind => :on_nl, :text => "\n" },
+      { :line_no => 3, :char_no => 0, :kind => :on_const, :text => 'B' }
+    ]
+
+    @c2_a.collect_tokens
+    @c2_a.add_tokens(*tokens)
+
+    assert_equal <<-EXPECTED.chomp, @c2_a.markup_code
+<span class="ruby-comment"># File xref_data.rb, line 1</span>
+<span class="ruby-constant">A</span>
+<span class="ruby-constant">B</span>
+    EXPECTED
+
+    @options.line_numbers = true
+    assert_equal <<-EXPECTED.chomp, @c2_a.markup_code
+  <span class="ruby-comment"># File xref_data.rb</span>
+<span class="line-num">1</span> <span class="ruby-constant">A</span>
+<span class="line-num">2</span> <span class="ruby-constant">B</span>
+    EXPECTED
+  end
+
   def test_markup_code_empty
     assert_equal '', @c2_a.markup_code
   end


### PR DESCRIPTION
The showing line numbers feature is implemented, but an ignition of the feature is not implemented. In this commit, `RDoc::MethodAttr#markup_code` uses `options.line_numbers` for the ignition.

This closes https://github.com/ruby/rdoc/issues/597.