### PR TITLE
Allow `#+`, `#-`, `#`' to be cross referenced

### DIFF
--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -19,7 +19,7 @@ class RDoc::CrossReference
   #
   # See CLASS_REGEXP_STR
 
-  METHOD_REGEXP_STR = '([a-z]\w*[!?=]?|%|===|\[\]=?|<<|>>)(?:\([\w.+*/=<>-]*\))?'
+  METHOD_REGEXP_STR = '([a-z]\w*[!?=]?|%|===|\[\]=?|<<|>>|-|\+|\*)(?:\([\w.+*/=<>-]*\))?'
 
   ##
   # Regular expressions matching text that should potentially have

--- a/test/test_rdoc_any_method.rb
+++ b/test/test_rdoc_any_method.rb
@@ -165,7 +165,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_marshal_load_class_method
-    class_method = Marshal.load Marshal.dump(@c1.method_list.first)
+    class_method = Marshal.load Marshal.dump(@c1.find_class_method_named 'm')
 
     assert_equal 'C1::m', class_method.full_name
     assert_equal 'C1',    class_method.parent_name
@@ -174,7 +174,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_marshal_load_instance_method
-    instance_method = Marshal.load Marshal.dump(@c1.method_list.last)
+    instance_method = Marshal.load Marshal.dump(@c1.find_instance_method_named 'm')
 
     assert_equal 'C1#m',  instance_method.full_name
     assert_equal 'C1',    instance_method.parent_name

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -91,6 +91,7 @@ class TestRDocClassModule < XrefTestCase
 
     assert @c1.document_self_or_methods
 
+    @c1_plus.document_self = false
     @c1_m.document_self = false
 
     assert @c1.document_self_or_methods

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -660,7 +660,7 @@ class TestRDocContext < XrefTestCase
       'instance' => {
         :private   => [],
         :protected => [],
-        :public    => [@c1_m],
+        :public    => [@c1_plus, @c1_m],
       },
       'class' => {
         :private   => [],

--- a/test/test_rdoc_cross_reference.rb
+++ b/test/test_rdoc_cross_reference.rb
@@ -107,17 +107,23 @@ class TestRDocCrossReference < XrefTestCase
   end
 
   def test_resolve_method
-    assert_ref @c1__m, 'm'
-    assert_ref @c1_m,  '#m'
-    assert_ref @c1__m, '::m'
+    assert_ref @c1__m,    'm'
+    assert_ref @c1__m,    '::m'
+    assert_ref @c1_m,     '#m'
+    assert_ref @c1_plus,  '#+'
 
-    assert_ref @c1_m,  'C1#m'
-    assert_ref @c1__m, 'C1.m'
-    assert_ref @c1__m, 'C1::m'
+    assert_ref @c1_m,     'C1#m'
+    assert_ref @c1_plus,  'C1#+'
+    assert_ref @c1__m,    'C1.m'
+    assert_ref @c1__m,    'C1::m'
 
     assert_ref @c1_m, 'C1#m'
     assert_ref @c1_m, 'C1#m()'
     assert_ref @c1_m, 'C1#m(*)'
+
+    assert_ref @c1_plus, 'C1#+'
+    assert_ref @c1_plus, 'C1#+()'
+    assert_ref @c1_plus, 'C1#+(*)'
 
     assert_ref @c1__m, 'C1.m'
     assert_ref @c1__m, 'C1.m()'

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -20,6 +20,8 @@ class C1
   def m foo
   end
 
+  def +
+  end
 end
 
 class C2

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -31,9 +31,10 @@ class XrefTestCase < RDoc::TestCase
     @rdoc.options = @options
     @rdoc.generator = generator
 
-    @c1    = @xref_data.find_module_named 'C1'
-    @c1_m  = @c1.method_list.last  # C1#m
-    @c1__m = @c1.method_list.first # C1::m
+    @c1       = @xref_data.find_module_named 'C1'
+    @c1__m    = @c1.find_class_method_named 'm' # C1::m
+    @c1_m     = @c1.find_instance_method_named 'm'  # C1#m
+    @c1_plus  = @c1.find_instance_method_named '+'
 
     @c2    = @xref_data.find_module_named 'C2'
     @c2_a  = @c2.method_list.last


### PR DESCRIPTION
Hi :wave: 

This small pr allows for methods like `#+`, `#-`, `#*` to be cross referenced.

This, for example, will improve ruby documentation. See [Array#concat documentation](https://ruby-doc.org/core-2.5.1/Array.html#method-i-concat)

---

I'd be happy to added tests with a little guidance on where this regex is currently tested