### PR TITLE
Use original method notation

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -135,9 +135,6 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
 
     ref = @cross_reference.resolve name, text
 
-    text = ref.output_name @context if
-      RDoc::MethodAttr === ref and text == original_name
-
     case ref
     when String then
       ref

--- a/test/test_rdoc_markup_to_html_crossref.rb
+++ b/test/test_rdoc_markup_to_html_crossref.rb
@@ -59,7 +59,7 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   def test_convert_RDOCLINK_rdoc_ref_method
     result = @to.convert 'rdoc-ref:C1#m'
 
-    assert_equal para("<a href=\"C1.html#method-i-m\">#m</a>"), result
+    assert_equal para("<a href=\"C1.html#method-i-m\">C1#m</a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_label
@@ -75,13 +75,13 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
     result = @to.convert 'rdoc-ref:C1#%'
 
-    assert_equal para("<a href=\"C1.html#method-i-25\">#%</a>"), result
+    assert_equal para("<a href=\"C1.html#method-i-25\">C1#%</a>"), result
 
     m.singleton = true
 
     result = @to.convert 'rdoc-ref:C1::%'
 
-    assert_equal para("<a href=\"C1.html#method-c-25\">::%</a>"), result
+    assert_equal para("<a href=\"C1.html#method-c-25\">C1::%</a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_percent_label
@@ -200,11 +200,16 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   def test_link
     assert_equal 'n', @to.link('n', 'n')
 
-    assert_equal '<a href="C1.html#method-c-m">::m</a>', @to.link('m', 'm')
+    assert_equal '<a href="C1.html#method-c-m">m</a>', @to.link('m', 'm')
+  end
+
+  def test_link_for_method_traverse
+    @to = RDoc::Markup::ToHtmlCrossref.new @options, 'C2.html', @c9
+    assert_equal '<a href="C9/A.html#method-i-foo">C9::B#foo</a>', @to.link('C9::B#foo', 'C9::B#foo')
   end
 
   def test_link_class_method_full
-    assert_equal '<a href="Parent.html#method-c-m">Parent.m</a>',
+    assert_equal '<a href="Parent.html#method-c-m">Parent::m</a>',
                  @to.link('Parent::m', 'Parent::m')
   end
 


### PR DESCRIPTION
At 297cd5a2, method names are replaced with normalized text. But the feature has critical problems.

## Some methods are replaced with parents class receiver

For example, the document of `BasicSocket` describes `#read_nonblock` for inheritance, but it's replaced with `IO#read_nonblock`. This behavior confuses users.

## Arguments are removed

For example, the document of Time describes like below:

> Time.utc(99) means the year 99 AD, not 1999 AD.

But it's replaced with:

> Time.utc means the year 99 AD, not 1999 AD.

This behavior clearly is a bug.

This Pull Request removes the normalization logic.