### PR TITLE
add test to display_name

### DIFF
--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -699,6 +699,12 @@ class TestRDocRIDriver < RDoc::TestCase
     refute_match %r%must not be displayed%, out
   end
 
+  def test_display_name
+    util_store
+
+    assert_equal true, @driver.display_name('home:README.rdoc')
+  end
+
   def test_display_name_not_found_class
     util_store
 


### PR DESCRIPTION
add test to `display_name`

this PR improves the coverage of the file `test/test_rdoc_ri_driver.rb` from 69.5% to 69.7%