### PR TITLE
Treat "if" with EXPR_MID as postfix "if"

### DIFF
--- a/lib/rdoc/parser/ripper_state_lex.rb
+++ b/lib/rdoc/parser/ripper_state_lex.rb
@@ -114,7 +114,7 @@ class RDoc::Parser::RipperStateLex
         @continue = true
         @in_fname = true
       when 'if', 'unless', 'while', 'until'
-        if ((EXPR_END | EXPR_ENDARG | EXPR_ENDFN | EXPR_ARG | EXPR_CMDARG) & @lex_state) != 0 # postfix if
+        if ((EXPR_MID | EXPR_END | EXPR_ENDARG | EXPR_ENDFN | EXPR_ARG | EXPR_CMDARG) & @lex_state) != 0 # postfix if
           @lex_state = EXPR_BEG | EXPR_LABEL
         else
           @lex_state = EXPR_BEG

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2310,6 +2310,31 @@ end
     assert_equal 'C#bar', methods[1].full_name
   end
 
+  def test_parse_statements_postfix_if_unless_with_expr_mid
+    util_parser <<-CODE
+class A
+  class B
+    def foo
+      return if nil
+    end
+  end
+
+  class C
+  end
+end
+    CODE
+
+    @parser.parse_statements @top_level, RDoc::Parser::Ruby::NORMAL, nil
+
+    a = @top_level.classes.first
+    assert_equal 'A', a.full_name, 'class A'
+    assert_equal 2, a.classes.length
+    b = a.classes[0]
+    assert_equal 'A::B', b.full_name, 'class A::B'
+    c = a.classes[1]
+    assert_equal 'A::C', c.full_name, 'class A::C'
+  end
+
   def test_parse_statements_class_nested
     comment = RDoc::Comment.new "##\n# my method\n", @top_level
 


### PR DESCRIPTION
The `return` without argument comes with `EXPR_MID`. So the `if` below should be treated as postfix `if`:

```ruby
return if true
```
