### PR TITLE
Added Rubocop task after file generation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AllCops:
+  TargetRubyVersion: 2.5
+  DisabledByDefault: true
+  Exclude:
+    - rdoc.gemspec
+
+Layout/TrailingWhitespace:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ $:.unshift File.expand_path 'lib'
 require 'rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
 task :docs    => :generate
 task :test    => :generate
@@ -80,7 +81,11 @@ end
 
 task "#{path}.gem" => package_parser_files
 
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = [*parsed_files]
+end
+
 desc "Genrate all files used racc and kpeg"
 task :generate => parsed_files
 
-task :build => [:generate]
+task :build => [:generate, "rubocop:auto_correct"]

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -58,4 +58,5 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.add_development_dependency("racc", "> 1.4.10")
   s.add_development_dependency("kpeg")
   s.add_development_dependency("minitest", "~> 5")
+  s.add_development_dependency("rubocop")
 end

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -4087,7 +4087,7 @@ end
 module A
   class B
     include(Module.new do
-      def e m 
+      def e m
       end
     end)
   end


### PR DESCRIPTION
I always faced removing trailing-whitespace when I merged rdoc into ruby core repository.

https://github.com/ruby/ruby/commit/6a052fcd046db10ad1d04fcfc078444703bb575f

I added rubocop for removing trailing-whitespace and added rubocop task on Rakefile.