### PR TITLE
Improve language in "alias for" comment for ri

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1468,7 +1468,7 @@ or the PAGER environment variable.
         out << method.comment
       end
       out << RDoc::Markup::BlankLine.new
-      out << RDoc::Markup::Paragraph.new("(this method is alias for #{alias_for.full_name})")
+      out << RDoc::Markup::Paragraph.new("(This method is an alias for #{alias_for.full_name}.)")
       out << RDoc::Markup::BlankLine.new
       out << alias_for.comment
       out << RDoc::Markup::BlankLine.new

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -260,7 +260,7 @@ class TestRDocRIDriver < RDoc::TestCase
         para('alias comment'),
         blank_line,
         blank_line,
-        para('(this method is alias for Qux#original)'),
+        para('(This method is an alias for Qux#original.)'),
         blank_line,
         para('original comment'),
         blank_line,


### PR DESCRIPTION
Language improvement in generated comment for aliases in ri docs.