### PR TITLE
Mark up code inside link text as <code>

### DIFF
--- a/test/test_rdoc_markup_to_html_crossref.rb
+++ b/test/test_rdoc_markup_to_html_crossref.rb
@@ -14,26 +14,26 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   def test_convert_CROSSREF
     result = @to.convert 'C1'
 
-    assert_equal para("<a href=\"C1.html\">C1</a>"), result
+    assert_equal para("<a href=\"C1.html\"><code>C1</code></a>"), result
   end
 
   def test_convert_CROSSREF_label
     result = @to.convert 'C1@foo'
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at C1</a>"), result
+    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>"), result
 
     result = @to.convert 'C1#m@foo'
-    assert_equal para("<a href=\"C1.html#method-i-m-label-foo\">foo at C1#m</a>"),
+    assert_equal para("<a href=\"C1.html#method-i-m-label-foo\">foo at <code>C1#m</code></a>"),
                  result
   end
 
   def test_convert_CROSSREF_label_period
     result = @to.convert 'C1@foo.'
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at C1</a>."), result
+    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>."), result
   end
 
   def test_convert_CROSSREF_label_space
     result = @to.convert 'C1@foo+bar'
-    assert_equal para("<a href=\"C1.html#label-foo+bar\">foo bar at C1</a>"),
+    assert_equal para("<a href=\"C1.html#label-foo+bar\">foo bar at <code>C1</code></a>"),
                  result
   end
 
@@ -41,31 +41,31 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
     @c1.add_section 'Section'
 
     result = @to.convert 'C1@Section'
-    assert_equal para("<a href=\"C1.html#Section\">Section at C1</a>"), result
+    assert_equal para("<a href=\"C1.html#Section\">Section at <code>C1</code></a>"), result
   end
 
   def test_convert_CROSSREF_constant
     result = @to.convert 'C1::CONST'
 
-    assert_equal para("<a href=\"C1.html#CONST\">C1::CONST</a>"), result
+    assert_equal para("<a href=\"C1.html#CONST\"><code>C1::CONST</code></a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref
     result = @to.convert 'rdoc-ref:C1'
 
-    assert_equal para("<a href=\"C1.html\">C1</a>"), result
+    assert_equal para("<a href=\"C1.html\"><code>C1</code></a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method
     result = @to.convert 'rdoc-ref:C1#m'
 
-    assert_equal para("<a href=\"C1.html#method-i-m\">C1#m</a>"), result
+    assert_equal para("<a href=\"C1.html#method-i-m\"><code>C1#m</code></a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_label
     result = @to.convert 'rdoc-ref:C1#m@foo'
 
-    assert_equal para("<a href=\"C1.html#method-i-m-label-foo\">foo at C1#m</a>"),
+    assert_equal para("<a href=\"C1.html#method-i-m-label-foo\">foo at <code>C1#m</code></a>"),
                  result, 'rdoc-ref:C1#m@foo'
   end
 
@@ -75,13 +75,13 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
     result = @to.convert 'rdoc-ref:C1#%'
 
-    assert_equal para("<a href=\"C1.html#method-i-25\">C1#%</a>"), result
+    assert_equal para("<a href=\"C1.html#method-i-25\"><code>C1#%</code></a>"), result
 
     m.singleton = true
 
     result = @to.convert 'rdoc-ref:C1::%'
 
-    assert_equal para("<a href=\"C1.html#method-c-25\">C1::%</a>"), result
+    assert_equal para("<a href=\"C1.html#method-c-25\"><code>C1::%</code></a>"), result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_percent_label
@@ -90,21 +90,21 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
     result = @to.convert 'rdoc-ref:C1#%@f'
 
-    assert_equal para("<a href=\"C1.html#method-i-25-label-f\">f at C1#%</a>"),
+    assert_equal para("<a href=\"C1.html#method-i-25-label-f\">f at <code>C1#%</code></a>"),
                  result
 
     m.singleton = true
 
     result = @to.convert 'rdoc-ref:C1::%@f'
 
-    assert_equal para("<a href=\"C1.html#method-c-25-label-f\">f at C1::%</a>"),
+    assert_equal para("<a href=\"C1.html#method-c-25-label-f\">f at <code>C1::%</code></a>"),
                  result
   end
 
   def test_convert_RDOCLINK_rdoc_ref_label
     result = @to.convert 'rdoc-ref:C1@foo'
 
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at C1</a>"), result,
+    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>"), result,
                  'rdoc-ref:C1@foo'
   end
 
@@ -117,18 +117,18 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   end
 
   def test_handle_regexp_CROSSREF
-    assert_equal "<a href=\"C2/C3.html\">C2::C3</a>", REGEXP_HANDLING('C2::C3')
+    assert_equal "<a href=\"C2/C3.html\"><code>C2::C3</code></a>", REGEXP_HANDLING('C2::C3')
   end
 
   def test_handle_regexp_CROSSREF_label
-    assert_equal "<a href=\"C1.html#method-i-m-label-foo\">foo at C1#m</a>",
+    assert_equal "<a href=\"C1.html#method-i-m-label-foo\">foo at <code>C1#m</code></a>",
                  REGEXP_HANDLING('C1#m@foo')
   end
 
   def test_handle_regexp_CROSSREF_show_hash_false
     @to.show_hash = false
 
-    assert_equal "<a href=\"C1.html#method-i-m\">m</a>",
+    assert_equal "<a href=\"C1.html#method-i-m\"><code>m</code></a>",
                  REGEXP_HANDLING('#m')
   end
 
@@ -140,11 +140,11 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
     link = @to.handle_regexp_HYPERLINK hyper 'C2::C3'
 
-    assert_equal '<a href="C2/C3.html">C2::C3</a>', link
+    assert_equal '<a href="C2/C3.html"><code>C2::C3</code></a>', link
 
     link = @to.handle_regexp_HYPERLINK hyper 'C4'
 
-    assert_equal '<a href="C4.html">C4</a>', link
+    assert_equal '<a href="C4.html"><code>C4</code></a>', link
 
     link = @to.handle_regexp_HYPERLINK hyper 'README.txt'
 
@@ -200,16 +200,16 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   def test_link
     assert_equal 'n', @to.link('n', 'n')
 
-    assert_equal '<a href="C1.html#method-c-m">m</a>', @to.link('m', 'm')
+    assert_equal '<a href="C1.html#method-c-m"><code>m</code></a>', @to.link('m', 'm')
   end
 
   def test_link_for_method_traverse
     @to = RDoc::Markup::ToHtmlCrossref.new @options, 'C2.html', @c9
-    assert_equal '<a href="C9/A.html#method-i-foo">C9::B#foo</a>', @to.link('C9::B#foo', 'C9::B#foo')
+    assert_equal '<a href="C9/A.html#method-i-foo"><code>C9::B#foo</code></a>', @to.link('C9::B#foo', 'C9::B#foo')
   end
 
   def test_link_class_method_full
-    assert_equal '<a href="Parent.html#method-c-m">Parent::m</a>',
+    assert_equal '<a href="Parent.html#method-c-m"><code>Parent::m</code></a>',
                  @to.link('Parent::m', 'Parent::m')
   end
 


### PR DESCRIPTION
I want links to a class/module/method name to be `<code>`.
For instance, `Array#union` should be become `<a href="Array.html#method-i-union"><code>Array#union</code></a>`  instead of `<a href="Array.html#method-i-union">Array</a>`.