### PR TITLE
Ignore dynamically added methods

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -217,6 +217,7 @@ class RDoc::Parser::C < RDoc::Parser
   def deduplicate_call_seq
     @methods.each do |var_name, functions|
       class_name = @known_classes[var_name]
+      next unless class_name
       class_obj  = find_class var_name, class_name
 
       functions.each_value do |method_names|

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -1630,6 +1630,19 @@ Init_IO(void) {
     assert read_method.singleton
   end
 
+  def test_define_method_dynamically
+    content = <<-EOF
+void
+Init_foo(void)
+{
+    rb_define_singleton_method(obj, "foo", foo, -1);
+}
+    EOF
+
+    klass = util_get_class content, 'obj'
+    assert_nil klass
+  end
+
   def test_define_method_with_prototype
     content = <<-EOF
 static VALUE rb_io_s_read(int, VALUE*, VALUE);


### PR DESCRIPTION
When adding a singleton method by `rb_define_singleton_method` in a method,
the class to be added is unknown at generating documents.
In that case,`unknown.html` is generated, its content is useless at all.
