### PR TITLE
add ruby 2.5 to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,4 +29,6 @@ environment:
     - ruby_version: 23-x64
     - ruby_version: 24
     - ruby_version: 24-x64
+    - ruby_version: 25
+    - ruby_version: 25-x64
     - ruby_version: _trunk


### PR DESCRIPTION
This PR is just adding Ruby 2.5 to appveyor CI. I think this was just forgotten about when it was released.