### PR TITLE
Move ruby-head to allow_failures in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ env:
 script: rake
 matrix:
   allow_failures:
+    - rvm: ruby-head
     - rvm: jruby-9.1.17.0
     - rvm: jruby-9.2.0.0


### PR DESCRIPTION
Travis CI tests with ruby-head fail in Racc processing and I still can't reproduce it locally. Maybe it's heavy problem and I'm surveying about that. The ruby-head should be disabled until the problem is solved.