### PR TITLE
Reduce 1 char from progress output for Windows

### DIFF
--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -31,7 +31,7 @@ class RDoc::Stats::Normal < RDoc::Stats::Quiet
       # will be truncated if necessary.
       size = IO.respond_to?(:console_size) ? IO.console_size : IO.console.winsize
       terminal_width = size[1].to_i.nonzero? || 80
-      max_filename_size = terminal_width - progress_bar.size
+      max_filename_size = (terminal_width - progress_bar.size) - 1
 
       if filename.size > max_filename_size then
         # Turn "some_long_filename.rb" to "...ong_filename.rb"


### PR DESCRIPTION
Windows command prompt force wraps at the maximum number of chars of the last line so this commit reduces 1 char of it.