### PR TITLE
Use VT100 sequence to erase previos line

### DIFF
--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -42,7 +42,7 @@ class RDoc::Stats::Normal < RDoc::Stats::Quiet
     if $stdout.tty?
       # Clean the line with whitespaces so that leftover output from the
       # previous line doesn't show up.
-      $stdout.print("\r" + (" " * @last_width) + ("\b" * @last_width) + "\r") if @last_width && @last_width > 0
+      $stdout.print("\r\e[K") if @last_width && @last_width > 0
       @last_width = line.size
       $stdout.print("#{line}\r")
     else


### PR DESCRIPTION
It has been supported also on Windows since 2.0.0, and recent Windows 10 supports it too.