### PR TITLE
Fix random test failure by Bundler integration

### DIFF
--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+require 'bundler/errors'
 begin
   gem 'minitest', '~> 5.0'
-rescue NoMethodError, Gem::LoadError
+rescue NoMethodError, Gem::LoadError, Bundler::GemfileNotFound
   # for ruby tests
 end
 


### PR DESCRIPTION
With Ruby 2.6, this test helper randomly crashes test-all on Ruby's CI like:
http://ci.rvm.jp/results/trunk_clang_60@silicon-docker/1509085