### PR TITLE
Add frozen string literal support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,4 +12,4 @@ jobs:
         gem install bundler --no-document
         bundle install
     - name: Run test
-      run: rake
+      run: rake && RUBYOPT=--enable-frozen_string_literal rake

--- a/lib/rdoc/erb_partial.rb
+++ b/lib/rdoc/erb_partial.rb
@@ -12,7 +12,7 @@ class RDoc::ERBPartial < ERB
   def set_eoutvar compiler, eoutvar = '_erbout'
     super
 
-    compiler.pre_cmd = ["#{eoutvar} ||= ''"]
+    compiler.pre_cmd = ["#{eoutvar} ||= +''"]
   end
 
 end


### PR DESCRIPTION
I created this but when I was forking the gem, I noticed that it's already fixed on https://github.com/ruby/rdoc/tree/fix-for-frozen-string-literal. And the test there is probably better than re-running everything :man_shrugging:.