### PR TITLE
Gitignore coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.rbc
 *.swp
+/coverage
 .DS_Store
 /.rdoc
 /.rvmrc


### PR DESCRIPTION
So contributors don't accidentally commit it.