### PR TITLE
Normalization of comment should check language

### DIFF
--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -48,9 +48,10 @@ class RDoc::Comment
   # Creates a new comment with +text+ that is found in the RDoc::TopLevel
   # +location+.
 
-  def initialize text = nil, location = nil
+  def initialize text = nil, location = nil, language = nil
     @location = location
     @text     = text.nil? ? nil : text.dup
+    @language = language
 
     @document   = nil
     @format     = 'rdoc'

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -446,7 +446,7 @@ class RDoc::Parser::C < RDoc::Parser
       next unless cls = @classes[c]
       m = @known_classes[m] || m
 
-      comment = RDoc::Comment.new '', @top_level
+      comment = RDoc::Comment.new '', @top_level, :c
       incl = cls.add_include RDoc::Include.new(m, comment)
       incl.record_location @top_level
     end
@@ -564,7 +564,7 @@ class RDoc::Parser::C < RDoc::Parser
                                    \s*"#{Regexp.escape new_name}"\s*,
                                    \s*"#{Regexp.escape old_name}"\s*\);%xm
 
-    RDoc::Comment.new($1 || '', @top_level)
+    RDoc::Comment.new($1 || '', @top_level, :c)
   end
 
   ##
@@ -603,7 +603,7 @@ class RDoc::Parser::C < RDoc::Parser
                 ''
               end
 
-    RDoc::Comment.new comment, @top_level
+    RDoc::Comment.new comment, @top_level, :c
   end
 
   ##
@@ -643,7 +643,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     case type
     when :func_def
-      comment = RDoc::Comment.new args[0], @top_level
+      comment = RDoc::Comment.new args[0], @top_level, :c
       body = args[1]
       offset, = args[2]
 
@@ -673,7 +673,7 @@ class RDoc::Parser::C < RDoc::Parser
 
       body
     when :macro_def
-      comment = RDoc::Comment.new args[0], @top_level
+      comment = RDoc::Comment.new args[0], @top_level, :c
       body = args[1]
       offset, = args[2]
 
@@ -780,7 +780,7 @@ class RDoc::Parser::C < RDoc::Parser
       comment = ''
     end
 
-    comment = RDoc::Comment.new comment, @top_level
+    comment = RDoc::Comment.new comment, @top_level, :c
     comment.normalize
 
     look_for_directives_in class_mod, comment
@@ -825,7 +825,7 @@ class RDoc::Parser::C < RDoc::Parser
       table[const_name] ||
       ''
 
-    RDoc::Comment.new comment, @top_level
+    RDoc::Comment.new comment, @top_level, :c
   end
 
   ##
@@ -856,7 +856,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     return unless comment
 
-    RDoc::Comment.new comment, @top_level
+    RDoc::Comment.new comment, @top_level, :c
   end
 
   ##
@@ -990,7 +990,7 @@ class RDoc::Parser::C < RDoc::Parser
 
         new_comment = "#{$1}#{new_comment.lstrip}"
 
-        new_comment = RDoc::Comment.new new_comment, @top_level
+        new_comment = RDoc::Comment.new new_comment, @top_level, :c
 
         con = RDoc::Constant.new const_name, new_definition, new_comment
       else

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -667,7 +667,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Creates a comment with the correct format
 
   def new_comment comment
-    c = RDoc::Comment.new comment, @top_level
+    c = RDoc::Comment.new comment, @top_level, :ruby
     c.format = @markup
     c
   end

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -10,6 +10,8 @@ require 'strscan'
 
 module RDoc::Text
 
+  attr_accessor :language
+
   ##
   # Maps markup formats to classes that can parse them.  If the format is
   # unknown, "rdoc" format is used.
@@ -111,8 +113,12 @@ module RDoc::Text
   def normalize_comment text
     return text if text.empty?
 
-    text = strip_stars    text
-    text = strip_hashes   text
+    case language
+    when :ruby
+      text = strip_hashes text
+    when :c
+      text = strip_stars text
+    end
     text = expand_tabs    text
     text = flush_left     text
     text = strip_newlines text

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -97,8 +97,9 @@ class RDoc::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Un
   # Creates an RDoc::Comment with +text+ which was defined on +top_level+.
   # By default the comment has the 'rdoc' format.
 
-  def comment text, top_level = @top_level
-    RDoc::Comment.new text, top_level
+  def comment text, top_level = @top_level, language = nil
+    comment = RDoc::Comment.new text, top_level, language
+    comment
   end
 
   ##

--- a/test/test_rdoc_class_module.rb
+++ b/test/test_rdoc_class_module.rb
@@ -9,19 +9,19 @@ class TestRDocClassModule < XrefTestCase
     tl3 = @store.add_file 'three.rb'
 
     cm = RDoc::ClassModule.new 'Klass'
-    comment_tl1 = RDoc::Comment.new('# comment 1')
+    comment_tl1 = RDoc::Comment.new('# comment 1', @top_level, :ruby)
     cm.add_comment comment_tl1, tl1
 
     assert_equal [[comment_tl1, tl1]], cm.comment_location
     assert_equal 'comment 1', cm.comment.text
 
-    comment_tl2 = RDoc::Comment.new('# comment 2')
+    comment_tl2 = RDoc::Comment.new('# comment 2', @top_level, :ruby)
     cm.add_comment comment_tl2, tl2
 
     assert_equal [[comment_tl1, tl1], [comment_tl2, tl2]], cm.comment_location
     assert_equal "comment 1\n---\ncomment 2", cm.comment
 
-    comment_tl3 = RDoc::Comment.new('# * comment 3')
+    comment_tl3 = RDoc::Comment.new('# * comment 3', @top_level, :ruby)
     cm.add_comment comment_tl3, tl3
 
     assert_equal [[comment_tl1, tl1],
@@ -42,11 +42,13 @@ class TestRDocClassModule < XrefTestCase
     tl1 = @store.add_file 'one.rb'
 
     cm = RDoc::ClassModule.new 'Klass'
-    cm.add_comment '# comment 1', tl1
-    cm.add_comment '# comment 2', tl1
+    comment1 = RDoc::Comment.new('# comment 1', @top_level, :ruby)
+    comment2 = RDoc::Comment.new('# comment 2', @top_level, :ruby)
+    cm.add_comment comment1, tl1
+    cm.add_comment comment2, tl1
 
-    assert_equal [['comment 1', tl1],
-                  ['comment 2', tl1]], cm.comment_location
+    assert_equal [[comment1, tl1],
+                  [comment2, tl1]], cm.comment_location
   end
 
   def test_add_comment_stopdoc
@@ -66,17 +68,17 @@ class TestRDocClassModule < XrefTestCase
 
   def test_comment_equals
     cm = RDoc::ClassModule.new 'Klass'
-    cm.comment = '# comment 1'
+    cm.comment = RDoc::Comment.new('# comment 1', @top_level, :ruby)
 
-    assert_equal 'comment 1', cm.comment
+    assert_equal 'comment 1', cm.comment.to_s
 
-    cm.comment = '# comment 2'
+    cm.comment = RDoc::Comment.new('# comment 2', @top_level, :ruby)
 
-    assert_equal "comment 1\n---\ncomment 2", cm.comment
+    assert_equal "comment 1\n---\ncomment 2", cm.comment.to_s
 
-    cm.comment = "# * comment 3"
+    cm.comment = RDoc::Comment.new('# * comment 3', @top_level, :ruby)
 
-    assert_equal "comment 1\n---\ncomment 2\n---\n* comment 3", cm.comment
+    assert_equal "comment 1\n---\ncomment 2\n---\n* comment 3", cm.comment.to_s
   end
 
   def test_comment_equals_comment

--- a/test/test_rdoc_comment.rb
+++ b/test/test_rdoc_comment.rb
@@ -241,6 +241,7 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
     @comment.text = <<-TEXT
   # comment
     TEXT
+    @comment.language = :ruby
 
     assert_same @comment, @comment.normalize
 

--- a/test/test_rdoc_context_section.rb
+++ b/test/test_rdoc_context_section.rb
@@ -11,7 +11,7 @@ class TestRDocContextSection < RDoc::TestCase
     @klass = @top_level.add_class RDoc::NormalClass, 'Object'
 
     @S = RDoc::Context::Section
-    @s = @S.new @klass, 'section', comment('# comment', @top_level)
+    @s = @S.new @klass, 'section', comment('# comment', @top_level, :ruby)
   end
 
   def test_add_comment

--- a/test/test_rdoc_parser_c.rb
+++ b/test/test_rdoc_parser_c.rb
@@ -1381,7 +1381,7 @@ commercial() -> Date <br />
   end
 
   def test_find_modifiers_yields
-    comment = RDoc::Comment.new <<-COMMENT
+    comment = RDoc::Comment.new <<-COMMENT, @top_level, :c
 /* :yields: a, b
  *
  * Blah

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -435,7 +435,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my attr\n", @top_level
+    comment = RDoc::Comment.new "##\n# my attr\n", @top_level, :ruby
 
     util_parser "attr :foo, :bar"
 
@@ -472,7 +472,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my attr\n", @top_level
+    comment = RDoc::Comment.new "##\n# my attr\n", @top_level, :ruby
 
     util_parser "attr_accessor :foo, :bar"
 
@@ -499,7 +499,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my attr\n", @top_level
+    comment = RDoc::Comment.new "##\n# my attr\n", @top_level, :ruby
 
     util_parser "attr_accessor :foo, :bar,\n  :baz,\n  :qux"
 
@@ -584,7 +584,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my attr\n", @top_level
+    comment = RDoc::Comment.new "##\n# my attr\n", @top_level, :ruby
 
     util_parser "attr_writer :foo, :bar"
 
@@ -610,7 +610,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# :attr: \n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# :attr: \n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar"
 
@@ -631,7 +631,7 @@ ruby
     klass.parent = @top_level
 
     comment =
-      RDoc::Comment.new "##\n# :attr_accessor: \n# my method\n", @top_level
+      RDoc::Comment.new "##\n# :attr_accessor: \n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar"
 
@@ -651,7 +651,7 @@ ruby
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# :attr: foo\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# :attr: foo\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar"
 
@@ -672,7 +672,7 @@ ruby
     klass.parent = @top_level
 
     comment =
-      RDoc::Comment.new "##\n# :attr_reader: \n# my method\n", @top_level
+      RDoc::Comment.new "##\n# :attr_reader: \n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar"
 
@@ -708,7 +708,7 @@ ruby
     klass.parent = @top_level
 
     comment =
-      RDoc::Comment.new "##\n# :attr_writer: \n# my method\n", @top_level
+      RDoc::Comment.new "##\n# :attr_writer: \n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar"
 
@@ -724,7 +724,7 @@ ruby
   end
 
   def test_parse_class
-    comment = RDoc::Comment.new "##\n# my class\n", @top_level
+    comment = RDoc::Comment.new "##\n# my class\n", @top_level, :ruby
 
     util_parser "class Foo\nend"
 
@@ -1001,7 +1001,7 @@ end
   end
 
   def test_parse_module
-    comment = RDoc::Comment.new "##\n# my module\n", @top_level
+    comment = RDoc::Comment.new "##\n# my module\n", @top_level, :ruby
 
     util_parser "module Foo\nend"
 
@@ -1247,7 +1247,7 @@ EOF
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# :attr: foo\n# my attr\n", @top_level
+    comment = RDoc::Comment.new "##\n# :attr: foo\n# my attr\n", @top_level, :ruby
 
     util_parser "\n"
 
@@ -1311,7 +1311,7 @@ EOF
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# :method: foo\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# :method: foo\n# my method\n", @top_level, :ruby
 
     util_parser "\n"
 
@@ -1595,7 +1595,7 @@ end
     klass = RDoc::NormalClass.new 'C'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "# my extend\n", @top_level
+    comment = RDoc::Comment.new "# my extend\n", @top_level, :ruby
 
     util_parser "extend I"
 
@@ -1615,7 +1615,7 @@ end
     klass = RDoc::NormalClass.new 'C'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "# my include\n", @top_level
+    comment = RDoc::Comment.new "# my include\n", @top_level, :ruby
 
     util_parser "include I"
 
@@ -1635,7 +1635,7 @@ end
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar\nadd_my_method :baz"
 
@@ -1719,7 +1719,7 @@ end
 
   def test_parse_meta_method_define_method
     klass = RDoc::NormalClass.new 'Foo'
-    comment = RDoc::Comment.new "##\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# my method\n", @top_level, :ruby
 
     util_parser "define_method :foo do end"
 
@@ -1738,7 +1738,7 @@ end
     klass.parent = @top_level
 
     comment =
-      RDoc::Comment.new "##\n# :method: woo_hoo!\n# my method\n", @top_level
+      RDoc::Comment.new "##\n# :method: woo_hoo!\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar\nadd_my_method :baz"
 
@@ -1757,7 +1757,7 @@ end
     klass.parent = @top_level
 
     comment =
-      RDoc::Comment.new "##\n# :singleton-method:\n# my method\n", @top_level
+      RDoc::Comment.new "##\n# :singleton-method:\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar\nadd_my_method :baz"
 
@@ -1778,7 +1778,7 @@ end
 
     comment =
       RDoc::Comment.new "##\n# :singleton-method: woo_hoo!\n# my method\n",
-                        @top_level
+                        @top_level, :ruby
 
     util_parser "add_my_method :foo, :bar\nadd_my_method :baz"
 
@@ -1795,7 +1795,7 @@ end
 
   def test_parse_meta_method_string_name
     klass = RDoc::NormalClass.new 'Foo'
-    comment = RDoc::Comment.new "##\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method 'foo'"
 
@@ -1827,7 +1827,7 @@ end
 
   def test_parse_meta_method_unknown
     klass = RDoc::NormalClass.new 'Foo'
-    comment = RDoc::Comment.new "##\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# my method\n", @top_level, :ruby
 
     util_parser "add_my_method ('foo')"
 
@@ -1845,7 +1845,7 @@ end
     klass = RDoc::NormalClass.new 'Foo'
     klass.parent = @top_level
 
-    comment = RDoc::Comment.new "##\n# my method\n", @top_level
+    comment = RDoc::Comment.new "##\n# my method\n", @top_level, :ruby
 
     util_parser "def foo() :bar end"
 

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -13,6 +13,7 @@ class TestRDocText < RDoc::TestCase
     @options = RDoc::Options.new
 
     @top_level = @store.add_file 'file.rb'
+    @language = nil
   end
 
   def test_self_encode_fallback
@@ -137,6 +138,8 @@ we don't worry too much.
 The comments associated with
     EXPECTED
 
+    @language = :ruby
+
     assert_equal expected, normalize_comment(text)
   end
 
@@ -155,6 +158,8 @@ we don't worry too much.
 The comments associated with
     EXPECTED
 
+    @language = :c
+
     assert_equal expected, normalize_comment(text)
   end
 
@@ -172,6 +177,8 @@ we don't worry too much.
 
 The comments associated with
     EXPECTED
+
+    @language = :c
 
     assert_equal expected, normalize_comment(text)
   end
@@ -200,6 +207,8 @@ The comments associated with
   end
 
   def test_parse_empty_newline
+    @language = :ruby
+
     assert_equal RDoc::Markup::Document.new, parse("#\n")
   end
 


### PR DESCRIPTION
`RDoc::Text#normalize_comment` that is included `RDoc::Comment` always remove Ruby style comment indicator `#` and C style comment indicator `/**/`, but should check language and remove only the language's comment indicator.