### PR TITLE
Support nesting text page URL

### DIFF
--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -145,11 +145,14 @@ class RDoc::Servlet < WEBrick::HTTPServlet::AbstractServlet
   # +generator+ is used to create the page.
 
   def documentation_page store, generator, path, req, res
-    name = path.sub(/.html$/, '').gsub '/', '::'
+    text_name = path.sub /.html$/, ''
+    name = text_name.gsub '/', '::'
 
     if klass = store.find_class_or_module(name) then
       res.body = generator.generate_class klass
     elsif page = store.find_text_page(name.sub(/_([^_]*)$/, '.\1')) then
+      res.body = generator.generate_page page
+    elsif page = store.find_text_page(text_name.sub(/_([^_]*)$/, '.\1')) then
       res.body = generator.generate_page page
     else
       not_found generator, req, res

--- a/test/test_rdoc_servlet.rb
+++ b/test/test_rdoc_servlet.rb
@@ -232,6 +232,18 @@ class TestRDocServlet < RDoc::TestCase
     assert_match %r%<body [^>]+ class="file">%,      @res.body
   end
 
+  def test_documentation_page_page_with_nesting
+    store = RDoc::Store.new
+
+    generator = @s.generator_for store
+
+    readme = store.add_file 'nesting/README.rdoc', parser: RDoc::Parser::Simple
+
+    @s.documentation_page store, generator, 'nesting/README_rdoc.html', @req, @res
+
+    assert_equal 200, @res.status
+  end
+
   def test_documentation_source
     store, path = @s.documentation_source '/ruby/Object.html'
 


### PR DESCRIPTION
`RDoc::Servlet#documentation_page` replaces "/" in URL with "::" for class or module but it's also used for the replaced name on text pages. This causes a bug when text pages are in nesting directory.

This commit fixes #615.