### PR TITLE
Colorize background of code/pre

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -62,6 +62,9 @@ h6:hover span {
 code,
 pre {
   font-family: "Source Code Pro", Monaco, monospace;
+  background-color: rgba(27,31,35,0.05);
+  padding: 0em 0.2em;
+  border-radius: 0.2em;
 }
 
 /* @group Generic Classes */


### PR DESCRIPTION
Copied the style of bugs.ruby-lang.org.