### PR TITLE
appveyor.yml - correct case in paths, use trunk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 ---
+image: Visual Studio 2017
+
+clone_depth: 50
+
 init:
-  # Set UTF-8 to use Unicode property because the defualt encoding on AppVeyor is Encoding::IBM437
+  # Set UTF-8 to use Unicode property because the default encoding on AppVeyor is Encoding::IBM437
   - set RUBYOPT=-EUTF-8
   # To avoid duplicated executables in PATH, see https://github.com/ruby/spec/pull/468
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\msys64\usr\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32;C:\Program Files;C:\Windows
+  - set PATH=C:\Ruby%ruby_version%\bin;C:\msys64\usr\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32;C:\Program Files;C:\Windows
   # Loads trunk build and updates MSYS2 / MinGW to most recent gcc compiler
   - if %ruby_version%==_trunk (
       appveyor DownloadFile %APPVEYOR_URL%/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
@@ -31,4 +35,6 @@ environment:
     - ruby_version: 24-x64
     - ruby_version: 25
     - ruby_version: 25-x64
-    #- ruby_version: _trunk
+    #- ruby_version: 26
+    #- ruby_version: 26-x64
+    - ruby_version: _trunk

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ init:
   # Set UTF-8 to use Unicode property because the defualt encoding on AppVeyor is Encoding::IBM437
   - set RUBYOPT=-EUTF-8
   # To avoid duplicated executables in PATH, see https://github.com/ruby/spec/pull/468
-  - set PATH=C:\ruby%RUBY_VERSION%\bin;C:\msys64\usr\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32;C:\Program Files;C:\Windows
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\msys64\usr\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32;C:\Program Files;C:\Windows
   # Loads trunk build and updates MSYS2 / MinGW to most recent gcc compiler
   - if %ruby_version%==_trunk (
       appveyor DownloadFile %APPVEYOR_URL%/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
-      7z x C:\ruby_trunk.7z -oC:\ruby_trunk)
+      7z x C:\ruby_trunk.7z -oC:\Ruby_trunk)
 
 install:
   - bundle install


### PR DESCRIPTION
This can cause very odd issues, seemingly coming out of nowhere.  I had the mistake in some repos also...

2nd commit uses trunk.