### PR TITLE
Fix links to headings

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -153,7 +153,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
             ref.sections.any? { |section| label == section.title } then
         path << "##{label}"
       else
-        path << "#label-#{label}"
+        path << "##{ref.aref}-label-#{label}"
       end if label
 
       "<a href=\"#{path}\">#{text}</a>"

--- a/test/test_rdoc_markup_to_html_crossref.rb
+++ b/test/test_rdoc_markup_to_html_crossref.rb
@@ -19,7 +19,7 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
   def test_convert_CROSSREF_label
     result = @to.convert 'C1@foo'
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>"), result
+    assert_equal para("<a href=\"C1.html#class-C1-label-foo\">foo at <code>C1</code></a>"), result
 
     result = @to.convert 'C1#m@foo'
     assert_equal para("<a href=\"C1.html#method-i-m-label-foo\">foo at <code>C1#m</code></a>"),
@@ -28,12 +28,12 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
   def test_convert_CROSSREF_label_period
     result = @to.convert 'C1@foo.'
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>."), result
+    assert_equal para("<a href=\"C1.html#class-C1-label-foo\">foo at <code>C1</code></a>."), result
   end
 
   def test_convert_CROSSREF_label_space
     result = @to.convert 'C1@foo+bar'
-    assert_equal para("<a href=\"C1.html#label-foo+bar\">foo bar at <code>C1</code></a>"),
+    assert_equal para("<a href=\"C1.html#class-C1-label-foo+bar\">foo bar at <code>C1</code></a>"),
                  result
   end
 
@@ -104,7 +104,7 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   def test_convert_RDOCLINK_rdoc_ref_label
     result = @to.convert 'rdoc-ref:C1@foo'
 
-    assert_equal para("<a href=\"C1.html#label-foo\">foo at <code>C1</code></a>"), result,
+    assert_equal para("<a href=\"C1.html#class-C1-label-foo\">foo at <code>C1</code></a>"), result,
                  'rdoc-ref:C1@foo'
   end
 


### PR DESCRIPTION
A previous change made the header's id be fully referenced (for the sidebar I believe) but this broke links to them.

You can see the issue in the doc for Links: https://ruby.github.io/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-Links. In the 4th paragraph, there is a link `Links at RDoc::Markup`, which link to `#label-Links`. You can scroll and then click on it to see that it does nothing. That's because the ID of the header is actually `class-RDoc::Markup-label-Links`

This change fixes it.

