### PR TITLE
Memoize the result of the module lookup

### DIFF
--- a/lib/rdoc/mixin.rb
+++ b/lib/rdoc/mixin.rb
@@ -55,6 +55,12 @@ class RDoc::Mixin < RDoc::CodeObject
     ]
   end
 
+  def module
+    return @memoized_module if instance_variable_defined?(:@memoized_module)
+
+    @memoized_module = lookup_module
+  end
+
   ##
   # Attempts to locate the included module object.  Returns the name if not
   # known.
@@ -72,7 +78,7 @@ class RDoc::Mixin < RDoc::CodeObject
   #
   # As of the beginning of October, 2011, no gem includes nonexistent modules.
 
-  def module
+  def lookup_module
     return @module if @module
 
     # search the current context


### PR DESCRIPTION
Memoizes the expensive module lookup of RDoc::Mixin#module. 

Note: It may be that a memoization of the result is not feasable due to changes in the loaded datastructures between calls, which would render this change moot.

Motivation: Generating the ri documentation for a lot of gems is very very slow. Looking at the process after the inital parsing phase, a lot of time is spent in repeated lookups of the module of a mixin. While the method contains lots of early returns, no early return seems to be possible if the logic falls through to the final @name return of the method, and watching the behaviour of the code it seems the same lookup can happen dozens of times for the very same Mixin instance, each time completing the entire method without early return.

A prominent example would be generating documentation for the http-2.8.3. With the unchanged code, generating ri documentation takes over 30 minutes on my gen 6 i7. In fact, I cancelled the jobs after 30 minutes:

    ~/.rvm/gems/ruby-2.6.3/gems/httpclient-2.8.3 $ time rdoc --ri
    Parsing sources...
    100% [67/67]  test/test_webagent-cookie.rb
    
    Generating RI format into /home/sr/.rdoc...
    ^C
    Interrupted
  
    real	31m29.441s
    user	31m28.062s
    sys	0m0.199s

With the proposed changes, building the ri documentation takes about 3 seconds:

    ~/.rvm/gems/ruby-2.6.3/gems/httpclient-2.8.3 $ time rdoc --ri
    Parsing sources...
    100% [67/67]  test/test_webagent-cookie.rb

    Generating RI format into /home/sr/.rdoc...

      Files:        67

      Classes:      91 ( 54 undocumented)
      Modules:      17 ( 10 undocumented)
      Constants:    94 ( 84 undocumented)
      Attributes:  140 ( 87 undocumented)
      Methods:     726 (511 undocumented)

      Total:      1068 (746 undocumented)
       30.15% documented

      Elapsed: 2.8s


    real	0m3.235s
    user	0m2.994s
    sys	0m0.209s
