### PR TITLE
Skip test option

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -339,6 +339,10 @@ class RDoc::Options
 
   attr_reader :visibility
 
+  ##
+  # Indicates if files of test suites should be skipped
+  attr_reader :skip_tests
+
   def initialize loaded_options = nil # :nodoc:
     init_ivars
     override loaded_options if loaded_options
@@ -386,6 +390,7 @@ class RDoc::Options
     @write_options = false
     @encoding = Encoding::UTF_8
     @charset = @encoding.name
+    @skip_tests = true
   end
 
   def init_with map # :nodoc:
@@ -774,6 +779,13 @@ Usage: #{opt.program_name} [options] [names...]
              "Do not process files or directories",
              "matching PATTERN.") do |value|
         @exclude << value
+      end
+
+      opt.separator nil
+
+      opt.on("--no-skipping-tests", nil,
+             "Don't skip generating documentation for test and spec files") do |value|
+        @skip_tests = false
       end
 
       opt.separator nil

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -341,7 +341,7 @@ class RDoc::Options
 
   ##
   # Indicates if files of test suites should be skipped
-  attr_reader :skip_tests
+  attr_accessor :skip_tests
 
   def initialize loaded_options = nil # :nodoc:
     init_ivars

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -281,6 +281,7 @@ option)
         end
       when "directory" then
         next if rel_file_name == "CVS" || rel_file_name == ".svn"
+        next if options.skip_tests && %w[spec test].include?(File.basename(rel_file_name))
 
         created_rid = File.join rel_file_name, "created.rid"
         next if File.file? created_rid

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -36,6 +36,17 @@ class RDoc::RDoc
   GENERATORS = {}
 
   ##
+  # List of directory names always skipped
+
+  UNCONDITIONALLY_SKIPPED_DIRECTORIES = %w[CVS .svn .git].freeze
+
+  ##
+  # List of directory names skipped if test suites should be skipped
+
+  TEST_SUITE_DIRECTORY_NAMES = %w[spec test].freeze
+
+
+  ##
   # Generator instance used for creating output
 
   attr_accessor :generator
@@ -280,8 +291,10 @@ option)
           file_list[rel_file_name] = mtime
         end
       when "directory" then
-        next if rel_file_name == "CVS" || rel_file_name == ".svn"
-        next if options.skip_tests && %w[spec test].include?(File.basename(rel_file_name))
+        next if UNCONDITIONALLY_SKIPPED_DIRECTORIES.include?(rel_file_name)
+
+        basename = File.basename(rel_file_name)
+        next if options.skip_tests && TEST_SUITE_DIRECTORY_NAMES.include?(basename)
 
         created_rid = File.join rel_file_name, "created.rid"
         next if File.file? created_rid

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -83,6 +83,7 @@ class TestRDocOptions < RDoc::TestCase
       'title'                => nil,
       'visibility'           => :protected,
       'webcvs'               => nil,
+      'skip_tests'           => true,
     }
 
     assert_equal expected, coder
@@ -869,6 +870,16 @@ rdoc_include:
 
       assert_kind_of RDoc::Options, options
     end
+  end
+
+  def test_skip_test_default_value
+    @options.parse %w[]
+    assert_equal true, @options.skip_tests
+  end
+
+  def test_no_skip_test_value
+    @options.parse %w[--no-skipping-tests]
+    assert_equal false, @options.skip_tests
   end
 
   class DummyCoder < Hash

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -213,6 +213,48 @@ class TestRDocRDoc < RDoc::TestCase
     assert_equal expected_files, files
   end
 
+  def test_normalized_file_list_with_skipping_tests_enabled
+    files = temp_dir do |dir|
+      @a = File.expand_path('a.rb')
+      spec_dir = File.expand_path('spec')
+      spec_file = File.expand_path(File.join('spec', 'my_spec.rb'))
+      test_dir = File.expand_path('test')
+      test_file = File.expand_path(File.join('test', 'my_test.rb'))
+      FileUtils.touch @a
+      FileUtils.mkdir_p spec_dir
+      FileUtils.touch spec_file
+      FileUtils.mkdir_p test_dir
+      FileUtils.touch test_file
+
+      @rdoc.options.skip_tests = true
+      @rdoc.normalized_file_list [File.realpath(dir)]
+    end
+
+    files = files.map { |file| File.expand_path file }
+    assert_equal [@a], files
+  end
+
+  def test_normalized_file_list_with_skipping_tests_disabled
+    files = temp_dir do |dir|
+      @a = File.expand_path('a.rb')
+      spec_dir = File.expand_path('spec')
+      @spec_file = File.expand_path(File.join('spec', 'my_spec.rb'))
+      test_dir = File.expand_path('test')
+      @test_file = File.expand_path(File.join('test', 'my_test.rb'))
+      FileUtils.touch @a
+      FileUtils.mkdir_p spec_dir
+      FileUtils.touch @spec_file
+      FileUtils.mkdir_p test_dir
+      FileUtils.touch @test_file
+
+      @rdoc.options.skip_tests = false
+      @rdoc.normalized_file_list [File.realpath(dir)]
+    end
+
+    files = files.map { |file| File.expand_path file }
+    assert_equal [@test_file, @spec_file, @a], files
+  end
+
   def test_parse_file
     @rdoc.store = RDoc::Store.new
 

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -230,7 +230,7 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.normalized_file_list [File.realpath(dir)]
     end
 
-    files = files.map { |file| File.expand_path file }
+    files = files.map { |file, *| File.expand_path file }
     assert_equal [@a], files
   end
 
@@ -251,8 +251,8 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.normalized_file_list [File.realpath(dir)]
     end
 
-    files = files.map { |file| File.expand_path file }
-    assert_equal [@test_file, @spec_file, @a], files
+    files = files.map { |file, *| File.expand_path file }
+    assert_equal [@a, @spec_file, @test_file], files.sort
   end
 
   def test_parse_file


### PR DESCRIPTION
A surprising amount of gems include their test suites in the gem distribution (out of 185 gems in my current gem set, 78 include a first-level 'spec' or 'test' directory. This can increase the number of files to process by quite a bit.

This proposed change will not gather files to process in under directories called 'spec' or 'test', unless the --no-skipping-tests command line option is supplied.

This feature is similar to --exclude, however will work regardless if the current directory includes a .rdoc_options file. 

Alternatively, a feature could be introduced that loads and parses an .rdoc_options file from the users home directory before such a file is looked for and parsed from the current directory.