### PR TITLE
Treat multiple Ruby methods calling the same C method as aliases

### DIFF
--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -98,8 +98,8 @@
 
     <% methods.each do |method| %>
       <div id="<%= method.aref %>" class="method-detail <%= method.is_alias_for ? "method-alias" : '' %>">
-        <% if method.call_seq then %>
-        <%   method.call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
+        <% if (call_seq = method.call_seq) then %>
+        <%   call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
         <div class="method-heading">
           <span class="method-callseq">
             <%= h(call_seq.strip.

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -210,48 +210,6 @@ class RDoc::Parser::C < RDoc::Parser
   end
 
   ##
-  # Removes duplicate call-seq entries for methods using the same
-  # implementation.
-
-  def deduplicate_call_seq
-    @methods.each do |var_name, functions|
-      class_name = @known_classes[var_name]
-      next unless class_name
-      class_obj  = find_class var_name, class_name
-
-      functions.each_value do |method_names|
-        next if method_names.length == 1
-
-        method_names.each do |method_name|
-          deduplicate_method_name class_obj, method_name
-        end
-      end
-    end
-  end
-
-  ##
-  # If two ruby methods share a C implementation (and comment) this
-  # deduplicates the examples in the call_seq for the method to reduce
-  # confusion in the output.
-
-  def deduplicate_method_name class_obj, method_name # :nodoc:
-    return unless
-      method = class_obj.method_list.find { |m| m.name == method_name }
-    return unless call_seq = method.call_seq
-
-    method_name = method_name[0, 1] if method_name =~ /\A\[/
-
-    entries = call_seq.split "\n"
-
-    matching = entries.select do |entry|
-      entry =~ /^\w*\.?#{Regexp.escape method_name}/ or
-        entry =~ /\s#{Regexp.escape method_name}\s/
-    end
-
-    method.call_seq = matching.join "\n"
-  end
-
-  ##
   # Scans #content for rb_define_alias
 
   def do_aliases
@@ -269,21 +227,27 @@ class RDoc::Parser::C < RDoc::Parser
       end
 
       class_obj = find_class var_name, class_name
-
-      al = RDoc::Alias.new '', old_name, new_name, ''
-      al.singleton = @singleton_classes.key? var_name
-
       comment = find_alias_comment var_name, new_name, old_name
-
       comment.normalize
-
-      al.comment = comment
-
-      al.record_location @top_level
-
-      class_obj.add_alias al
-      @stats.add_alias al
+      if comment.to_s.empty? and existing_method = class_obj.method_list.find { |m| m.name == old_name}
+        comment = existing_method.comment
+      end
+      add_alias(var_name, class_obj, old_name, new_name, comment)
     end
+  end
+
+  ##
+  # Add alias, either from a direct alias definition, or from two
+  # method that reference the same function.
+
+  def add_alias(var_name, class_obj, old_name, new_name, comment)
+    al = RDoc::Alias.new '', old_name, new_name, ''
+    al.singleton = @singleton_classes.key? var_name
+    al.comment = comment
+    al.record_location @top_level
+    class_obj.add_alias al
+    @stats.add_alias al
+    al
   end
 
   ##
@@ -1021,6 +985,10 @@ class RDoc::Parser::C < RDoc::Parser
 
     class_obj = find_class var_name, class_name
 
+    if existing_method = class_obj.method_list.find { |m| m.c_function == function }
+      add_alias(var_name, class_obj, existing_method.name, meth_name, existing_method.comment)
+    end
+
     if class_obj then
       if meth_name == 'initialize' then
         meth_name = 'new'
@@ -1248,8 +1216,6 @@ class RDoc::Parser::C < RDoc::Parser
     do_includes
     do_aliases
     do_attrs
-
-    deduplicate_call_seq
 
     @store.add_c_variables self
 


### PR DESCRIPTION
Previously, only calls to rb_define_alias were treated as aliases.
This treats calls to rb_define_method with the same C function as
aliases, with the first function defined being the primary method.

This moves the dedup code from the C parser to AnyMethod, and has
AnyMethod look in its aliases to find the call_seq.

Switch the deduplication code to remove lines matching one of the
other aliases, instead of only keeping lines matching the current
alias.  The previous approach could eliminate all call_seq lines
in cases where no line matched.  This was necessary to pass
tests when call_seq does deduplication by default.

The only change to the darkfish template is to not perform
unnecessary work by deduplicating twice.

Fixes Ruby Bug 9242.