### PR TITLE
Drop JRuby 9.1.17.0

### DIFF
--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2.6.0', 'jruby-9.1.17.0', 'ruby-head' ]
+        ruby: [ 'jruby-9.2.6.0', 'ruby-head' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
It supports Ruby 2.3.x support but RDoc has dropped support of the version.