### PR TITLE
Make `(#methodname)` a link

### DIFF
--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -28,7 +28,7 @@ class RDoc::CrossReference
   # have been suppressed, since the suppression characters are removed by the
   # code that is triggered.
 
-  CROSSREF_REGEXP = /(?:^|\s)
+  CROSSREF_REGEXP = /(?:^|[\s()])
                      (
                       (?:
                        # A::B::C.meth

--- a/test/rdoc/test_rdoc_markup_attribute_manager.rb
+++ b/test/rdoc/test_rdoc_markup_attribute_manager.rb
@@ -358,6 +358,8 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
                   @am.flow("#fred dogs'"))
 
     assert_equal(["cats' ", crossref("#fred")].flatten, @am.flow("cats' #fred"))
+
+    assert_equal(["(", crossref("#fred"), ")"].flatten, @am.flow("(#fred)"))
   end
 
   def test_tt_html


### PR DESCRIPTION
https://twitter.com/schneems/status/1187074925611376642
> The links at the top of base64.rb are broken in the class docs. I think there needs to be a space after the `(` but before the `#` so `(#encode64` would become `( #encode64`.