### PR TITLE
update all files if any file is newer

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -755,7 +755,7 @@ Usage: #{opt.program_name} [options] [names...]
 
       opt.on("--[no-]force-update", "-U",
              "Forces rdoc to scan all sources even if",
-             "newer than the flag file.") do |value|
+             "no files are newer than the flag file.") do |value|
         @force_update = value
       end
 

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -112,11 +112,17 @@ class RDoc::RDoc
 
     file_list = normalized_file_list files, true, @options.exclude
 
-    file_list = file_list.uniq
+    file_list = remove_unparseable(file_list)
 
-    file_list = remove_unparseable file_list
-
-    file_list.sort
+    if file_list.count {|name, mtime|
+         file_list[name] = @last_modified[name] unless mtime
+         mtime
+       } > 0
+      @last_modified.replace file_list
+      file_list.keys.sort
+    else
+      []
+    end
   end
 
   ##
@@ -254,11 +260,11 @@ option)
     # read and strip comments
     patterns = File.read(filename).gsub(/#.*/, '')
 
-    result = []
+    result = {}
 
     patterns.split.each do |patt|
       candidates = Dir.glob(File.join(in_dir, patt))
-      result.concat normalized_file_list(candidates, false, @options.exclude)
+      result.update normalized_file_list(candidates, false, @options.exclude)
     end
 
     result
@@ -278,21 +284,21 @@ option)
 
   def normalized_file_list(relative_files, force_doc = false,
                            exclude_pattern = nil)
-    file_list = []
+    file_list = {}
 
     relative_files.each do |rel_file_name|
+      rel_file_name = rel_file_name.sub(/^\.\//, '')
       next if rel_file_name.end_with? 'created.rid'
       next if exclude_pattern && exclude_pattern =~ rel_file_name
       stat = File.stat rel_file_name rescue next
 
       case type = stat.ftype
       when "file" then
-        next if last_modified = @last_modified[rel_file_name] and
-                stat.mtime.to_i <= last_modified.to_i
+        mtime = (stat.mtime unless (last_modified = @last_modified[rel_file_name] and
+                                    stat.mtime.to_i <= last_modified.to_i))
 
         if force_doc or RDoc::Parser.can_parse(rel_file_name) then
-          file_list << rel_file_name.sub(/^\.\//, '')
-          @last_modified[rel_file_name] = stat.mtime
+          file_list[rel_file_name] = mtime
         end
       when "directory" then
         next if rel_file_name == "CVS" || rel_file_name == ".svn"
@@ -303,16 +309,16 @@ option)
         dot_doc = File.join rel_file_name, RDoc::DOT_DOC_FILENAME
 
         if File.file? dot_doc then
-          file_list << parse_dot_doc_file(rel_file_name, dot_doc)
+          file_list.update(parse_dot_doc_file(rel_file_name, dot_doc))
         else
-          file_list << list_files_in_directory(rel_file_name)
+          file_list.update(list_files_in_directory(rel_file_name))
         end
       else
         warn "rdoc can't parse the #{type} #{rel_file_name}"
       end
     end
 
-    file_list.flatten
+    file_list
   end
 
   ##
@@ -427,7 +433,7 @@ The internal error was:
   # files for emacs and vim.
 
   def remove_unparseable files
-    files.reject do |file|
+    files.reject do |file, *|
       file =~ /\.(?:class|eps|erb|scpt\.txt|svg|ttf|yml)$/i or
         (file =~ /tags$/i and
          open(file, 'rb') { |io|

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -73,6 +73,11 @@ class TestRDocRDoc < RDoc::TestCase
     b = File.expand_path '../test_rdoc_text.rb', __FILE__
 
     assert_equal [a, b], @rdoc.gather_files([b, a, b])
+
+    assert_empty @rdoc.gather_files([b, a, b])
+
+    @rdoc.last_modified[a] -= 10
+    assert_equal [a, b], @rdoc.gather_files([b, a, b])
   end
 
   def test_handle_pipe
@@ -146,7 +151,7 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.normalized_file_list [test_path, flag_file]
     end
 
-    files = files.map { |file| File.expand_path file }
+    files = files.map { |file, *| File.expand_path file }
 
     assert_equal [test_path], files
   end
@@ -156,7 +161,9 @@ class TestRDocRDoc < RDoc::TestCase
 
     files = @rdoc.normalized_file_list [__FILE__]
 
-    assert_empty files
+    files = files.collect {|file, mtime| file if mtime}.compact
+
+    assert_empty(files)
   end
 
   def test_normalized_file_list_non_file_directory
@@ -205,7 +212,7 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.normalized_file_list [File.realpath(dir)]
     end
 
-    files = files.map { |file| File.expand_path file }
+    files = files.map { |file, *| File.expand_path file }
 
     assert_equal expected_files, files
   end
@@ -236,7 +243,7 @@ class TestRDocRDoc < RDoc::TestCase
       @rdoc.normalized_file_list [File.realpath(dir)]
     end
 
-    files = files.map { |file| File.expand_path file }
+    files = files.map { |file, *| File.expand_path file }
 
     assert_equal expected_files, files
   end


### PR DESCRIPTION
Cross references need parse all files which define the subject names.  This commit makes `--force-update` option enforce to parse all files if any file is newer than the previous parse, not only updated files.
