### PR TITLE
Separate off test of RDoc::RubygemsHook

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake/testtask'
 require 'rubocop/rake_task'
 
 task :docs    => :generate
-task :test    => [:normal_test, :rubygems_test, :generate]
+task :test    => [:normal_test, :rubygems_test]
 
 PARSER_FILES = %w[
   lib/rdoc/rd/block_parser.ry
@@ -37,12 +37,14 @@ end
 Rake::TestTask.new(:normal_test) do |t|
   t.libs << "test/rdoc"
   t.verbose = true
+  t.deps = :generate
   t.test_files = FileList["test/**/test_*.rb"].exclude("test/rdoc/test_rdoc_rubygems_hook.rb")
 end
 
 Rake::TestTask.new(:rubygems_test) do |t|
   t.libs << "test/rdoc"
   t.verbose = true
+  t.deps = :generate
   t.pattern = "test/rdoc/test_rdoc_rubygems_hook.rb"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake/testtask'
 require 'rubocop/rake_task'
 
 task :docs    => :generate
-task :test    => :generate
+task :test    => [:normal_test, :rubygems_test, :generate]
 
 PARSER_FILES = %w[
   lib/rdoc/rd/block_parser.ry
@@ -34,10 +34,16 @@ task ghpages: :rdoc do
   FileUtils.cp_r Dir.glob("/tmp/html/*"), "."
 end
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new(:normal_test) do |t|
   t.libs << "test/rdoc"
   t.verbose = true
-  t.test_files = FileList['test/**/test_*.rb']
+  t.test_files = FileList["test/**/test_*.rb"].exclude("test/rdoc/test_rdoc_rubygems_hook.rb")
+end
+
+Rake::TestTask.new(:rubygems_test) do |t|
+  t.libs << "test/rdoc"
+  t.verbose = true
+  t.pattern = "test/rdoc/test_rdoc_rubygems_hook.rb"
 end
 
 path = "pkg/#{Bundler::GemHelper.gemspec.full_name}"

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -555,7 +555,13 @@ class RDoc::Options
 
     @files << @page_dir.to_s
 
-    page_dir = @page_dir.expand_path.relative_path_from @root
+    page_dir = nil
+    begin
+      page_dir = @page_dir.expand_path.relative_path_from @root
+    rescue ArgumentError
+      # On Windows, sometimes crosses different drive letters.
+      page_dir = @page_dir.expand_path
+    end
 
     @page_dir = page_dir
   end
@@ -1154,8 +1160,17 @@ Usage: #{opt.program_name} [options] [names...]
 
     path.reject do |item|
       path = Pathname.new(item).expand_path
-      relative = path.relative_path_from(dot).to_s
-      relative.start_with? '..'
+      is_reject = nil
+      relative = nil
+      begin
+        relative = path.relative_path_from(dot).to_s
+      rescue ArgumentError
+        # On Windows, sometimes crosses different drive letters.
+        is_reject = true
+      else
+        is_reject = relative.start_with? '..'
+      end
+      is_reject
     end
   end
 

--- a/test/rdoc/test_rdoc_generator_json_index.rb
+++ b/test/rdoc/test_rdoc_generator_json_index.rb
@@ -168,7 +168,7 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     begin
       require 'zlib'
     rescue LoadError
-      skip "no zlib"
+      omit "no zlib"
     end
     @g.generate
     @g.generate_gzipped

--- a/test/rdoc/test_rdoc_i18n_locale.rb
+++ b/test/rdoc/test_rdoc_i18n_locale.rb
@@ -32,7 +32,7 @@ class TestRDocI18nLocale < RDoc::TestCase
     begin
       require 'gettext/po_parser'
     rescue LoadError
-      skip 'gettext gem is not found'
+      omit 'gettext gem is not found'
     end
 
     fr_locale_dir = File.join @locale_dir, 'fr'

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -17,8 +17,8 @@ class TestRDocOptions < RDoc::TestCase
   end
 
   def test_check_files
-    skip "assumes UNIX permission model" if /mswin|mingw/ =~ RUBY_PLATFORM
-    skip "assumes that euid is not root" if Process.euid == 0
+    omit "assumes UNIX permission model" if /mswin|mingw/ =~ RUBY_PLATFORM
+    omit "assumes that euid is not root" if Process.euid == 0
 
     out, err = capture_output do
       temp_dir do

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -493,8 +493,14 @@ rdoc_include:
     assert_empty out
     assert_empty err
 
-    expected =
-      Pathname(Dir.tmpdir).expand_path.relative_path_from @options.root
+    expected = nil
+    begin
+      expected =
+        Pathname(Dir.tmpdir).expand_path.relative_path_from @options.root
+    rescue ArgumentError
+      # On Windows, sometimes crosses different drive letters.
+      expected = Pathname(Dir.tmpdir).expand_path
+    end
 
     assert_equal expected,     @options.page_dir
     assert_equal [Dir.tmpdir], @options.files

--- a/test/rdoc/test_rdoc_parser.rb
+++ b/test/rdoc/test_rdoc_parser.rb
@@ -104,7 +104,7 @@ class TestRDocParser < RDoc::TestCase
   end
 
   def test_class_for_forbidden
-    skip 'chmod not supported' if Gem.win_platform?
+    omit 'chmod not supported' if Gem.win_platform?
 
     tf = Tempfile.open 'forbidden' do |io|
       begin

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -163,7 +163,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_normalized_file_list_non_file_directory
     dev = File::NULL
-    skip "#{dev} is not a character special" unless
+    omit "#{dev} is not a character special" unless
       File.chardev? dev
 
     files = nil
@@ -349,8 +349,8 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file_forbidden
-    skip 'chmod not supported' if Gem.win_platform?
-    skip "assumes that euid is not root" if Process.euid == 0
+    omit 'chmod not supported' if Gem.win_platform?
+    omit "assumes that euid is not root" if Process.euid == 0
 
     @rdoc.store = RDoc::Store.new
 

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -190,6 +190,10 @@ class TestRDocRDoc < RDoc::TestCase
       FileUtils.touch a
       FileUtils.touch b
       FileUtils.touch c
+      # Use Dir.glob to convert short path of Dir.tmpdir to long path.
+      a = Dir.glob(a).first
+      b = Dir.glob(b).first
+      c = Dir.glob(c).first
 
       dot_doc = File.expand_path('.document')
       FileUtils.touch dot_doc
@@ -217,6 +221,10 @@ class TestRDocRDoc < RDoc::TestCase
       FileUtils.touch a
       FileUtils.touch b
       FileUtils.touch c
+      # Use Dir.glob to convert short path of Dir.tmpdir to long path.
+      a = Dir.glob(a).first
+      b = Dir.glob(b).first
+      c = Dir.glob(c).first
 
       dot_doc = File.expand_path('.document')
       FileUtils.touch dot_doc

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -1029,7 +1029,7 @@ Foo::Bar#bother
   end
 
   def test_did_you_mean
-    skip 'skip test with did_you_men' unless defined? DidYouMean::SpellChecker
+    omit 'skip test with did_you_men' unless defined? DidYouMean::SpellChecker
 
     util_ancestors_store
 
@@ -1227,7 +1227,7 @@ Foo::Bar#bother
 
     with_dummy_pager do
       @driver.page do |io|
-        skip "couldn't find a standard pager" if io == $stdout
+        omit "couldn't find a standard pager" if io == $stdout
 
         assert @driver.paging?
       end
@@ -1406,7 +1406,7 @@ Foo::Bar#bother
 
     pager = with_dummy_pager do @driver.setup_pager end
 
-    skip "couldn't find a standard pager" unless pager
+    omit "couldn't find a standard pager" unless pager
 
     assert @driver.paging?
   ensure

--- a/test/rdoc/test_rdoc_servlet.rb
+++ b/test/rdoc/test_rdoc_servlet.rb
@@ -294,7 +294,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_if_modified_since
-    skip 'File.utime on directory not supported' if Gem.win_platform?
+    omit 'File.utime on directory not supported' if Gem.win_platform?
 
     temp_dir do
       now = Time.now
@@ -307,7 +307,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_if_modified_since_not_modified
-    skip 'File.utime on directory not supported' if Gem.win_platform?
+    omit 'File.utime on directory not supported' if Gem.win_platform?
 
     temp_dir do
       now = Time.now


### PR DESCRIPTION
RDoc uses test-unit but RubyGems uses minitest. `RDoc::RubygemsHook` is a part of RubyGems so its test also uses minitest. Rakefile of RDoc runs both tests at one time so always only `RDoc::RubygemsHook`'s test runs. All other tests do never be run. So modified Rakefile to be run both tests separately.