### PR TITLE
Treat Proc#call syntax sugar for constant correctly

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -379,6 +379,10 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
       get_tk
       skip_tkspace_without_nl
+      if :on_lparen == peek_tk[:kind] # ProcObjectInConstant::()
+        parse_method_or_yield_parameters
+        break
+      end
       name_t = get_tk
       unless :on_const == name_t[:kind] || :on_ident == name_t[:kind]
         raise RDoc::Error, "Invalid class or module definition: #{given_name}"

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -830,6 +830,17 @@ end
     assert_equal @top_level, blah.file
   end
 
+  def test_parse_call_syntax_sugar_for_constant
+    util_parser <<-CODE
+Foo = proc{}
+Foo::()
+    CODE
+
+    assert_nothing_raised do
+      @parser.scan
+    end
+  end
+
   def test_parse_class_multi_ghost_methods
     util_parser <<-'CLASS'
 class Foo


### PR DESCRIPTION
This fixes https://github.com/ruby/rdoc/issues/752.