### PR TITLE
Support newline in the middle of constant definition

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -378,7 +378,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       record_location container
 
       get_tk
-      skip_tkspace_without_nl
+      skip_tkspace
       if :on_lparen == peek_tk[:kind] # ProcObjectInConstant::()
         parse_method_or_yield_parameters
         break

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -100,7 +100,7 @@ class C; end
     assert_equal 'E', name_t[:text]
     assert_equal 'D::E', given_name
 
-    assert_raise RDoc::Error do
+    assert_nothing_raised do
       util_parser("A::\nB").get_class_or_module ctxt
     end
   end


### PR DESCRIPTION
This fixes https://github.com/ruby/rdoc/issues/745.