### PR TITLE
Update link to GFM specification

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -176,7 +176,7 @@
 # The port to kpeg was performed by Eric Hodel and Evan Phoenix
 #
 # [dingus]: http://daringfireball.net/projects/markdown/dingus
-# [GFM]: http://github.github.com/github-flavored-markdown/
+# [GFM]: https://github.github.com/gfm/
 # [pegmarkdown]: https://github.com/jgm/peg-markdown
 # [PHPE]: http://michelf.com/projects/php-markdown/extra/#def-list
 # [syntax]: http://daringfireball.net/projects/markdown/syntax


### PR DESCRIPTION
This pull request will update the GitHub Flavored Markdown specification link.
The old link looks expired. It redirects to https://help.github.com/en/github/writing-on-github, but the destination is not the specification. It looks "how to use GitHub".




---


The original idea is https://github.com/rurema/doctree/pull/1474 (Japanese issue), by @sho-h. Thanks.