### PR TITLE
Removed `RDoc::Context::Section#sequence`

### DIFF
--- a/lib/rdoc/context/section.rb
+++ b/lib/rdoc/context/section.rb
@@ -34,17 +34,12 @@ class RDoc::Context::Section
 
   attr_reader :title
 
-  @@sequence = "SEC00000"
-
   ##
   # Creates a new section with +title+ and +comment+
 
   def initialize parent, title, comment
     @parent = parent
     @title = title ? title.strip : title
-
-    @@sequence = @@sequence.succ
-    @sequence = @@sequence.dup
 
     @comments = []
 
@@ -231,14 +226,6 @@ class RDoc::Context::Section
     else
       raise RDoc::Error, "BUG: unknown comment class #{@comments.class}"
     end
-  end
-
-  ##
-  # Section sequence number (deprecated)
-
-  def sequence
-    warn "RDoc::Context::Section#sequence is deprecated, use #aref"
-    @sequence
   end
 
 end

--- a/test/rdoc/test_rdoc_context_section.rb
+++ b/test/rdoc/test_rdoc_context_section.rb
@@ -143,13 +143,5 @@ class TestRDocContextSection < RDoc::TestCase
     assert_equal doc(other_comment.parse), loaded.comments
   end
 
-  def test_sequence
-    _, err = verbose_capture_output do
-      assert_match(/\ASEC\d{5}\Z/, @s.sequence)
-    end
-
-    assert_equal "#{@S}#sequence is deprecated, use #aref\n", err
-  end
-
 end
 


### PR DESCRIPTION
It has been deprecated since 2011.