### PR TITLE
Escape method names in HTML

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -144,7 +144,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
       path = ref.as_href @from_path
 
       if code and RDoc::CodeObject === ref and !(RDoc::TopLevel === ref)
-        text = "<code>#{text}</code>"
+        text = "<code>#{CGI.escapeHTML text}</code>"
       end
 
       if path =~ /#/ then

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -89,6 +89,20 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
     assert_equal para("<a href=\"C1.html#method-c-25\"><code>C1::%</code></a>"), result
   end
 
+  def test_convert_RDOCLINK_rdoc_ref_method_escape_html
+    m = @c1.add_method RDoc::AnyMethod.new nil, '<<'
+    m.singleton = false
+
+    result = @to.convert 'rdoc-ref:C1#<<'
+
+    assert_equal para("<a href=\"C1.html#method-i-3C-3C\"><code>C1#&lt;&lt;</code></a>"), result
+    m.singleton = true
+
+    result = @to.convert 'rdoc-ref:C1::<<'
+
+    assert_equal para("<a href=\"C1.html#method-c-3C-3C\"><code>C1::&lt;&lt;</code></a>"), result
+  end
+
   def test_convert_RDOCLINK_rdoc_ref_method_percent_label
     m = @c1.add_method RDoc::AnyMethod.new nil, '%'
     m.singleton = false


### PR DESCRIPTION
The following is invalid HTML:
```html
<a href="Array.html#method-i-3C-3C"><code><<</code></a></p>
```

Incorrect:
```html
<code><<</code>
```

Correct:
```html
<code>&lt;&lt;</code>
```

Fixes #761