### PR TITLE
Process crossref before tidylink

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -52,12 +52,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
     @th = nil
     @hard_break = "<br>\n"
 
-    # external links
-    @markup.add_regexp_handling(/(?:link:|https?:|mailto:|ftp:|irc:|www\.)\S+\w/,
-                                :HYPERLINK)
-
-    add_regexp_handling_RDOCLINK
-    add_regexp_handling_TIDYLINK
+    init_regexp_handlings
 
     init_tags
   end
@@ -65,6 +60,24 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # :section: Regexp Handling
   #
   # These methods are used by regexp handling markup added by RDoc::Markup#add_regexp_handling.
+
+  ##
+  # Adds regexp handlings.
+
+  def init_regexp_handlings
+    # external links
+    @markup.add_regexp_handling(/(?:link:|https?:|mailto:|ftp:|irc:|www\.)\S+\w/,
+                                :HYPERLINK)
+    init_link_notation_regexp_handlings
+  end
+
+  ##
+  # Adds regexp handlings about link notations.
+
+  def init_link_notation_regexp_handlings
+    add_regexp_handling_RDOCLINK
+    add_regexp_handling_TIDYLINK
+  end
 
   def handle_RDOCLINK url # :nodoc:
     case url

--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -39,10 +39,18 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
     @hyperlink_all = @options.hyperlink_all
     @show_hash     = @options.show_hash
 
-    crossref_re = @hyperlink_all ? ALL_CROSSREF_REGEXP : CROSSREF_REGEXP
+    @cross_reference = RDoc::CrossReference.new @context
+  end
+
+  def init_link_notation_regexp_handlings
+    add_regexp_handling_RDOCLINK
+
+    # The crossref must be linked before tidylink because Klass.method[:sym]
+    # will be processed as a tidylink first and will be broken.
+    crossref_re = @options.hyperlink_all ? ALL_CROSSREF_REGEXP : CROSSREF_REGEXP
     @markup.add_regexp_handling crossref_re, :CROSSREF
 
-    @cross_reference = RDoc::CrossReference.new @context
+    add_regexp_handling_TIDYLINK
   end
 
   ##

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -151,6 +151,13 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
                  REGEXP_HANDLING('#m')
   end
 
+  def test_handle_regexp_CROSSREF_with_arg_looks_like_TIDYLINK
+    result = @to.convert 'C1.m[:sym]'
+
+    assert_equal para("<a href=\"C1.html#method-c-m\"><code>C1.m[:sym]</code></a>"), result,
+                 'C1.m[:sym]'
+  end
+
   def test_handle_regexp_HYPERLINK_rdoc
     readme = @store.add_file 'README.txt'
     readme.parser = RDoc::Parser::Simple


### PR DESCRIPTION
The crossref must be linked before tidylink because `Klass.method[:sym]` will be processed as a tidylink first and will be broken.