### PR TITLE
Fixed inadvertent environment variable changes

### DIFF
--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -8,6 +8,8 @@ require 'rdoc/markdown'
 class TestRDocMarkdown < RDoc::TestCase
 
   def setup
+    super
+
     @RM = RDoc::Markup
 
     @parser = RDoc::Markdown.new

--- a/test/rdoc/test_rdoc_parser_changelog.rb
+++ b/test/rdoc/test_rdoc_parser_changelog.rb
@@ -14,6 +14,8 @@ class TestRDocParserChangeLog < RDoc::TestCase
 
   def teardown
     @tempfile.close!
+
+    super
   end
 
   def test_class_can_parse

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -13,7 +13,6 @@ class TestRDocRIDriver < RDoc::TestCase
     FileUtils.mkdir_p @home_ri
 
     @orig_ri = ENV['RI']
-    @orig_home = ENV['HOME']
     ENV['HOME'] = @tmpdir
     @rdoc_home = File.join ENV["HOME"], ".rdoc"
     FileUtils.mkdir_p @rdoc_home
@@ -33,7 +32,6 @@ class TestRDocRIDriver < RDoc::TestCase
   end
 
   def teardown
-    ENV['HOME'] = @orig_home
     ENV['RI'] = @orig_ri
     FileUtils.rm_rf @tmpdir
 

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -33,11 +33,11 @@ class TestRDocRIDriver < RDoc::TestCase
   end
 
   def teardown
-    super
-
     ENV['HOME'] = @orig_home
     ENV['RI'] = @orig_ri
     FileUtils.rm_rf @tmpdir
+
+    super
   end
 
   DUMMY_PAGER = ":;\n"

--- a/test/rdoc/test_rdoc_ri_paths.rb
+++ b/test/rdoc/test_rdoc_ri_paths.rb
@@ -36,12 +36,12 @@ class TestRDocRIPaths < RDoc::TestCase
   end
 
   def teardown
-    super
-
     Gem.use_paths(*@orig_gem_path)
     Gem::Specification.reset
     FileUtils.rm_rf @tempdir
     ENV.replace(@orig_env)
+
+    super
   end
 
   def test_class_each


### PR DESCRIPTION
https://github.com/ruby/ruby/runs/615268864?check_suite_focus=true#step:14:136
```
Environment variable changed: TestRDocMarkdown#test_class_parse : "HOME" deleted
Environment variable changed: TestRDocParserChangeLog#test_class_can_parse : "HOME" added
Environment variable changed: TestRDocRIDriver#test_add_also_in : "HOME" changed : "/home/runner" -> "/tmp"
```