### PR TITLE
Fixed inverted CSS for note-list and label-list

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -276,7 +276,7 @@ ul.link-list .type {
   -webkit-border-radius: 5px;
 }
 
-dl.label-list dt {
+dl.note-list dt {
   float: left;
   margin-right: 1em;
 }


### PR DESCRIPTION
ruby/ruby@33d026034e68 was misread.

"note-list" seems to be compact.

> If you want the list bodies to line up to the left of the labels, use two colons:
