### PR TITLE
Fix RDoc::Context#instance_method_list

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -1003,8 +1003,8 @@ class RDoc::Context < RDoc::CodeObject
   # TODO remove this later
 
   def instance_method_list
-    @instance_methods ||= method_list.reject { |a| a.singleton }
     warn '#instance_method_list is obsoleted, please use #instance_methods'
+    @instance_methods ||= method_list.reject { |a| a.singleton }
   end
 
   ##


### PR DESCRIPTION
The `warn` method returns `nil`, it's a bug of `#instance_method_list`.