### PR TITLE
Remove empty lines from html file by using ERB trim_mode flag

### DIFF
--- a/lib/rdoc/generator/template/darkfish/_head.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_head.rhtml
@@ -15,9 +15,8 @@
 
 <link href="<%= asset_rel_prefix %>/css/fonts.css" rel="stylesheet">
 <link href="<%= asset_rel_prefix %>/css/rdoc.css" rel="stylesheet">
-<% if @options.template_stylesheets.flatten.any? then %>
-<%   @options.template_stylesheets.flatten.each do |stylesheet| %>
+<%- if @options.template_stylesheets.flatten.any? then -%>
+<%-   @options.template_stylesheets.flatten.each do |stylesheet| -%>
 <link href="<%= asset_rel_prefix %>/<%= File.basename stylesheet %>" rel="stylesheet">
-<%   end %>
-<% end %>
-
+<%-   end -%>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_VCS_info.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_VCS_info.rhtml
@@ -1,4 +1,4 @@
-<% if !svninfo.empty? then %>
+<%- if !svninfo.empty? then %>
 <div id="file-svninfo-section" class="nav-section">
   <h3>VCS Info</h3>
 
@@ -16,4 +16,4 @@
     </dl>
   </div>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
@@ -2,8 +2,8 @@
   <h3>Class and Module Index</h3>
 
   <ul class="link-list">
-  <% @modsort.each do |index_klass| %>
+  <%- @modsort.each do |index_klass| -%>
     <li><a href="<%= rel_prefix %>/<%= index_klass.path %>"><%= index_klass.full_name %></a>
-  <% end %>
+  <%- end -%>
   </ul>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
@@ -1,15 +1,15 @@
-<% unless klass.extends.empty? then %>
+<%- unless klass.extends.empty? then %>
 <div id="extends-section" class="nav-section">
   <h3>Extended With Modules</h3>
 
   <ul class="link-list">
-    <% klass.each_extend do |ext| %>
-  <% unless String === ext.module then %>
+    <%- klass.each_extend do |ext| -%>
+  <%- unless String === ext.module then -%>
     <li><a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a>
-  <% else %>
+  <%- else -%>
     <li><span class="extend"><%= ext.name %></span>
-  <% end %>
-  <% end %>
+  <%- end -%>
+  <%- end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_in_files.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_in_files.rhtml
@@ -2,8 +2,8 @@
   <h3>Defined In</h3>
 
   <ul>
-<% klass.in_files.each do |tl| %>
+<%- klass.in_files.each do |tl| -%>
     <li><%= h tl.relative_name %>
-<% end %>
+<%- end -%>
   </ul>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
@@ -1,15 +1,15 @@
-<% unless klass.includes.empty? then %>
+<%- unless klass.includes.empty? then %>
 <div id="includes-section" class="nav-section">
   <h3>Included Modules</h3>
 
   <ul class="link-list">
-  <% klass.each_include do |inc| %>
-  <% unless String === inc.module then %>
+  <%- klass.each_include do |inc| -%>
+  <%- unless String === inc.module then -%>
     <li><a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a>
-  <% else %>
+  <%- else -%>
     <li><span class="include"><%= inc.name %></span>
-  <% end %>
-  <% end %>
+  <%- end -%>
+  <%- end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_installed.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_installed.rhtml
@@ -2,14 +2,14 @@
   <h3>Documentation</h3>
 
   <ul>
-  <% installed.each do |name, href, exists, type, _| %>
-    <% next if type == :extra %>
+  <%- installed.each do |name, href, exists, type, _| -%>
+    <%- next if type == :extra -%>
     <li class="folder">
-    <% if exists then %>
+    <%- if exists then -%>
       <a href="<%= href %>"><%= h name %></a>
-    <% else %>
+    <%- else -%>
       <%= h name %>
-    <% end %>
-  <% end %>
+    <%- end -%>
+  <%- end -%>
   </ul>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_methods.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_methods.rhtml
@@ -1,12 +1,12 @@
-<% unless klass.method_list.empty? then %>
+<%- unless klass.method_list.empty? then %>
 <!-- Method Quickref -->
 <div id="method-list-section" class="nav-section">
   <h3>Methods</h3>
 
   <ul class="link-list" role="directory">
-    <% klass.each_method do |meth| %>
-    <li <% if meth.calls_super %>class="calls-super" <% end %>><a href="#<%= meth.aref %>"><%= meth.singleton ? '::' : '#' %><%= h meth.name %></a>
-    <% end %>
+    <%- klass.each_method do |meth| -%>
+    <li <%- if meth.calls_super %>class="calls-super" <%- end %>><a href="#<%= meth.aref %>"><%= meth.singleton ? '::' : '#' %><%= h meth.name -%></a>
+    <%- end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_pages.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_pages.rhtml
@@ -1,12 +1,12 @@
-<% simple_files = @files.select { |f| f.text? } %>
-<% unless simple_files.empty? then %>
+<%- simple_files = @files.select { |f| f.text? } %>
+<%- unless simple_files.empty? then -%>
 <div id="fileindex-section" class="nav-section">
   <h3>Pages</h3>
 
   <ul class="link-list">
-  <% simple_files.each do |f| %>
+  <%- simple_files.each do |f| -%>
     <li><a href="<%= rel_prefix %>/<%= f.path %>"><%= h f.page_name %></a>
-  <% end %>
+  <%- end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_parent.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_parent.rhtml
@@ -1,11 +1,11 @@
-<% if klass.type == 'class' then %>
+<%- if klass.type == 'class' then %>
 <div id="parent-class-section" class="nav-section">
   <h3>Parent</h3>
 
-  <% if klass.superclass and not String === klass.superclass then %>
+  <%- if klass.superclass and not String === klass.superclass then -%>
   <p class="link"><a href="<%= klass.aref_to klass.superclass.path %>"><%= klass.superclass.full_name %></a>
-  <% else %>
+  <%- else -%>
   <p class="link"><%= klass.superclass %>
-  <% end %>
+  <%- end -%>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_sections.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_sections.rhtml
@@ -1,11 +1,11 @@
-<% unless klass.sections.length == 1 then %>
+<%- unless klass.sections.length == 1 then %>
 <div id="sections-section" class="nav-section">
   <h3>Sections</h3>
 
   <ul class="link-list" role="directory">
-    <% klass.sort_sections.each do |section| %>
+    <%- klass.sort_sections.each do |section| -%>
       <li><a href="#<%= section.aref %>"><%= h section.title %></a></li>
-    <% end %>
+    <%- end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_table_of_contents.rhtml
@@ -1,4 +1,4 @@
-<% comment = if current.respond_to? :comment_location then
+<%- comment = if current.respond_to? :comment_location then
                current.comment_location
              else
                current.comment
@@ -10,9 +10,9 @@
   <h3>Table of Contents</h3>
 
   <ul class="link-list" role="directory">
-<%   table.each do |heading| %>
+<%-   table.each do |heading| -%>
     <li><a href="#<%= heading.label current %>"><%= heading.plain_html %></a>
-<%   end %>
+<%-   end -%>
   </ul>
 </div>
-<% end %>
+<%- end -%>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -25,9 +25,9 @@
     <%= klass.description %>
   </section>
 
-  <% klass.each_section do |section, constants, attributes| %>
+  <%- klass.each_section do |section, constants, attributes| -%>
   <section id="<%= section.aref %>" class="documentation-section">
-    <% if section.title then %>
+    <%- if section.title then -%>
     <header class="documentation-section-title">
       <h2>
         <%= section.title %>
@@ -36,39 +36,39 @@
         <a href="#top">&uarr; top</a>
       </span>
     </header>
-    <% end %>
+    <%- end -%>
 
-    <% if section.comment then %>
+    <%- if section.comment then -%>
     <div>
       <%= section.description %>
     </div>
-    <% end %>
+    <%- end -%>
 
-    <% unless constants.empty? then %>
+    <%- unless constants.empty? then -%>
     <section class="constants-list">
       <header>
         <h3>Constants</h3>
       </header>
       <dl>
-      <% constants.each do |const| %>
+      <%- constants.each do |const| -%>
         <dt id="<%= const.name %>"><%= const.name %>
-        <% if const.comment then %>
+        <%- if const.comment then -%>
         <dd><%= const.description.strip %>
-        <% else %>
+        <%- else -%>
         <dd class="missing-docs">(Not documented)
-        <% end %>
-      <% end %>
+        <%- end -%>
+      <%- end -%>
       </dl>
     </section>
-    <% end %>
+    <%- end -%>
 
-    <% unless attributes.empty? then %>
+    <%- unless attributes.empty? then -%>
     <section class="attribute-method-details" class="method-section">
       <header>
         <h3>Attributes</h3>
       </header>
 
-      <% attributes.each do |attrib| %>
+      <%- attributes.each do |attrib| -%>
       <div id="<%= attrib.aref %>" class="method-detail">
         <div class="method-heading attribute-method-heading">
           <span class="method-name"><%= h attrib.name %></span><span
@@ -76,18 +76,18 @@
         </div>
 
         <div class="method-description">
-        <% if attrib.comment then %>
+        <%- if attrib.comment then -%>
         <%= attrib.description.strip %>
-        <% else %>
+        <%- else -%>
         <p class="missing-docs">(Not documented)
-        <% end %>
+        <%- end -%>
         </div>
       </div>
-      <% end %>
+      <%- end -%>
     </section>
-    <% end %>
+    <%- end -%>
 
-    <% klass.methods_by_type(section).each do |type, visibilities|
+    <%- klass.methods_by_type(section).each do |type, visibilities|
        next if visibilities.empty?
        visibilities.each do |visibility, methods|
          next if methods.empty? %>
@@ -96,38 +96,38 @@
          <h3><%= visibility.to_s.capitalize %> <%= type.capitalize %> Methods</h3>
        </header>
 
-    <% methods.each do |method| %>
+    <%- methods.each do |method| -%>
       <div id="<%= method.aref %>" class="method-detail <%= method.is_alias_for ? "method-alias" : '' %>">
-        <% if (call_seq = method.call_seq) then %>
-        <%   call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
+        <%- if (call_seq = method.call_seq) then -%>
+        <%-   call_seq.strip.split("\n").each_with_index do |call_seq, i| -%>
         <div class="method-heading">
           <span class="method-callseq">
             <%= h(call_seq.strip.
                   gsub( /^\w+\./m, '')).
                   gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
           </span>
-          <% if i == 0 and method.token_stream then %>
+          <%- if i == 0 and method.token_stream then -%>
           <span class="method-click-advice">click to toggle source</span>
-          <% end %>
+          <%- end -%>
         </div>
-        <%   end %>
-        <% else %>
+        <%-   end -%>
+        <%- else -%>
         <div class="method-heading">
           <span class="method-name"><%= h method.name %></span><span
             class="method-args"><%= h method.param_seq %></span>
-          <% if method.token_stream then %>
+          <%- if method.token_stream then -%>
           <span class="method-click-advice">click to toggle source</span>
-          <% end %>
+          <%- end -%>
         </div>
-        <% end %>
+        <%- end -%>
 
         <div class="method-description">
-          <% if method.comment then %>
+          <%- if method.comment then -%>
           <%= method.description.strip %>
-          <% else %>
+          <%- else -%>
           <p class="missing-docs">(Not documented)
-          <% end %>
-          <% if method.calls_super then %>
+          <%- end -%>
+          <%- if method.calls_super then -%>
             <div class="method-calls-super">
               Calls superclass method
               <%=
@@ -135,16 +135,16 @@
                   method.formatter.link(method.superclass_method.full_name, method.superclass_method.full_name) : nil
               %>
             </div>
-          <% end %>
+          <%- end -%>
 
-          <% if method.token_stream then %>
+          <%- if method.token_stream then -%>
           <div class="method-source-code" id="<%= method.html_name %>-source">
             <pre><%= method.markup_code %></pre>
           </div>
-          <% end %>
+          <%- end -%>
         </div>
 
-        <% unless method.aliases.empty? then %>
+        <%- unless method.aliases.empty? then -%>
         <div class="aliases">
           Also aliased as: <%= method.aliases.map do |aka|
             if aka.parent then # HACK lib/rexml/encodings
@@ -154,19 +154,19 @@
             end
           end.join ", " %>
         </div>
-        <% end %>
+        <%- end -%>
 
-        <% if method.is_alias_for then %>
+        <%- if method.is_alias_for then -%>
         <div class="aliases">
           Alias for: <a href="<%= klass.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
         </div>
-        <% end %>
+        <%- end -%>
       </div>
 
-    <% end %>
+    <%- end -%>
     </section>
-  <% end
+  <%- end
      end %>
   </section>
-<% end %>
+<%- end -%>
 </main>

--- a/lib/rdoc/generator/template/darkfish/index.rhtml
+++ b/lib/rdoc/generator/template/darkfish/index.rhtml
@@ -13,11 +13,10 @@
 </nav>
 
 <main role="main">
-<% if @options.main_page and
+<%- if @options.main_page and
       main_page = @files.find { |f| f.full_name == @options.main_page } then %>
 <%= main_page.description %>
-<% else %>
+<%- else -%>
 <p>This is the API documentation for <%= @title %>.
-<% end %>
+<%- end -%>
 </main>
-

--- a/lib/rdoc/generator/template/darkfish/servlet_root.rhtml
+++ b/lib/rdoc/generator/template/darkfish/servlet_root.rhtml
@@ -19,28 +19,28 @@
   <p>Here you can browse local documentation from the ruby standard library and
   your installed gems.
 
-<% extra_dirs = installed.select { |_, _, _, type,| type == :extra } %>
-<% unless extra_dirs.empty? %>
+<%- extra_dirs = installed.select { |_, _, _, type,| type == :extra } -%>
+<%- unless extra_dirs.empty? -%>
   <h2>Extra Documentation Directories</h2>
 
   <p>The following additional documentation directories are available:</p>
 
   <ol>
-  <% extra_dirs.each do |name, href, exists, _, path| %>
+  <%- extra_dirs.each do |name, href, exists, _, path| -%>
     <li>
-    <% if exists %>
+    <%- if exists -%>
       <a href="<%= href %>"><%= h name %></a> (<%= h path %>)
-    <% else %>
+    <%- else -%>
       <%= h name %> (<%= h path %>; <i>not available</i>)
-    <% end %>
+    <%- end -%>
     </li>
-  <% end %>
+  <%- end -%>
   </ol>
-<% end %>
+<%- end -%>
 
-<% gems = installed.select { |_, _, _, type,| type == :gem } %>
-<% missing = gems.reject { |_, _, exists,| exists } %>
-<% unless missing.empty? then %>
+<%- gems = installed.select { |_, _, _, type,| type == :gem } -%>
+<%- missing = gems.reject { |_, _, exists,| exists } -%>
+<%- unless missing.empty? then -%>
   <h2>Missing Gem Documentation</h2>
 
   <p>You are missing documentation for some of your installed gems.
@@ -53,11 +53,10 @@
   the following commands.
 
   <ul>
-  <% names = missing.map { |name,| name.sub(/-([^-]*)$/, '') }.uniq %>
-  <% names.each do |name| %>
+  <%- names = missing.map { |name,| name.sub(/-([^-]*)$/, '') }.uniq -%>
+  <%- names.each do |name| -%>
     <li><kbd>gem rdoc <%=h name %></kbd>
-  <% end %>
+  <%- end -%>
   </ul>
-<% end %>
+<%- end -%>
 </main>
-

--- a/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
@@ -2,11 +2,11 @@
 <main role="main">
 <h1 class="class"><%= h @title %></h1>
 
-<% simple_files = @files.select { |f| f.text? } %>
-<% unless simple_files.empty? then %>
+<%- simple_files = @files.select { |f| f.text? } -%>
+<%- unless simple_files.empty? then -%>
 <h2 id="pages">Pages</h2>
 <ul>
-<% simple_files.sort.each do |file| %>
+<%- simple_files.sort.each do |file| -%>
   <li class="file">
     <a href="<%= file.path %>"><%= h file.page_name %></a>
 <%
@@ -14,45 +14,45 @@
    table = file.parse(file.comment).table_of_contents
    unless table.empty? then %>
     <ul>
-<% table.each do |heading| %>
+<%- table.each do |heading| -%>
       <li><a href="<%= file.path %>#<%= heading.aref %>"><%= heading.plain_html %></a>
-<%   end %>
+<%-   end -%>
     </ul>
-<% end %>
+<%- end -%>
   </li>
-  <% end %>
+  <%- end -%>
 </ul>
-<% end %>
+<%- end -%>
 
 <h2 id="classes">Classes and Modules</h2>
 <ul>
-<% @modsort.each do |klass| %>
+<%- @modsort.each do |klass| -%>
   <li class="<%= klass.type %>">
     <a href="<%= klass.path %>"><%= klass.full_name %></a>
-<% table = []
+<%- table = []
    table.concat klass.parse(klass.comment_location).table_of_contents
    table.concat klass.section_contents
 
    unless table.empty? then %>
     <ul>
-<% table.each do |item| %>
+<%- table.each do |item| -%>
       <li><a href="<%= klass.path %>#<%= item.aref %>"><%= item.plain_html %></a>
-<%   end %>
+<%-   end -%>
     </ul>
-<% end %>
+<%- end -%>
   </li>
-<% end %>
+<%- end -%>
 </ul>
 
 <h2 id="methods">Methods</h2>
 <ul>
-<% @store.all_classes_and_modules.map do |mod|
+<%- @store.all_classes_and_modules.map do |mod|
      mod.method_list
    end.flatten.sort.each do |method| %>
   <li class="method">
     <a href="<%= method.path %>"><%= h method.pretty_name %></a>
     &mdash;
     <span class="container"><%= method.parent.full_name %></span>
-<% end %>
+<%- end -%>
 </ul>
 </main>


### PR DESCRIPTION
Close: https://github.com/ruby/rdoc/issues/759

As mentioned in https://github.com/ruby/rdoc/issues/759, I saw that `rdoc` is generating extra empty lines. This PR try to reduce the amount of empty lines to have a cleaner html structure. 

The impact of this PR can be seen on `rspec-core` gem documentation : https://github.com/benoittgt/rdoc-rspec-core-no-empty-lines/commit/6b57098b906e55583d81fc59ce2331a6c73896a7

First line of partial templates do not need to have `-%>` at the end, because it breaks the indentation when they are used in parent template.