### PR TITLE
Fix failing test by adding gettext as a development dependency

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -243,4 +243,6 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
   s.rubygems_version = "2.5.2"
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
+
+  s.add_development_dependency("gettext")
 end


### PR DESCRIPTION
The failing test was:

```
========================================================================================
rdoc/test/rdoc/test_rdoc_i18n_locale.rb:35:in `rescue in test_load_existent_po'
Omission: gettext gem is not found [test_load_existent_po(TestRDocI18nLocale)]
========================================================================================
```