### PR TITLE
Update Rdoc.css sidebar panel.

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -166,6 +166,7 @@ nav {
   width: 260px;
   font-family: Helvetica, sans-serif;
   font-size: 14px;
+  border-right: 1px solid #ccc;
 }
 
 main {


### PR DESCRIPTION
Updates css so the sidebar look like a panel instead of looking like chopped edges.

Minor css added to Panel : 
<img width="1239" alt="Screenshot 2021- 01-08 at 10 27 55 PM" src="https://user-images.githubusercontent.com/760429/104042880-0824b380-5201-11eb-9ebb-1558f9339cd3.png">

normally it looks like : 
<img width="1237" alt="Screenshot 2021-01-08 at 10 31 07 PM" src="https://user-images.githubusercontent.com/760429/104043034-37d3bb80-5201-11eb-8b6d-c9f23398f8e7.png">

