### PR TITLE
Fixed CodeFence without blank lines

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -896,7 +896,8 @@ StyleBlock =    < InStyleTags >
                   end }
 
 Inlines  =  ( !@Endline Inline:i { i }
-            | @Endline:c &Inline { c } )+:chunks @Endline?
+            | @Endline:c !( &{ github? } Ticks3 /[^`\n]*$/ )
+	      &Inline { c } )+:chunks @Endline?
             { chunks }
 
 Inline  = Str

--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -143,7 +143,7 @@ a block quote
   end
 
   def test_parse_code_github
-    doc = parse <<-MD
+    doc = <<-MD
 Example:
 
 ```
@@ -156,11 +156,25 @@ code goes here
         para("Example:"),
         verb("code goes here\n"))
 
-    assert_equal expected, doc
+    assert_equal expected, parse(doc)
+    assert_equal expected, parse(doc.sub(/^\n/, ''))
+
+    @parser.github = false
+
+    expected =
+      doc(para("Example:"),
+          para("<code>\n""code goes here\n</code>"))
+
+    assert_equal expected, parse(doc)
+
+    expected =
+      doc(para("Example:\n<code>\n""code goes here\n</code>"))
+
+    assert_equal expected, parse(doc.sub(/^\n/, ''))
   end
 
   def test_parse_code_github_format
-    doc = parse <<-MD
+    doc = <<-MD
 Example:
 
 ``` ruby
@@ -176,7 +190,21 @@ code goes here
         para("Example:"),
         code)
 
-    assert_equal expected, doc
+    assert_equal expected, parse(doc)
+    assert_equal expected, parse(doc.sub(/^\n/, ''))
+
+    @parser.github = false
+
+    expected =
+      doc(para("Example:"),
+          para("<code>ruby\n""code goes here\n</code>"))
+
+    assert_equal expected, parse(doc)
+
+    expected =
+      doc(para("Example:\n<code>ruby\n""code goes here\n</code>"))
+
+    assert_equal expected, parse(doc.sub(/^\n/, ''))
   end
 
   def test_parse_definition_list


### PR DESCRIPTION
Currently a fenced code block needs a preceding blank line, it should not be required, as:
https://github.github.com/gfm/#fenced-code-blocks
> A fenced code block may interrupt a paragraph, and does not require a blank line either before or after.

Just recommended:
https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks
> We recommend placing a blank line before and after code blocks to make the raw formatting easier to read.