### PR TITLE
Consider comments within DSL

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1867,11 +1867,11 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
         when 'end' then
           nest -= 1
+          container.ongoing_visibility = save_visibility
+
+          parse_comment container, tk, comment unless comment.empty?
+
           if nest == 0 then
-            container.ongoing_visibility = save_visibility
-
-            parse_comment container, tk, comment unless comment.empty?
-
             return
           end
         end
@@ -1882,7 +1882,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
         end
 
       when :on_ident then
-        if nest == 1 and current_method.nil? then
+        if current_method.nil? then
           keep_comment = parse_identifier container, single, tk, comment
         end
 

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -4297,4 +4297,29 @@ end
     assert_equal 'A::D', a_d.full_name
   end
 
+  def test_parse_included
+    util_parser <<-CLASS
+module A
+  module B
+    extend ActiveSupport::Concern
+    included do
+      ##
+      # :singleton-method:
+      # Hello
+      mattr_accessor :foo
+    end
+  end
+end
+    CLASS
+
+    @parser.scan
+
+    a = @store.find_module_named 'A'
+    assert_equal 'A', a.full_name
+    a_b = a.find_module_named 'B'
+    assert_equal 'A::B', a_b.full_name
+    meth = a_b.method_list.first
+    assert_equal 'foo', meth.name
+    assert_equal 'Hello', meth.comment.text
+  end
 end


### PR DESCRIPTION
`ActiveSupport::Concern` has `included` DSL and we may define singleton methods in it.

https://github.com/rails/rails/blob/168ddaa08a63cd956bb7c3ba10be1a7ae36d4ee2/activerecord/lib/active_record/core.rb#L9-L20