### PR TITLE
Links to document texts without "rdoc-ref:" prefix

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -357,6 +357,10 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
        url =~ /\.(gif|png|jpg|jpeg|bmp)$/ then
       "<img src=\"#{url}\" />"
     else
+      if scheme != 'link' and /\.(?:rb|rdoc|md)\z/i =~ url
+        url = url.sub(%r%\A([./]*)(.*)\z%) { "#$1#{$2.tr('.', '_')}.html" }
+      end
+
       text = text.sub %r%^#{scheme}:/*%i, ''
       text = text.sub %r%^[*\^](\d+)$%,   '\1'
 

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -738,6 +738,27 @@ EXPECTED
     assert_equal '<img src="https://example.com/image.png" />', @to.gen_url('https://example.com/image.png', 'ignored')
   end
 
+  def test_gen_url_rdoc_file
+    assert_equal '<a href="doc/example_rdoc.html">example</a>',
+                 @to.gen_url('doc/example.rdoc', 'example')
+    assert_equal '<a href="../ex_doc/example_rdoc.html">example</a>',
+                 @to.gen_url('../ex.doc/example.rdoc', 'example')
+  end
+
+  def test_gen_url_md_file
+    assert_equal '<a href="doc/example_md.html">example</a>',
+                 @to.gen_url('doc/example.md', 'example')
+    assert_equal '<a href="../ex_doc/example_md.html">example</a>',
+                 @to.gen_url('../ex.doc/example.md', 'example')
+  end
+
+  def test_gen_url_rb_file
+    assert_equal '<a href="doc/example_rb.html">example</a>',
+                 @to.gen_url('doc/example.rb', 'example')
+    assert_equal '<a href="../ex_doc/example_rb.html">example</a>',
+                 @to.gen_url('../ex.doc/example.rb', 'example')
+  end
+
   def test_handle_regexp_HYPERLINK_link
     target = RDoc::Markup::RegexpHandling.new 0, 'link:README.txt'
 

--- a/test/rdoc/test_rdoc_top_level.rb
+++ b/test/rdoc/test_rdoc_top_level.rb
@@ -157,6 +157,9 @@ class TestRDocTopLevel < XrefTestCase
 
   def test_http_url
     assert_equal 'prefix/path/top_level_rb.html', @top_level.http_url('prefix')
+
+    other_level = @store.add_file 'path.other/level.rb'
+    assert_equal 'prefix/path_other/level_rb.html', other_level.http_url('prefix')
   end
 
   def test_last_modified


### PR DESCRIPTION
While links to generated HTML from RDoc file needs to be prefixed by "rdoc-ref:" currently, in case of explicit references this seems just redundant.

Also GitHub RDoc support does not work with this prefix.

This patch lets links to such document texts (".rb", ".rdoc" and ".md" now) refer URLs generated by `RDoc::TopLevel#http_url` without the prefix.
