### PR TITLE
CI: Use jruby-9.2.17.0

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2.14.0', 'head', '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ 'jruby-9.2.17.0', 'head', '3.0', '2.7', '2.6', '2.5', '2.4' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.17.0**.

[JRuby 9.2.17.0 release blog post](https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html)

**Update**: Re-run now, as we want to see it run green; the last attempt was too early, and the image was not there, yet.