### PR TITLE
Document 'ruby:' to show core documentation in ri

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -142,6 +142,8 @@ Where name can be:
 
   gem_name: | gem_name:README | gem_name:History
 
+  ruby: | ruby:NEWS | ruby:globals
+
 All class names may be abbreviated to their minimum unambiguous form.
 If a name is ambiguous, all valid options will be listed.
 
@@ -153,6 +155,10 @@ they're contained in.  If the gem name is followed by a ':' all files in the
 gem will be shown.  The file name extension may be omitted where it is
 unambiguous.
 
+'ruby' can be used as a pseudo gem name to display files from the Ruby
+core documentation. Use 'ruby:' by itself to get a list of all available
+core documentation files.
+
 For example:
 
     #{opt.program_name} Fil
@@ -160,6 +166,7 @@ For example:
     #{opt.program_name} File.new
     #{opt.program_name} zip
     #{opt.program_name} rdoc:README
+    #{opt.program_name} ruby:comments
 
 Note that shell quoting or escaping may be required for method names
 containing punctuation:


### PR DESCRIPTION
ri supports 'ruby:' as a kind of "pseudo gem name" to display files of the core Ruby documentation such as syntax and NEWS. Add the appropriate documentation to the description of options shown by "ri --help".