### PR TITLE
Fix test failures

### DIFF
--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -460,7 +460,7 @@ class TestRDocRDoc < RDoc::TestCase
     temp_dir do
       file_list = ['| touch evil.txt && echo tags']
       file_list.each do |f|
-        FileUtils.touch f
+        FileUtils.touch f rescue omit
       end
 
       assert_equal file_list, @rdoc.remove_unparseable(file_list)

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -464,7 +464,7 @@ class TestRDocRDoc < RDoc::TestCase
       end
 
       assert_equal file_list, @rdoc.remove_unparseable(file_list)
-      assert_equal file_list, Dir.children('.')
+      assert_equal file_list, Dir.entries('.') - %w[. ..]
     end
   end
 


### PR DESCRIPTION
Fixes following failures:

* NoMethodError on ruby 2.4
  > https://github.com/ruby/rdoc/runs/2565344070?check_suite_focus=true#step:5:64
  > ```
  > Error: test_remove_unparseable_CVE_2021_31799(TestRDocRDoc): NoMethodError: undefined method `children' for Dir:Class
  > /home/runner/work/rdoc/rdoc/test/rdoc/test_rdoc_rdoc.rb:467:in `block in test_remove_unparseable_CVE_2021_31799'
  >      464:       end
  >      465:
  >      466:       assert_equal file_list, @rdoc.remove_unparseable(file_list)
  >   => 467:       assert_equal file_list, Dir.children('.')
  >      468:     end
  >      469:   end
  >      470:
  > ```

* `EINVAL` on Windows
  > https://github.com/ruby/rdoc/runs/2565343916?check_suite_focus=true#step:5:58
  > ```
  > Error: test_remove_unparseable_CVE_2021_31799(TestRDocRDoc): Errno::EINVAL: Invalid argument @ utime_failed - | touch evil.txt && echo tags
  > D:/rubyinstaller-head-x64/lib/ruby/3.1.0/fileutils.rb:1142:in `utime'
  > D:/rubyinstaller-head-x64/lib/ruby/3.1.0/fileutils.rb:1142:in `block in touch'
  > D:/rubyinstaller-head-x64/lib/ruby/3.1.0/fileutils.rb:1139:in `each'
  > D:/rubyinstaller-head-x64/lib/ruby/3.1.0/fileutils.rb:1139:in `touch'
  > D:/a/rdoc/rdoc/test/rdoc/test_rdoc_rdoc.rb:463:in `block (2 levels) in test_remove_unparseable_CVE_2021_31799'
  >      460:     temp_dir do
  >      461:       file_list = ['| touch evil.txt && echo tags']
  >      462:       file_list.each do |f|
  >   => 463:         FileUtils.touch f
  >      464:       end
  >      465:
  >      466:       assert_equal file_list, @rdoc.remove_unparseable(file_list)
  > ```
