### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2.17.0', 'head', '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ 'jruby-9.2.17.0', 'head', '3.0', '2.7', '2.6', '2.5' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [ 'head', '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ 'head', '3.0', '2.7', '2.6', '2.5' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -242,7 +242,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     TODO.rdoc
   ]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
   s.add_development_dependency("gettext")

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -464,7 +464,7 @@ class TestRDocRDoc < RDoc::TestCase
       end
 
       assert_equal file_list, @rdoc.remove_unparseable(file_list)
-      assert_equal file_list, Dir.entries('.') - %w[. ..]
+      assert_equal file_list, Dir.children('.')
     end
   end
 


### PR DESCRIPTION
Even 2.5 is EOL, so I don't think we should support even older versions.