### PR TITLE
lib/rdoc/rdoc.rb: Allow RDoc::Options and Symbol in .rdoc_options

### DIFF
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -118,6 +118,8 @@ module RDoc
     ensure
       require 'yaml'
     end
+
+    @YAML_LOAD_NEEDS_PERMITTED_CLASSES = YAML.method(:load).parameters.any? {|_, arg| arg == :permitted_classes}
   end
 
   def self.home

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -161,12 +161,14 @@ class RDoc::RDoc
 
     RDoc.load_yaml
 
+    load_options = (RDoc.instance_variable_get(:@YAML_LOAD_NEEDS_PERMITTED_CLASSES) ?
+      {permitted_classes: [RDoc::Options, Symbol]} : {})
     begin
-      options = YAML.load_file '.rdoc_options'
+      options = YAML.load_file '.rdoc_options', **load_options
     rescue Psych::SyntaxError
+    else
+      return RDoc::Options.new unless options # Allow empty file.
     end
-
-    return RDoc::Options.new if options == false # Allow empty file.
 
     raise RDoc::Error, "#{options_file} is not a valid rdoc options file" unless
       RDoc::Options === options or Hash === options

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -145,7 +145,7 @@ class TestRDocOptions < RDoc::TestCase
 
     @options.encoding = Encoding::IBM437
 
-    options = YAML.load YAML.dump @options
+    options = load_options YAML.dump(@options)
 
     assert_equal Encoding::IBM437, options.encoding
   end
@@ -161,7 +161,7 @@ rdoc_include:
 - /etc
     YAML
 
-    options = YAML.load yaml
+    options = load_options yaml
 
     assert_empty options.rdoc_include
     assert_empty options.static_path
@@ -749,7 +749,7 @@ rdoc_include:
 
       assert File.exist? '.rdoc_options'
 
-      assert_equal @options, YAML.load(File.read('.rdoc_options'))
+      assert_equal @options, load_options(File.read('.rdoc_options'))
     end
   end
 
@@ -776,5 +776,14 @@ rdoc_include:
   def test_visibility
     @options.visibility = :all
     assert_equal :private, @options.visibility
+  end
+
+  private
+  def load_options(yaml)
+    if YAML.method(:load).parameters.any? {|_, arg| arg == :permitted_classes}
+      YAML.load(yaml, permitted_classes: [RDoc::Options, Symbol])
+    else
+      YAML.load(yaml)
+    end
   end
 end


### PR DESCRIPTION
As `Psych.load` calls `safe_load` now, need to permit these classes explicitly to load.
