### PR TITLE
Fix chained inclusion ancestors_of

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -609,11 +609,11 @@ or the PAGER environment variable.
 
       stores = classes[current]
 
-      break unless stores and not stores.empty?
+      next unless stores and not stores.empty?
 
-      klasses = stores.map do |store|
-        store.ancestors[current]
-      end.flatten.uniq
+      klasses = stores.flat_map do |store|
+        store.ancestors[current] || []
+      end.uniq
 
       klasses = klasses - seen
 

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -421,6 +421,30 @@ class TestRDocRIDriver < RDoc::TestCase
     assert_equal %w[X Mixin Object Foo], @driver.ancestors_of('Foo::Bar')
   end
 
+  def test_ancestors_of_chained_inclusion
+    # Store represents something like:
+    #
+    #   module X
+    #   end
+    #
+    #   module Y
+    #     include X
+    #   end
+    #
+    #   class Z
+    #     include Y
+    #   end
+    #
+    # Y is not chosen randomly, it has to be after Object in the alphabet
+    # to reproduce https://github.com/ruby/rdoc/issues/814.
+    store = RDoc::RI::Store.new @home_ri
+    store.cache[:ancestors] = { "Z" => ["Object", "Y"], "Y" => ["X"] }
+    store.cache[:modules] = %W[X Y Z]
+    @driver.stores = [store]
+
+    assert_equal %w[X Y Object], @driver.ancestors_of('Z')
+  end
+
   def test_classes
     util_multi_store
 


### PR DESCRIPTION
Fixes #814

(thanks for the great gem ❤️)


----

In the process of doing this PR I bumped on a dev issue. I was running tests like `ruby test/rdoc/test_rdoc_ri_driver.rb --name=test_ancestors_of_chained_inclusion` and it was loading the wrong rdoc version.

I tend to think that is not the developer responsibility, but rather the gem to always internally point to relative resources, make sure we do not load anything coming from somewhere else.

Hence I started a patch, but it is a bit long and I did want to keep this PR simple. I could however open another one with only relative paths for internal resources. Please, tell me if you'd be ready to merge something like that 🙂 (e.g: `require_relative` and `autoload __dir__ + path`)