### PR TITLE
Relative loading for easier development

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-$:.unshift File.expand_path 'lib'
-require 'rdoc/task'
+# frozen_string_literal: true
+
+require_relative 'lib/rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
@@ -34,14 +35,14 @@ task ghpages: :rdoc do
 end
 
 Rake::TestTask.new(:normal_test) do |t|
-  t.libs << "test/rdoc"
+  t.libs = []
   t.verbose = true
   t.deps = :generate
   t.test_files = FileList["test/**/test_*.rb"].exclude("test/rdoc/test_rdoc_rubygems_hook.rb")
 end
 
 Rake::TestTask.new(:rubygems_test) do |t|
-  t.libs << "test/rdoc"
+  t.libs = []
   t.verbose = true
   t.deps = :generate
   t.pattern = "test/rdoc/test_rdoc_rubygems_hook.rb"

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "rdoc"
+require_relative "../lib/rdoc"
 
 require "irb"
 IRB.start

--- a/exe/rdoc
+++ b/exe/rdoc
@@ -41,4 +41,3 @@ rescue Exception => e
 
   exit 1
 end
-

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -62,7 +62,7 @@ module RDoc
 
   class Error < RuntimeError; end
 
-  require 'rdoc/version'
+  require_relative 'rdoc/version'
 
   ##
   # Method visibilities
@@ -141,61 +141,61 @@ module RDoc
     end
   end
 
-  autoload :RDoc,           'rdoc/rdoc'
+  autoload :RDoc,           "#{__dir__}/rdoc/rdoc"
 
-  autoload :CrossReference, 'rdoc/cross_reference'
-  autoload :ERBIO,          'rdoc/erbio'
-  autoload :ERBPartial,     'rdoc/erb_partial'
-  autoload :Encoding,       'rdoc/encoding'
-  autoload :Generator,      'rdoc/generator'
-  autoload :Options,        'rdoc/options'
-  autoload :Parser,         'rdoc/parser'
-  autoload :Servlet,        'rdoc/servlet'
-  autoload :RI,             'rdoc/ri'
-  autoload :Stats,          'rdoc/stats'
-  autoload :Store,          'rdoc/store'
-  autoload :Task,           'rdoc/task'
-  autoload :Text,           'rdoc/text'
+  autoload :CrossReference, "#{__dir__}/rdoc/cross_reference"
+  autoload :ERBIO,          "#{__dir__}/rdoc/erbio"
+  autoload :ERBPartial,     "#{__dir__}/rdoc/erb_partial"
+  autoload :Encoding,       "#{__dir__}/rdoc/encoding"
+  autoload :Generator,      "#{__dir__}/rdoc/generator"
+  autoload :Options,        "#{__dir__}/rdoc/options"
+  autoload :Parser,         "#{__dir__}/rdoc/parser"
+  autoload :Servlet,        "#{__dir__}/rdoc/servlet"
+  autoload :RI,             "#{__dir__}/rdoc/ri"
+  autoload :Stats,          "#{__dir__}/rdoc/stats"
+  autoload :Store,          "#{__dir__}/rdoc/store"
+  autoload :Task,           "#{__dir__}/rdoc/task"
+  autoload :Text,           "#{__dir__}/rdoc/text"
 
-  autoload :Markdown,       'rdoc/markdown'
-  autoload :Markup,         'rdoc/markup'
-  autoload :RD,             'rdoc/rd'
-  autoload :TomDoc,         'rdoc/tom_doc'
+  autoload :Markdown,       "#{__dir__}/rdoc/markdown"
+  autoload :Markup,         "#{__dir__}/rdoc/markup"
+  autoload :RD,             "#{__dir__}/rdoc/rd"
+  autoload :TomDoc,         "#{__dir__}/rdoc/tom_doc"
 
-  autoload :KNOWN_CLASSES,  'rdoc/known_classes'
+  autoload :KNOWN_CLASSES,  "#{__dir__}/rdoc/known_classes"
 
-  autoload :TokenStream,    'rdoc/token_stream'
+  autoload :TokenStream,    "#{__dir__}/rdoc/token_stream"
 
-  autoload :Comment,        'rdoc/comment'
+  autoload :Comment,        "#{__dir__}/rdoc/comment"
 
-  require 'rdoc/i18n'
+  require_relative 'rdoc/i18n'
 
   # code objects
   #
   # We represent the various high-level code constructs that appear in Ruby
   # programs: classes, modules, methods, and so on.
-  autoload :CodeObject,     'rdoc/code_object'
+  autoload :CodeObject,     "#{__dir__}/rdoc/code_object"
 
-  autoload :Context,        'rdoc/context'
-  autoload :TopLevel,       'rdoc/top_level'
+  autoload :Context,        "#{__dir__}/rdoc/context"
+  autoload :TopLevel,       "#{__dir__}/rdoc/top_level"
 
-  autoload :AnonClass,      'rdoc/anon_class'
-  autoload :ClassModule,    'rdoc/class_module'
-  autoload :NormalClass,    'rdoc/normal_class'
-  autoload :NormalModule,   'rdoc/normal_module'
-  autoload :SingleClass,    'rdoc/single_class'
+  autoload :AnonClass,      "#{__dir__}/rdoc/anon_class"
+  autoload :ClassModule,    "#{__dir__}/rdoc/class_module"
+  autoload :NormalClass,    "#{__dir__}/rdoc/normal_class"
+  autoload :NormalModule,   "#{__dir__}/rdoc/normal_module"
+  autoload :SingleClass,    "#{__dir__}/rdoc/single_class"
 
-  autoload :Alias,          'rdoc/alias'
-  autoload :AnyMethod,      'rdoc/any_method'
-  autoload :MethodAttr,     'rdoc/method_attr'
-  autoload :GhostMethod,    'rdoc/ghost_method'
-  autoload :MetaMethod,     'rdoc/meta_method'
-  autoload :Attr,           'rdoc/attr'
+  autoload :Alias,          "#{__dir__}/rdoc/alias"
+  autoload :AnyMethod,      "#{__dir__}/rdoc/any_method"
+  autoload :MethodAttr,     "#{__dir__}/rdoc/method_attr"
+  autoload :GhostMethod,    "#{__dir__}/rdoc/ghost_method"
+  autoload :MetaMethod,     "#{__dir__}/rdoc/meta_method"
+  autoload :Attr,           "#{__dir__}/rdoc/attr"
 
-  autoload :Constant,       'rdoc/constant'
-  autoload :Mixin,          'rdoc/mixin'
-  autoload :Include,        'rdoc/include'
-  autoload :Extend,         'rdoc/extend'
-  autoload :Require,        'rdoc/require'
+  autoload :Constant,       "#{__dir__}/rdoc/constant"
+  autoload :Mixin,          "#{__dir__}/rdoc/mixin"
+  autoload :Include,        "#{__dir__}/rdoc/include"
+  autoload :Extend,         "#{__dir__}/rdoc/extend"
+  autoload :Require,        "#{__dir__}/rdoc/require"
 
 end

--- a/lib/rdoc/code_objects.rb
+++ b/lib/rdoc/code_objects.rb
@@ -2,5 +2,4 @@
 # This file was used to load all the RDoc::CodeObject subclasses at once.  Now
 # autoload handles this.
 
-require 'rdoc'
-
+require_relative '../rdoc'

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -1261,6 +1261,6 @@ class RDoc::Context < RDoc::CodeObject
     klass
   end
 
-  autoload :Section, 'rdoc/context/section'
+  autoload :Section, "#{__dir__}/context/section"
 
 end

--- a/lib/rdoc/generator.rb
+++ b/lib/rdoc/generator.rb
@@ -41,11 +41,11 @@
 
 module RDoc::Generator
 
-  autoload :Markup,   'rdoc/generator/markup'
+  autoload :Markup,   "#{__dir__}/generator/markup"
 
-  autoload :Darkfish,  'rdoc/generator/darkfish'
-  autoload :JsonIndex, 'rdoc/generator/json_index'
-  autoload :RI,        'rdoc/generator/ri'
-  autoload :POT,       'rdoc/generator/pot'
+  autoload :Darkfish,  "#{__dir__}/generator/darkfish"
+  autoload :JsonIndex, "#{__dir__}/generator/json_index"
+  autoload :RI,        "#{__dir__}/generator/ri"
+  autoload :POT,       "#{__dir__}/generator/pot"
 
 end

--- a/lib/rdoc/i18n.rb
+++ b/lib/rdoc/i18n.rb
@@ -4,7 +4,7 @@
 
 module RDoc::I18n
 
-  autoload :Locale, 'rdoc/i18n/locale'
+  autoload :Locale, "#{__dir__}/i18n/locale"
   require_relative 'i18n/text'
 
 end

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -187,11 +187,11 @@
 
 %% {
 
-  require 'rdoc'
-  require 'rdoc/markup/to_joined_paragraph'
-  require 'rdoc/markdown/entities'
+  require_relative '../rdoc'
+  require_relative 'markup/to_joined_paragraph'
+  require_relative 'markdown/entities'
 
-  require 'rdoc/markdown/literals'
+  require_relative 'markdown/literals'
 
   ##
   # Supported extensions

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -822,46 +822,45 @@ https://github.com/ruby/rdoc/issues
     document.accept formatter
   end
 
-  autoload :Parser,                'rdoc/markup/parser'
-  autoload :PreProcess,            'rdoc/markup/pre_process'
+  autoload :Parser,                "#{__dir__}/markup/parser"
+  autoload :PreProcess,            "#{__dir__}/markup/pre_process"
 
   # Inline markup classes
-  autoload :AttrChanger,           'rdoc/markup/attr_changer'
-  autoload :AttrSpan,              'rdoc/markup/attr_span'
-  autoload :Attributes,            'rdoc/markup/attributes'
-  autoload :AttributeManager,      'rdoc/markup/attribute_manager'
-  autoload :RegexpHandling,        'rdoc/markup/regexp_handling'
+  autoload :AttrChanger,           "#{__dir__}/markup/attr_changer"
+  autoload :AttrSpan,              "#{__dir__}/markup/attr_span"
+  autoload :Attributes,            "#{__dir__}/markup/attributes"
+  autoload :AttributeManager,      "#{__dir__}/markup/attribute_manager"
+  autoload :RegexpHandling,        "#{__dir__}/markup/regexp_handling"
 
   # RDoc::Markup AST
-  autoload :BlankLine,             'rdoc/markup/blank_line'
-  autoload :BlockQuote,            'rdoc/markup/block_quote'
-  autoload :Document,              'rdoc/markup/document'
-  autoload :HardBreak,             'rdoc/markup/hard_break'
-  autoload :Heading,               'rdoc/markup/heading'
-  autoload :Include,               'rdoc/markup/include'
-  autoload :IndentedParagraph,     'rdoc/markup/indented_paragraph'
-  autoload :List,                  'rdoc/markup/list'
-  autoload :ListItem,              'rdoc/markup/list_item'
-  autoload :Paragraph,             'rdoc/markup/paragraph'
-  autoload :Table,                 'rdoc/markup/table'
-  autoload :Raw,                   'rdoc/markup/raw'
-  autoload :Rule,                  'rdoc/markup/rule'
-  autoload :Verbatim,              'rdoc/markup/verbatim'
+  autoload :BlankLine,             "#{__dir__}/markup/blank_line"
+  autoload :BlockQuote,            "#{__dir__}/markup/block_quote"
+  autoload :Document,              "#{__dir__}/markup/document"
+  autoload :HardBreak,             "#{__dir__}/markup/hard_break"
+  autoload :Heading,               "#{__dir__}/markup/heading"
+  autoload :Include,               "#{__dir__}/markup/include"
+  autoload :IndentedParagraph,     "#{__dir__}/markup/indented_paragraph"
+  autoload :List,                  "#{__dir__}/markup/list"
+  autoload :ListItem,              "#{__dir__}/markup/list_item"
+  autoload :Paragraph,             "#{__dir__}/markup/paragraph"
+  autoload :Table,                 "#{__dir__}/markup/table"
+  autoload :Raw,                   "#{__dir__}/markup/raw"
+  autoload :Rule,                  "#{__dir__}/markup/rule"
+  autoload :Verbatim,              "#{__dir__}/markup/verbatim"
 
   # Formatters
-  autoload :Formatter,             'rdoc/markup/formatter'
+  autoload :Formatter,             "#{__dir__}/markup/formatter"
 
-  autoload :ToAnsi,                'rdoc/markup/to_ansi'
-  autoload :ToBs,                  'rdoc/markup/to_bs'
-  autoload :ToHtml,                'rdoc/markup/to_html'
-  autoload :ToHtmlCrossref,        'rdoc/markup/to_html_crossref'
-  autoload :ToHtmlSnippet,         'rdoc/markup/to_html_snippet'
-  autoload :ToLabel,               'rdoc/markup/to_label'
-  autoload :ToMarkdown,            'rdoc/markup/to_markdown'
-  autoload :ToRdoc,                'rdoc/markup/to_rdoc'
-  autoload :ToTableOfContents,     'rdoc/markup/to_table_of_contents'
-  autoload :ToTest,                'rdoc/markup/to_test'
-  autoload :ToTtOnly,              'rdoc/markup/to_tt_only'
+  autoload :ToAnsi,                "#{__dir__}/markup/to_ansi"
+  autoload :ToBs,                  "#{__dir__}/markup/to_bs"
+  autoload :ToHtml,                "#{__dir__}/markup/to_html"
+  autoload :ToHtmlCrossref,        "#{__dir__}/markup/to_html_crossref"
+  autoload :ToHtmlSnippet,         "#{__dir__}/markup/to_html_snippet"
+  autoload :ToLabel,               "#{__dir__}/markup/to_label"
+  autoload :ToMarkdown,            "#{__dir__}/markup/to_markdown"
+  autoload :ToRdoc,                "#{__dir__}/markup/to_rdoc"
+  autoload :ToTableOfContents,     "#{__dir__}/markup/to_table_of_contents"
+  autoload :ToTest,                "#{__dir__}/markup/to_test"
+  autoload :ToTtOnly,              "#{__dir__}/markup/to_tt_only"
 
 end
-

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -263,8 +263,8 @@ class RDoc::Parser
     @preprocess.options = @options
   end
 
-  autoload :RubyTools, 'rdoc/parser/ruby_tools'
-  autoload :Text,      'rdoc/parser/text'
+  autoload :RubyTools, "#{__dir__}/parser/ruby_tools"
+  autoload :Text,      "#{__dir__}/parser/text"
 
 end
 

--- a/lib/rdoc/rd.rb
+++ b/lib/rdoc/rd.rb
@@ -92,9 +92,8 @@ class RDoc::RD
     document
   end
 
-  autoload :BlockParser,  'rdoc/rd/block_parser'
-  autoload :InlineParser, 'rdoc/rd/inline_parser'
-  autoload :Inline,       'rdoc/rd/inline'
+  autoload :BlockParser,  "#{__dir__}/rd/block_parser"
+  autoload :InlineParser, "#{__dir__}/rd/inline_parser"
+  autoload :Inline,       "#{__dir__}/rd/inline"
 
 end
-

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rdoc'
+require_relative '../rdoc'
 
 require 'find'
 require 'fileutils'

--- a/lib/rdoc/ri.rb
+++ b/lib/rdoc/ri.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rdoc'
+require_relative '../rdoc'
 
 ##
 # Namespace for the ri command line tool's implementation.
@@ -13,9 +13,8 @@ module RDoc::RI
 
   class Error < RDoc::Error; end
 
-  autoload :Driver, 'rdoc/ri/driver'
-  autoload :Paths,  'rdoc/ri/paths'
-  autoload :Store,  'rdoc/ri/store'
+  autoload :Driver, "#{__dir__}/ri/driver"
+  autoload :Paths,  "#{__dir__}/ri/paths"
+  autoload :Store,  "#{__dir__}/ri/store"
 
 end
-

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -12,7 +12,7 @@ begin
 rescue LoadError
 end
 
-require 'rdoc'
+require_relative '../../rdoc'
 
 ##
 # For RubyGems backwards compatibility

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems/user_interaction'
 require 'fileutils'
-require 'rdoc'
+require_relative '../rdoc'
 
 ##
 # Gem::RDoc provides methods to generate RDoc and ri data for installed gems

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rdoc'
+require_relative '../rdoc'
 require 'erb'
 require 'time'
 require 'json'

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -454,9 +454,8 @@ class RDoc::Stats
     [params.length, undoc]
   end
 
-  autoload :Quiet,   'rdoc/stats/quiet'
-  autoload :Normal,  'rdoc/stats/normal'
-  autoload :Verbose, 'rdoc/stats/verbose'
+  autoload :Quiet,   "#{__dir__}/stats/quiet"
+  autoload :Normal,  "#{__dir__}/stats/normal"
+  autoload :Verbose, "#{__dir__}/stats/verbose"
 
 end
-

--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -32,7 +32,7 @@ begin
 rescue Gem::LoadError
 end unless defined?(Rake)
 
-require 'rdoc'
+require_relative '../rdoc'
 require 'rake'
 require 'rake/tasklib'
 

--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RDoc
 
   ##

--- a/test/rdoc/helper.rb
+++ b/test/rdoc/helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require_relative './support/test_case'
-require_relative './support/formatter_test_case'
-require_relative './support/text_formatter_test_case'
+require_relative 'support/test_case'
+require_relative 'support/formatter_test_case'
+require_relative 'support/text_formatter_test_case'

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -26,7 +26,7 @@ require 'tempfile'
 require 'tmpdir'
 require 'stringio'
 
-require 'rdoc'
+require_relative '../../../lib/rdoc'
 
 ##
 # RDoc::TestCase is an abstract TestCase to provide common setup and teardown

--- a/test/rdoc/test_rdoc_alias.rb
+++ b/test/rdoc/test_rdoc_alias.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocAlias < XrefTestCase
 
@@ -11,4 +11,3 @@ class TestRDocAlias < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_any_method.rb
+++ b/test/rdoc/test_rdoc_any_method.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocAnyMethod < XrefTestCase
 

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocClassModule < XrefTestCase
 
@@ -1501,4 +1501,3 @@ class TestRDocClassModule < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_code_object.rb
+++ b/test/rdoc/test_rdoc_code_object.rb
@@ -1,7 +1,7 @@
 # coding: US-ASCII
 # frozen_string_literal: true
 
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocCodeObject < XrefTestCase
 

--- a/test/rdoc/test_rdoc_constant.rb
+++ b/test/rdoc/test_rdoc_constant.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocConstant < XrefTestCase
 

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocContext < XrefTestCase
 

--- a/test/rdoc/test_rdoc_cross_reference.rb
+++ b/test/rdoc/test_rdoc_cross_reference.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocCrossReference < XrefTestCase
 
@@ -204,4 +204,3 @@ class TestRDocCrossReference < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_extend.rb
+++ b/test/rdoc/test_rdoc_extend.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocExtend < XrefTestCase
 
@@ -92,4 +92,3 @@ class TestRDocExtend < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_include.rb
+++ b/test/rdoc/test_rdoc_include.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocInclude < XrefTestCase
 
@@ -106,4 +106,3 @@ class TestRDocInclude < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
-require 'rdoc/markup/block_quote'
-require 'rdoc/markdown'
+require_relative '../../lib/rdoc/markup/block_quote'
+require_relative '../../lib/rdoc/markdown'
 
 class TestRDocMarkdown < RDoc::TestCase
 
@@ -1068,4 +1068,3 @@ and an extra note.[^2]
   end
 
 end
-

--- a/test/rdoc/test_rdoc_markdown_test.rb
+++ b/test/rdoc/test_rdoc_markdown_test.rb
@@ -2,8 +2,8 @@
 require_relative 'helper'
 require 'pp'
 
-require 'rdoc'
-require 'rdoc/markdown'
+require_relative '../../lib/rdoc'
+require_relative '../../lib/rdoc/markdown'
 
 class TestRDocMarkdownTest < RDoc::TestCase
 

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocMarkupToHtmlCrossref < XrefTestCase
 
@@ -260,4 +260,3 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_method_attr.rb
+++ b/test/rdoc/test_rdoc_method_attr.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocMethodAttr < XrefTestCase
 
@@ -191,4 +191,3 @@ class TestRDocMethodAttr < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_normal_class.rb
+++ b/test/rdoc/test_rdoc_normal_class.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocNormalClass < XrefTestCase
 
@@ -45,4 +45,3 @@ class TestRDocNormalClass < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_normal_module.rb
+++ b/test/rdoc/test_rdoc_normal_module.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocNormalModule < XrefTestCase
 
@@ -40,4 +40,3 @@ class TestRDocNormalModule < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_require.rb
+++ b/test/rdoc/test_rdoc_require.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocRequire < XrefTestCase
 
@@ -23,4 +23,3 @@ class TestRDocRequire < XrefTestCase
   end
 
 end
-

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -32,8 +32,8 @@ class TestRDocRIDriver < RDoc::TestCase
   end
 
   def teardown
-    ENV['RI'] = @orig_ri
-    FileUtils.rm_rf @tmpdir
+    defined?(@orig_ri) and ENV['RI'] = @orig_ri
+    defined?(@tmpdir) and FileUtils.rm_rf @tmpdir
 
     super
   end

--- a/test/rdoc/test_rdoc_rubygems_hook.rb
+++ b/test/rdoc/test_rdoc_rubygems_hook.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require "rubygems"
-require "fileutils"
-require "tmpdir"
-require 'rdoc/rubygems_hook'
-require "test/unit"
+require 'rubygems'
+require 'fileutils'
+require 'tmpdir'
+require_relative '../../lib/rdoc/rubygems_hook'
+require 'test/unit'
 
 class TestRDocRubygemsHook < Test::Unit::TestCase
   def setup

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocStore < XrefTestCase
 

--- a/test/rdoc/test_rdoc_task.rb
+++ b/test/rdoc/test_rdoc_task.rb
@@ -171,4 +171,3 @@ class TestRDocTask < RDoc::TestCase
   end
 
 end if defined?(Rake::Task)
-

--- a/test/rdoc/test_rdoc_top_level.rb
+++ b/test/rdoc/test_rdoc_top_level.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require File.expand_path '../xref_test_case', __FILE__
+require_relative 'xref_test_case'
 
 class TestRDocTopLevel < XrefTestCase
 
@@ -288,4 +288,3 @@ class TestRDocTopLevel < XrefTestCase
   end
 
 end
-


### PR DESCRIPTION
This patch makes sure we only load relative code. Hence when coding or
testing rdoc, we'll be sure to always be using the correct code.

Discussion started at https://github.com/ruby/rdoc/pull/817.

---

There is one place I did not change `require` for `require_relative`, that is under `exe/` because I don't know how that is handled by rubygem, and guessed it could be copied. Moreover, there are no related tests.

---

I almost went and created a helper `autoload_relative` method, but I guess I'll let that [for ruby core at some point](https://bugs.ruby-lang.org/issues/15330).

---

The second commit acts as a _test_ for that new behavior, it may feel intrusive. In that case I'll revert that bit