### PR TITLE
CI: use jruby-9.2.19.0

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2.17.0', 'head', '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ 'jruby-9.2.19.0', 'head', '3.0', '2.7', '2.6', '2.5' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This is the latest release.
This PR updates the CI matrix to use latest JRuby, **9.2.19.0**.

[JRuby 9.2.19.0 release blog post](https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html)