### PR TITLE
Fix smart single quote

### DIFF
--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -237,7 +237,7 @@ module RDoc::Text
       when s.scan(/``/) then # backtick double quote
         html << encoded[:open_dquote]
         after_word = nil
-      when s.scan(/''/) then # tick double quote
+      when s.scan(/(?:&#39;|'){2}/) then # tick double quote
         html << encoded[:close_dquote]
         after_word = nil
       when s.scan(/`/) then # backtick

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -240,6 +240,14 @@ module RDoc::Text
       when s.scan(/''/) then # tick double quote
         html << encoded[:close_dquote]
         after_word = nil
+      when s.scan(/`/) then # backtick
+        if insquotes or after_word
+          html << '`'
+          after_word = false
+        else
+          html << encoded[:open_squote]
+          insquotes = true
+        end
       when s.scan(/&#39;|'/) then # single quote
         if insquotes
           html << encoded[:close_squote]

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -240,7 +240,7 @@ module RDoc::Text
       when s.scan(/''/) then # tick double quote
         html << encoded[:close_dquote]
         after_word = nil
-      when s.scan(/'/) then # single quote
+      when s.scan(/&#39;|'/) then # single quote
         if insquotes
           html << encoded[:close_squote]
           insquotes = false

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -712,7 +712,7 @@ EXPECTED
 
   def test_convert_underscore_adjacent_to_code
     assert_equal "\n<p><code>aaa</code>_</p>\n", @to.convert(%q{+aaa+_})
-    assert_equal "\n<p>`<code>i386-mswin32_</code><em>MSRTVERSION</em>&#39;</p>\n", @to.convert(%q{`+i386-mswin32_+_MSRTVERSION_'})
+    assert_equal "\n<p>\u{2018}<code>i386-mswin32_</code><em>MSRTVERSION</em>\u{2019}</p>\n", @to.convert(%q{`+i386-mswin32_+_MSRTVERSION_'})
   end
 
   def test_gen_url

--- a/test/rdoc/test_rdoc_text.rb
+++ b/test/rdoc/test_rdoc_text.rb
@@ -514,6 +514,7 @@ The comments associated with
   def test_to_html_double_backtick
     assert_equal '“a',  to_html('``a')
     assert_equal '“a“', to_html('``a``')
+    assert_equal '“a”', to_html("``a''")
   end
 
   def test_to_html_double_quote

--- a/test/rdoc/test_rdoc_text.rb
+++ b/test/rdoc/test_rdoc_text.rb
@@ -485,6 +485,13 @@ The comments associated with
     assert_equal '‘a’ ‘', to_html("'a' '")
   end
 
+  def test_to_html_apostrophe_entity
+    assert_equal '‘a', to_html("&#39;a")
+    assert_equal 'a’', to_html("a&#39;")
+
+    assert_equal '‘a’ ‘', to_html("&#39;a&#39; &#39;")
+  end
+
   def test_to_html_backslash
     assert_equal 'S', to_html('\\S')
   end


### PR DESCRIPTION
Smart single quote dicondn't work, since single quotes have been converted to character entity references earlier.
Also back qoutes will be converted to open single quotes