### PR TITLE
Completely remove minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development do
   gem 'racc', '> 1.4.10'
   gem 'kpeg', github: 'evanphx/kpeg'
   gem 'test-unit'
-  gem 'minitest' # for test_rdoc_rubygems_hook.rb
   gem 'rubocop'
   gem 'gettext'
 end

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -1,16 +1,3 @@
-##
-# RDoc::TestCase is an abstract TestCase to provide common setup and teardown
-# across all RDoc tests.  The test case uses minitest, so all the assertions
-# of minitest may be used.
-#
-# The testcase provides the following:
-#
-# * A reset code-object tree
-# * A reset markup preprocessor (RDoc::Markup::PreProcess)
-# * The <code>@RM</code> alias of RDoc::Markup (for less typing)
-# * <code>@pwd</code> containing the current working directory
-# * FileUtils, pp, Tempfile, Dir.tmpdir and StringIO
-
 require 'bundler/errors'
 begin
   gem 'test-unit'

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -17,8 +17,8 @@ require 'rdoc'
 
 ##
 # RDoc::TestCase is an abstract TestCase to provide common setup and teardown
-# across all RDoc tests.  The test case uses minitest, so all the assertions
-# of minitest may be used.
+# across all RDoc tests.  The test case uses test-unit, so all the assertions
+# of test-unit may be used.
 #
 # The testcase provides the following:
 #


### PR DESCRIPTION
 I will remove https://github.com/ruby/rdoc/blob/master/test/rdoc/test_rdoc_generator_darkfish.rb#L148 on ruby repo after this.

Fixed #834