### PR TITLE
Scrollable sidebar

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -186,6 +186,10 @@ nav {
   font-family: Helvetica, sans-serif;
   font-size: 14px;
   border-right: 1px solid #ccc;
+  position: sticky;
+  top: 0;
+  overflow: auto;
+  height: calc(100vh - 100px); /* reduce the footer height */
 }
 
 main {


### PR DESCRIPTION
This change makes the sidebar scrollable via `position: sticky` and `overflow: auto`;
See also <https://caniuse.com/?search=sticky>

Note: I'm worried that old browsers like IE 11 don't support `position: sticky`, so feel free to close this PR if RDoc should support such browsers.

### Demo

https://user-images.githubusercontent.com/473530/132940475-a9a10a77-d165-418e-8401-96e4477fc561.mov

