### PR TITLE
fix: alias to a method with call-seq should render properly if the call-seq does not specify the alias

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -356,6 +356,6 @@ class RDoc::AnyMethod < RDoc::MethodAttr
         entry =~ /\s#{ignore}\s/
     end
 
-    matching.join "\n"
+    matching.empty? ? nil : matching.join("\n")
   end
 end


### PR DESCRIPTION
## Description of the problem

If I have this ruby code:

```ruby
class Foo
  # :call-seq:
  #   foo(a)
  #   foo(a, b)
  #   foo(a, b, c)
  def foo(*args)
  end

  alias :bar :foo
end
```

The alias `bar` is rendered poorly:

![foo](https://user-images.githubusercontent.com/8207/134018593-45e3e051-5e3b-49d8-a4cd-07ffb5e12651.png)

After this change, it gracefully falls back to using the underlying method's param-seq:

![Screenshot from 2021-09-20 10-21-59](https://user-images.githubusercontent.com/8207/134018843-35f16b2b-291a-4d85-aa33-00c7b9326f8c.png)

## Explanation

The call-seq deduplication introduced in b792230 and refined in 0ead786 returns a blank string if the alias's underlying method does not name the alias in its call-seq.

This change fixes alias call-seq to return nil in this case, which in turn means that the darkfish template will use `#param_seq` instead of rendering with a missing `method-heading` div.

This change also backfills test coverage for b792230 and 0ead786 to ensure deduplication still works as expected.
