### PR TITLE
RDoc::Options support for serializing Regexp

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -121,7 +121,7 @@ class RDoc::Options
 
   ##
   # Classes that are permitted to be loaded by load_options
-  PERMITTED_CLASSES = [RDoc::Options, Symbol]
+  PERMITTED_CLASSES = [RDoc::Options, Symbol, Regexp]
 
   ##
   # Option validator for OptionParser that matches a directory that exists on

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -120,6 +120,10 @@ class RDoc::Options
   ]
 
   ##
+  # Classes that are permitted to be loaded by load_options
+  PERMITTED_CLASSES = [RDoc::Options, Symbol]
+
+  ##
   # Option validator for OptionParser that matches a directory that exists on
   # the filesystem.
 
@@ -1293,7 +1297,7 @@ Usage: #{opt.program_name} [options] [names...]
     RDoc.load_yaml
 
     begin
-      options = YAML.safe_load File.read('.rdoc_options'), permitted_classes: [RDoc::Options, Symbol]
+      options = YAML.safe_load File.read('.rdoc_options'), permitted_classes: PERMITTED_CLASSES
     rescue Psych::SyntaxError
       raise RDoc::Error, "#{options_file} is not a valid rdoc options file"
     end

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -760,11 +760,22 @@ rdoc_include:
 
   def test_write_options
     temp_dir do |dir|
+      @options.files = []
+      @options.template = ""
+      @options.tab_width = 42
+      @options.finish
       @options.write_options
 
       assert File.exist? '.rdoc_options'
 
-      assert_equal @options, YAML.safe_load(File.read('.rdoc_options'), permitted_classes: RDoc::Options::PERMITTED_CLASSES)
+      options = RDoc::Options.load_options
+
+      %i[charset encoding exclude hyperlink_all line_numbers locale locale_dir main_page markup
+         output_decoration page_dir show_hash tab_width template_stylesheets title visibility
+         webcvs
+        ].each do |attr|
+        assert_equal(@options.send(attr), options.send(attr), "expected #{attr} to be equal")
+      end
     end
   end
 

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -145,7 +145,7 @@ class TestRDocOptions < RDoc::TestCase
 
     @options.encoding = Encoding::IBM437
 
-    options = YAML.safe_load(YAML.dump(@options), permitted_classes: [RDoc::Options, Symbol])
+    options = YAML.safe_load(YAML.dump(@options), permitted_classes: RDoc::Options::PERMITTED_CLASSES)
 
     assert_equal Encoding::IBM437, options.encoding
   end
@@ -161,7 +161,7 @@ rdoc_include:
 - /etc
     YAML
 
-    options = YAML.safe_load(yaml, permitted_classes: [RDoc::Options, Symbol])
+    options = YAML.safe_load(yaml, permitted_classes: RDoc::Options::PERMITTED_CLASSES)
 
     assert_empty options.rdoc_include
     assert_empty options.static_path
@@ -764,7 +764,7 @@ rdoc_include:
 
       assert File.exist? '.rdoc_options'
 
-      assert_equal @options, YAML.safe_load(File.read('.rdoc_options'), permitted_classes: [RDoc::Options, Symbol])
+      assert_equal @options, YAML.safe_load(File.read('.rdoc_options'), permitted_classes: RDoc::Options::PERMITTED_CLASSES)
     end
   end
 


### PR DESCRIPTION
## Description of the problem

Commits f0141d4 and 58c0804 introduced `YAML.safe_load` for reading in serialized `RDoc::Options` from an `.rdoc_options` file.

The only permitted classes are `RDoc::Options` and `Symbol`. However, if someone uses the `--write-options` option, the `exclude` property is serialized as a `Regexp` and cannot be deserialized:

```sh
$ rdoc --write-options --exclude=ext/java

$ cat .rdoc_options
--- !ruby/object:RDoc::Options
encoding: UTF-8
static_path: []
rdoc_include:
- "."
- "/home/redacted/foo"
charset: UTF-8
exclude: !ruby/regexp /~\z|\.orig\z|\.rej\z|\.bak\z|\.gemspec\z|(?-mix:ext\/java)/
hyperlink_all: false
line_numbers: false
locale:
locale_dir: locale
locale_name:
main_page:
markup: rdoc
output_decoration: true
page_dir:
show_hash: false
tab_width: 8
template_stylesheets: []
title:
visibility: :protected
webcvs:

$ rdoc lib ext
uh-oh! RDoc had a problem:
Tried to load unspecified class: Regexp

run with --debug for full backtrace
```

The exception in this case is a `Psych::DisallowedClass` from `YAML.safe_load`.

## The fix

This PR first extracts the set of permitted classes into an array constant in `RDoc::Options` and then adds `Regexp` to that constant.

Test coverage has been added by changing `test_write_options` to invoke `#finish` on the options before writing them, for a true round-trip which coerces the `@exclude` ivar into a `Regexp`. `test_write_options` now tests equality of a specific set of attributes, rather than asserting equality on the entire `Options` object, because deserialization does not include some attributes (like `@op_dir`) that are inspected by `#==`.
