### PR TITLE
feature: add support for `:category:` on C functions

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -26,6 +26,9 @@ class RDoc::AnyMethod < RDoc::MethodAttr
 
   attr_accessor :c_function
 
+  # The section title of the method (if defined in a C file via +:category:+)
+  attr_accessor :section_title
+
   # Parameters for this method
 
   attr_accessor :params

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -163,6 +163,8 @@ class RDoc::Markup::PreProcess
       if RDoc::Context === code_object then
         section = code_object.add_section param
         code_object.temporary_section = section
+      elsif RDoc::AnyMethod === code_object then
+        code_object.section_title = param
       end
 
       blankline # ignore category if we're not on an RDoc::Context

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -1028,7 +1028,12 @@ class RDoc::Parser::C < RDoc::Parser
 
 
         meth_obj.record_location @top_level
+
+        if meth_obj.section_title
+          class_obj.temporary_section = class_obj.add_section(meth_obj.section_title)
+        end
         class_obj.add_method meth_obj
+
         @stats.add_method meth_obj
         meth_obj.visibility = :private if 'private_method' == type
       end

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -1600,6 +1600,39 @@ Init_IO(void) {
     assert_equal "Method Comment!   ", read_method.comment.text
     assert_equal "rb_io_s_read", read_method.c_function
     assert read_method.singleton
+    assert_nil read_method.section.title
+  end
+
+  def test_define_method_with_category
+    content = <<-EOF
+/* :category: Awesome Methods
+   Method Comment!
+ */
+static VALUE
+rb_io_s_read(argc, argv, io)
+    int argc;
+    VALUE *argv;
+    VALUE io;
+{
+}
+
+void
+Init_IO(void) {
+    /*
+     * a comment for class Foo on rb_define_class
+     */
+    VALUE rb_cIO = rb_define_class("IO", rb_cObject);
+    rb_define_singleton_method(rb_cIO, "read", rb_io_s_read, -1);
+}
+    EOF
+
+    klass = util_get_class content, 'rb_cIO'
+    read_method = klass.method_list.first
+    assert_equal "read", read_method.name
+    assert_equal "Method Comment!", read_method.comment.text.strip
+    assert_equal "rb_io_s_read", read_method.c_function
+    assert read_method.singleton
+    assert_equal "Awesome Methods", read_method.section.title
   end
 
   def test_define_method_dynamically


### PR DESCRIPTION
In 2011, 0b45495 added the `:category:` directive, but this directive hasn't worked on C functions due to limitation in how the C parser builds context objects.

This changeset has the preprocessor temporarily store the "category" in `AnyMethod#section_title` so that when the C parser adds the method to the class, it can also create a section on the class.