### PR TITLE
fix: use the global format default for C file comments

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -173,6 +173,8 @@ class RDoc::Parser::C < RDoc::Parser
     @classes           = load_variable_map :c_class_variables
     @singleton_classes = load_variable_map :c_singleton_class_variables
 
+    @markup = @options.markup
+
     # class_variable => { function => [method, ...] }
     @methods = Hash.new { |h, f| h[f] = Hash.new { |i, m| i[m] = [] } }
 
@@ -1223,6 +1225,8 @@ class RDoc::Parser::C < RDoc::Parser
   end
 
   def new_comment text = nil, location = nil, language = nil
-    RDoc::Comment.new(text, location, language)
+    RDoc::Comment.new(text, location, language).tap do |comment|
+      comment.format = @markup
+    end
   end
 end

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -1946,6 +1946,23 @@ void Init_Blah(void) {
     assert_equal("rdoc", klass.attributes.find {|a| a.name == "default_format"}.comment.format)
   end
 
+  def test_markup_format_override
+    content = <<-EOF
+void Init_Blah(void) {
+  cBlah = rb_define_class("Blah", rb_cObject);
+
+  /*
+   * This should be interpreted in the default format.
+   */
+  rb_attr(cBlah, rb_intern("default_format"), 1, 1, Qfalse);
+}
+    EOF
+
+    @options.markup = "markdown"
+    klass = util_get_class content, 'cBlah'
+    assert_equal("markdown", klass.attributes.find {|a| a.name == "default_format"}.comment.format)
+  end
+
   def util_get_class content, name = nil
     @parser = util_parser content
     @parser.scan


### PR DESCRIPTION
__Describe the problem being solved__

When users set a default format choice with the `--markup=` option, comments from a C file do not inherit that default.

This means that even if I use `--markup=markdown`, the C comments would be parsed as if they were "rdoc".

__How is this problem solved?__

This changeset sets the default markup format for C comments to the global option when they're created during parsing. I've added test coverage for the previous behavior and the new behavior.

__Anything else reviewers should note?__

Note that RDoc::Markup::PreProcess will apply any comment-local `:markup:` directives in the `#handle` method, and override this default as necessary.
