### PR TITLE
Fix RDoc::Markup::Document#accept to do what it says

### DIFF
--- a/lib/rdoc/markup/document.rb
+++ b/lib/rdoc/markup/document.rb
@@ -60,12 +60,14 @@ class RDoc::Markup::Document
   end
 
   ##
-  # Runs this document and all its #items through +visitor+
+  # Runs this document and all its #parts through +visitor+
 
   def accept visitor
     visitor.start_accepting
 
     visitor.accept_document self
+
+    parts.each {|part| part.accept(visitor) }
 
     visitor.end_accepting
   end


### PR DESCRIPTION
Although the parts are not iterated in `Document#accept`, it seems they are iterated somewhere else according to the tests 

Not sure if the change is correct or if the method comment needs to be changed...