### PR TITLE
Optimize RawLine by using a regexp instead of negative look-ahead rule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [ 'head', '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ 'head', '3.0', '2.7', '2.6' ]
         os:
           - windows-latest
           - ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # 'bundle install' and cache
     # Avoid issues on these platforms
-    - if: ${{ matrix.ruby == '2.5' || matrix.ruby == '2.6' }}
+    - if: ${{ matrix.ruby == '2.6' }}
       run: gem update --system
     - name: Run test
       run: bundle exec rake

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -1135,7 +1135,7 @@ StartList = &.
             { [] }
 
 Line =  @RawLine:a { a }
-RawLine = ( < (!"\r" !"\n" .)* @Newline >
+RawLine = ( < /[^\r\n]*/ @Newline >
         | < .+ > @Eof ) { text }
 
 SkipBlock = HtmlBlock


### PR DESCRIPTION
This improves the performance in some cases.
`rdoc .../gems/sinatra-2.1.0/README.md` takes 10.5 sec. before this
change, and 7.1 sec. after this change.
`make rdoc` of ruby/ruby takes 19.3 sec. before this change, 18.1 sec.
after this change.