### PR TITLE
Windows pager support

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1544,7 +1544,7 @@ or the PAGER environment variable.
 
     jruby = RUBY_ENGINE == 'jruby'
 
-    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more', 'more.com']
+    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more']
 
     pagers.compact.uniq.each do |pager|
       next unless pager

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1150,7 +1150,7 @@ or the PAGER environment variable.
   # Is +file+ in ENV['PATH']?
 
   def in_path? file
-    extensions = [''].union(RbConfig::CONFIG["EXECUTABLE_EXTS"]&.split || RbConfig::CONFIG["EXEEXT"].to_a)
+    extensions = [''].union(RbConfig::CONFIG['EXECUTABLE_EXTS']&.split || [RbConfig::CONFIG['EXEEXT' || '']])
     if absolute_path?(file)
       extensions.any? do |ext|
         File.exist?(file + ext)

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1534,7 +1534,7 @@ or the PAGER environment variable.
     pagers.compact.uniq.each do |pager|
       next unless pager
 
-      pager_cmd = pager[/\A\s*(?:"\K[^"]+(?=")|\K\S+)/]}
+      pager_cmd = pager[/\A\s*(?:"\K[^"]+(?=")|\K\S+)/]
 
       next unless in_path? pager_cmd
 

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1544,7 +1544,7 @@ or the PAGER environment variable.
 
     jruby = RUBY_ENGINE == 'jruby'
 
-    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more']
+    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more', 'more.com']
 
     pagers.compact.uniq.each do |pager|
       next unless pager

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1150,7 +1150,7 @@ or the PAGER environment variable.
   # Is +file+ in ENV['PATH']?
 
   def in_path? file
-    extensions = [''].concat((windows? ? ENV['PATHEXT']&.split(File::PATH_SEPARATOR) : nil).to_a)
+    extensions = [''].union(RbConfig::CONFIG["EXECUTABLE_EXTS"]&.split || RbConfig::CONFIG["EXEEXT"].to_a)
     if absolute_path?(file)
       extensions.any? do |ext|
         File.exist?(file + ext)

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1534,11 +1534,7 @@ or the PAGER environment variable.
     pagers.compact.uniq.each do |pager|
       next unless pager
 
-      if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/
-        pager_cmd = pager.sub('Program Files', "\0").split(' ').first.sub("\0", 'Program Files').gsub('"', '')
-      else
-        pager_cmd = pager.split(' ').first
-      end
+      pager_cmd = pager[/\A\s*(?:"\K[^"]+(?=")|\K\S+)/]}
 
       next unless in_path? pager_cmd
 

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1521,7 +1521,7 @@ or the PAGER environment variable.
 
     jruby = RUBY_ENGINE == 'jruby'
 
-    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more']
+    pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more', 'more.com']
 
     pagers.compact.uniq.each do |pager|
       next unless pager


### PR DESCRIPTION
I want to use PAGER and colourful documents on windows too.

with Git for Windows installed,

```
set PAGER="c:\Program Files\Git\usr\bin\less.exe" -r
set RI=--format ansi
```

or with RubyInstaller's devkit,

```
set PAGER=ridk.cmd exec less -r
set RI=--format ansi
```

also, this affects IRB's Alt+d document browser.
(more.com not clears screen, so some corrupted display appears because of overwriting irb dialogs)