### PR TITLE
Use readline history when `ri` is running interactive

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1088,7 +1088,7 @@ or the PAGER environment variable.
 
     loop do
       name = if defined? Readline then
-               Readline.readline ">> "
+               Readline.readline ">> ", true
              else
                print ">> "
                $stdin.gets


### PR DESCRIPTION
With history support enabled, navigating deeper nested namespaces is a more enjoyable experience.