### PR TITLE
Add Ruby 3.1 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [ 'head', '3.0', '2.7', '2.6' ]
+        ruby: [ 'head', '3.1', '3.0', '2.7', '2.6' ]
         os:
           - windows-latest
           - ubuntu-latest


### PR DESCRIPTION
Enable testing with Ruby 3.1 in CI.