### PR TITLE
Skip parentheses on singleton class declaration

### DIFF
--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -4345,4 +4345,17 @@ end
     assert_equal 'Hello', meth.comment.text
   end
 
+  def test_parenthesized_cdecl
+    util_parser <<-RUBY
+module DidYouMean
+  class << (NameErrorCheckers = Object.new)
+  end
+end
+    RUBY
+
+    @parser.scan
+
+    refute_predicate @store.find_class_or_module('DidYouMean'), :nil?
+    refute_predicate @store.find_class_or_module('DidYouMean::NameErrorCheckers'), :nil?
+  end
 end


### PR DESCRIPTION
Parsing Ruby code with singleton class declaration with assignment generates a class name with `(`.

This is the example of the source code.

```rb
module DidYouMean
  class << (NameErrorCheckers = Object.new)
  end
end
```

This generates `DidYouMean::(NameErrorCheckers` class, and raises an error during load.

```
.../rdoc/lib/rdoc/store.rb:530:in `block in load_all': end pattern with unmatched parenthesis: /^DidYouMean::(NameErrorCheckers::[^:]+$/ (RegexpError)
```

This PR fixes the issue by ignoring surrounding parentheses.