### PR TITLE
Prefer `require 'cgi/util'` instead of `require 'cgi'`

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'cgi'
-
 ##
 # A Context is something that can hold modules, classes, methods, attributes,
 # aliases, requires, and includes. Classes, modules, and files are all

--- a/lib/rdoc/context/section.rb
+++ b/lib/rdoc/context/section.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'cgi/util'
+
 ##
 # A section of documentation like:
 #

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cgi'
+require 'cgi/util'
 
 ##
 # Outputs RDoc markup as HTML.

--- a/lib/rdoc/markup/to_label.rb
+++ b/lib/rdoc/markup/to_label.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cgi'
+require 'cgi/util'
 
 ##
 # Creates HTML-safe labels suitable for use in id attributes.  Tidylinks are

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -289,7 +289,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
   # HTML id-friendly method/attribute name
 
   def html_name
-    require 'cgi'
+    require 'cgi/util'
 
     CGI.escape(@name.gsub('-', '-2D')).gsub('%','-').sub(/^-/, '')
   end


### PR DESCRIPTION
RDoc is using only CGI.escape, escapeHTML, and unescape.
We don't have to load the whole source code of cgi gem.