### PR TITLE
Support crossref of methods with multiple arguments

### DIFF
--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -15,11 +15,21 @@ class RDoc::CrossReference
   CLASS_REGEXP_STR = '\\\\?((?:\:{2})?[A-Z]\w*(?:\:\:\w+)*)'
 
   ##
+  # Regular expression to match a single method argument.
+
+  METHOD_ARG_REGEXP_STR = '[\w.+*/=<>-]+'
+
+  ##
+  # Regular expression to match method arguments.
+
+  METHOD_ARGS_REGEXP_STR = /(?:\((?:#{METHOD_ARG_REGEXP_STR}(?:,\s*#{METHOD_ARG_REGEXP_STR})*)?\))?/.source
+
+  ##
   # Regular expression to match method references.
   #
   # See CLASS_REGEXP_STR
 
-  METHOD_REGEXP_STR = '([A-Za-z]\w*[!?=]?|%|=(?:==?|~)|![=~]|\[\]=?|<(?:<|=>?)?|>[>=]?|[-+!]@?|\*\*?|[/%`|&^~])(?:\([\w.+*/=<>-]*\))?'
+  METHOD_REGEXP_STR = /([A-Za-z]\w*[!?=]?|%|=(?:==?|~)|![=~]|\[\]=?|<(?:<|=>?)?|>[>=]?|[-+!]@?|\*\*?|[\/%`|&^~])#{METHOD_ARGS_REGEXP_STR}/.source
 
   ##
   # Regular expressions matching text that should potentially have

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -17,6 +17,12 @@ class TestRDocMarkupToHtmlCrossref < XrefTestCase
     assert_equal para("<a href=\"C1.html\"><code>C1</code></a>"), result
   end
 
+  def test_convert_CROSSREF_method
+    result = @to.convert 'C1#m(foo, bar, baz)'
+
+    assert_equal para("<a href=\"C1.html#method-i-m\"><code>C1#m(foo, bar, baz)</code></a>"), result
+  end
+
   def test_convert_CROSSREF_label
     result = @to.convert 'C1@foo'
     assert_equal para("<a href=\"C1.html#class-C1-label-foo\">foo at <code>C1</code></a>"), result


### PR DESCRIPTION
For example, consider the following markup:

```
C1#m(a, b)
```

Before this patch, it generated this HTML:

```
<p><a href=\"C1.html#method-i-m\"><code>C1#m</code></a>(a, b)</p>
```

Which places the method arguments outside of the link.

Now it generates this HTML:

```
<a href=\"C1.html#method-i-m\"><code>C1#m(a, b)</code></a>
```