### PR TITLE
Fold "class and module index" list

### DIFF
--- a/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
@@ -14,18 +14,20 @@
       -%><code><%= index_klass.name %></code><%-
     end
   end
-  -%>
-  <%- traverse = proc do |klasses| -%>
+  if top = all_classes[nil]
+    solo = top.one? {|klass| klass.display?}
+    traverse = proc do |klasses| -%>
   <ul class="link-list">
-    <%- klasses.each do |index_klass| -%>
-      <%- if children = all_classes[index_klass.full_name] -%>
-  <li><details><summary><% link.call(index_klass) %></summary>
-        <%- traverse.call(children) -%>
+      <%- klasses.each do |index_klass| -%>
+        <%- if children = all_classes[index_klass.full_name] -%>
+  <li><details<% if solo; solo = false %> open<% end %>><summary><% link.call(index_klass) %></summary>
+          <%- traverse.call(children) -%>
   </ul></details>
-      <%- elsif index_klass.display? -%>
+        <%- elsif index_klass.display? -%>
   <li><% link.call(index_klass, true) %>
+        <%- end -%>
       <%- end -%>
     <%- end -%>
+    <%- traverse.call(top) -%>
   <%- end -%>
-  <%- traverse.call(all_classes[nil]) -%>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_classes.rhtml
@@ -1,9 +1,31 @@
 <div id="classindex-section" class="nav-section">
   <h3>Class and Module Index</h3>
 
+  <%-
+  all_classes = @classes.group_by do |klass|
+    klass.full_name[/\A[^:]++(?:::[^:]++(?=::))*+(?=::[^:]*+\z)/]
+  end.delete_if do |_, klasses|
+    !klasses.any?(&:display?)
+  end
+  link = proc do |index_klass, display = index_klass.display?|
+    if display
+      -%><code><a href="<%= rel_prefix %>/<%= index_klass.path %>"><%= index_klass.name %></a></code><%-
+    else
+      -%><code><%= index_klass.name %></code><%-
+    end
+  end
+  -%>
+  <%- traverse = proc do |klasses| -%>
   <ul class="link-list">
-  <%- @modsort.each do |index_klass| -%>
-    <li><a href="<%= rel_prefix %>/<%= index_klass.path %>"><%= index_klass.full_name %></a>
+    <%- klasses.each do |index_klass| -%>
+      <%- if children = all_classes[index_klass.full_name] -%>
+  <li><details><summary><% link.call(index_klass) %></summary>
+        <%- traverse.call(children) -%>
+  </ul></details>
+      <%- elsif index_klass.display? -%>
+  <li><% link.call(index_klass, true) %>
+      <%- end -%>
+    <%- end -%>
   <%- end -%>
-  </ul>
+  <%- traverse.call(all_classes[nil]) -%>
 </div>

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -484,6 +484,22 @@ main header h3 {
 
 /* @group Method Details */
 
+details summary {
+  display: block;
+}
+details summary::-webkit-details-marker {
+  display: none;
+}
+details summary:before {
+  content: "";
+}
+details summary:after {
+  content: "  ▶";
+}
+details[open] > summary:after {
+  content: "  ▽";
+}
+
 main .method-source-code {
   max-height: 0;
   overflow: hidden;

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -72,11 +72,14 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
   def test_generate
     top_level = @store.add_file 'file.rb'
     top_level.add_class @klass.class, @klass.name
+    @klass.add_class RDoc::NormalClass, 'Inner'
 
     @g.generate
 
     assert_file 'index.html'
     assert_file 'Object.html'
+    assert_file 'Klass.html'
+    assert_file 'Klass/Inner.html'
     assert_file 'table_of_contents.html'
     assert_file 'js/search_index.js'
 
@@ -92,6 +95,8 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
     assert_match %r%<meta charset="#{encoding}">%, File.read('Object.html')
 
     refute_match(/Ignored/, File.read('index.html'))
+    summary = File.read('index.html')[%r[<summary.*Klass\.html.*</summary>.*</details>]m]
+    assert_match(%r[Klass/Inner\.html".*>Inner<], summary)
   end
 
   def test_generate_dry_run


### PR DESCRIPTION
In ruby 3.2, "class and module index" list has 1,200+ items, and many of them are inner classes/modules of others.
Folding the list will make the readability and searchability better.