### PR TITLE
Fix full name of known class

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -667,13 +667,14 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Finds a RDoc::NormalClass or RDoc::NormalModule for +raw_name+
 
-  def find_class(raw_name, name)
+  def find_class(raw_name, name, base_name = nil)
     unless @classes[raw_name]
       if raw_name =~ /^rb_m/
         container = @top_level.add_module RDoc::NormalModule, name
       else
         container = @top_level.add_class RDoc::NormalClass, name
       end
+      container.name = base_name if base_name
 
       container.record_location @top_level
       @classes[raw_name] = container
@@ -911,7 +912,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     return unless class_name
 
-    class_obj = find_class var_name, class_name
+    class_obj = find_class var_name, class_name, class_name[/::\K[^:]+\z/]
 
     unless class_obj then
       @options.warn 'Enclosing class or module %p is not known' % [const_name]

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -638,6 +638,17 @@ void Init_File(void) {
     assert_equal 'LOCK_SH',          constant.name
     assert_equal 'INT2FIX(LOCK_SH)', constant.value
     assert_equal 'Shared lock',      constant.comment.text
+
+    @parser = util_parser <<-EOF
+void Init_File(void) {
+  rb_cFile = rb_define_class("File", rb_cIO);
+  rb_mFConst = rb_define_module_under(rb_cFile, "Constants");
+}
+    EOF
+    @parser.do_classes_and_modules
+    @parser.do_constants
+
+    assert_equal 'File::Constants',  klass.full_name
   end
 
   def test_do_includes


### PR DESCRIPTION
Properly set the name of `File::Constants`, which is the only name with a namespace in `RDoc::KNOWN_CLASSES`, and fixes longstanding bug that `File::Constants` becomes `File::File::Constants`.

When it is generated by `rb_file_const` in dir.c, `name` is set to the qualified name as same as `full_name`, and generated in the normal way in file.c later, already set `full_name` is cleared and `name` will be constructed from the enclosing namespace and the `name`.
It will results in duplicated namespace, `File::File::Constants`.
