### PR TITLE
Apply matching word pairs to underscore-methods

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -150,9 +150,10 @@ class RDoc::Markup::AttributeManager
       exclusive == exclusive?(bitmap)
     }.keys
     return if tags.empty?
-    all_tags = @matching_word_pairs.keys
+    tags = "[#{tags.join("")}](?!#{PROTECT_ATTR})"
+    all_tags = "[#{@matching_word_pairs.keys.join("")}](?!#{PROTECT_ATTR})"
 
-    re = /(^|\W|[#{all_tags.join("")}])([#{tags.join("")}])(\2*[#\\]?[\w:.\/\[\]-]+?\S?)\2(?!\2)([#{all_tags.join("")}]|\W|$)/
+    re = /(^|\W|#{all_tags})(#{tags})(\2*[#\\]?[\w:#{PROTECT_ATTR}.\/\[\]-]+?\S?)\2(?!\2)(#{all_tags}|\W|$)/
 
     1 while str.gsub!(re) { |orig|
       attr = @matching_word_pairs[$2]

--- a/test/rdoc/test_rdoc_markup_attribute_manager.rb
+++ b/test/rdoc/test_rdoc_markup_attribute_manager.rb
@@ -145,6 +145,8 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
 
     assert_equal(["cat and ", @em_on, "5", @em_off, " dogs"],
                   @am.flow("cat and _5_ dogs"))
+
+    assert_equal([@tt_on, "__id__", @tt_off], @am.flow("+__id__+"))
   end
 
   def test_bold


### PR DESCRIPTION
Protected characters with `PROTECT_ATTR` should not have special roles.