### PR TITLE
Remove never used win32console

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -7,11 +7,6 @@ begin
 rescue LoadError
 end
 
-begin
-  require 'win32console'
-rescue LoadError
-end
-
 require_relative '../../rdoc'
 
 require_relative 'formatter' # For RubyGems backwards compatibility


### PR DESCRIPTION
win32console has never been used since added at 54dbcf70b60f17652650d09d081108887b5399f6.