### PR TITLE
Use command array form of `IO.popen` always

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -426,9 +426,6 @@ or the PAGER environment variable.
     @use_stdout  = options[:use_stdout]
     @show_all    = options[:show_all]
     @width       = options[:width]
-
-    # pager process for jruby
-    @jruby_pager_process = nil
   end
 
   ##
@@ -1045,36 +1042,6 @@ or the PAGER environment variable.
   end
 
   ##
-  # Finds the given +pager+ for jruby.  Returns an IO if +pager+ was found.
-  #
-  # Returns false if +pager+ does not exist.
-  #
-  # Returns nil if the jruby JVM doesn't support ProcessBuilder redirection
-  # (1.6 and older).
-
-  def find_pager_jruby pager
-    require 'java'
-    require 'shellwords'
-
-    return nil unless java.lang.ProcessBuilder.constants.include? :Redirect
-
-    pager = Shellwords.split pager
-
-    pb = java.lang.ProcessBuilder.new(*pager)
-    pb = pb.redirect_output java.lang.ProcessBuilder::Redirect::INHERIT
-
-    @jruby_pager_process = pb.start
-
-    input = @jruby_pager_process.output_stream
-
-    io = input.to_io
-    io.sync = true
-    io
-  rescue java.io.IOException
-    false
-  end
-
-  ##
   # Finds a store that matches +name+ which can be the name of a gem, "ruby",
   # "home" or "site".
   #
@@ -1503,23 +1470,14 @@ or the PAGER environment variable.
   def setup_pager
     return if @use_stdout
 
-    jruby = RUBY_ENGINE == 'jruby'
-
     pagers = [ENV['RI_PAGER'], ENV['PAGER'], 'pager', 'less', 'more']
 
+    require 'shellwords'
     pagers.compact.uniq.each do |pager|
-      next unless pager
+      pager = Shellwords.split(pager)
+      next if pager.empty?
 
-      if jruby then
-        case io = find_pager_jruby(pager)
-        when nil   then break
-        when false then next
-        else            io
-        end
-      else
-        io = IO.popen(pager, 'w') rescue next
-      end
-
+      io = IO.popen(pager, 'w') rescue next
       next if $? and $?.pid == io.pid and $?.exited? # pager didn't work
 
       @paging = true


### PR DESCRIPTION
So that an exception raises by non-existent command, not via shell.