### PR TITLE
Fix call-seq for aliased method with similar names

### DIFF
--- a/lib/rdoc/any_method.rb
+++ b/lib/rdoc/any_method.rb
@@ -350,12 +350,12 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       ignore << is_alias_for.name
       ignore.concat is_alias_for.aliases.map(&:name)
     end
-    ignore.map! { |n| n =~ /\A\[/ ? n[0, 1] : n}
+    ignore.map! { |n| n =~ /\A\[/ ? /\[.*\]/ : n}
     ignore.delete(method_name)
     ignore = Regexp.union(ignore)
 
     matching = entries.reject do |entry|
-      entry =~ /^\w*\.?#{ignore}/ or
+      entry =~ /^\w*\.?#{ignore}[$\(\s]/ or
         entry =~ /\s#{ignore}\s/
     end
 

--- a/test/rdoc/test_rdoc_any_method.rb
+++ b/test/rdoc/test_rdoc_any_method.rb
@@ -51,6 +51,20 @@ method(a, b) { |c, d| ... }
     assert_equal 'foo', m.call_seq
   end
 
+  def test_call_seq_alias_for
+    a = RDoc::AnyMethod.new nil, "each"
+    m = RDoc::AnyMethod.new nil, "each_line"
+
+    a.call_seq = <<-CALLSEQ
+each(foo)
+each_line(foo)
+    CALLSEQ
+
+    m.is_alias_for = a
+
+    assert_equal "each_line(foo)", m.call_seq
+  end
+
   def test_full_name
     assert_equal 'C1::m', @c1.method_list.first.full_name
   end


### PR DESCRIPTION
`deduplicate_call_seq` has a bug that skips call-seq for methods where the alias is a prefix of the method name. For example, if the alias name is "each" and the current method name is "each_line", then `deduplicate_call_seq` will skip all call-seq for "each_line" since it will believe that it is for the alias.

Before:

<img width="756" alt="Screen Shot 2022-07-15 at 5 43 14 PM" src="https://user-images.githubusercontent.com/15860699/179314960-37225979-6a7e-4d82-bec1-b2ddbdb435aa.png">

After:

<img width="743" alt="Screen Shot 2022-07-15 at 5 43 31 PM" src="https://user-images.githubusercontent.com/15860699/179314979-3429d887-ca77-49d6-9b11-d9314e23e953.png">

