### PR TITLE
Allow multiple footnotes without in-between blank lines

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -449,7 +449,7 @@
 
       @note_order.each_with_index do |ref, index|
         label = index + 1
-        note = @footnotes[ref]
+        note = @footnotes[ref] or raise ParseError, "footnote [^#{ref}] not found"
 
         link = "{^#{label}}[rdoc-label:footmark-#{label}:foottext-#{label}] "
         note.parts.unshift link
@@ -1179,7 +1179,7 @@ InlineNote = &{ notes? }
 Notes = ( Note | SkipBlock )*
 
 RawNoteBlock = @StartList:a
-               ( !@BlankLine OptionallyIndentedLine:l { a << l } )+
+               ( !@BlankLine !RawNoteReference OptionallyIndentedLine:l { a << l } )+
                ( < @BlankLine* > { a << text } )
                { a }
 

--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -761,7 +761,6 @@ with inline notes^[like this]
 and an extra note.[^2]
 
 [^1]: With a footnote
-
 [^2]: Which should be numbered correctly
     MD
 


### PR DESCRIPTION
ruby/ruby@e4e054e3ce409f1c1d04bf7cd75aa9238e205d52 used four footnotes without blank lines.
And the ChangeLog generated from that commit resulted in ``undefined method `parts' for nil`` error.

For now, let a footnote terminated by the next footnote mark.

Also refined the error message when undefined footnote is used.