### PR TITLE
[DOC] Make example formats explicit and consistent

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -36,10 +36,8 @@ require 'rdoc'
 #
 # The treatment of markup in comments varies according to the type of file:
 #
-# - <tt>.rb</tt> (Ruby code file): markup is parsed from Ruby comments;
-#   see {Code Comments}[rdoc-ref:doc/syntax/comments.rdoc].
-# - <tt>.c</tt> (C code file): markup is parsed from C comments;
-#   see {C Comments}[https://www.w3schools.com/c/c_comments.php].
+# - <tt>.rb</tt> (Ruby code file): markup is parsed from Ruby comments.
+# - <tt>.c</tt> (C code file): markup is parsed from C comments.
 # - <tt>.rdoc</tt> (RDoc text file): markup is parsed from the entire file.
 #
 # In Ruby or C file, a comment that immediately precedes the definition

--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -41,13 +41,14 @@ require 'rdoc'
 # - <tt>.rdoc</tt> (RDoc text file): markup is parsed from the entire file.
 #
 # The comment associated with
-# o Ruby class, module, method, alias, constant, or attribute
+# a Ruby class, module, method, alias, constant, or attribute
 # becomes the documentation for that defined object:
 #
 # - In a Ruby file, that comment immediately precedes
 #   the definition of the object.
 # - In a C file, that comment immediately precedes
-#   the function that implements the object.
+#   the function that implements a method,
+#   or otherwise immediately precedes the definition of the object.
 #
 # In either a Ruby or a C file,
 # \RDoc ignores comments that do not precede object definitions.

--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -40,10 +40,17 @@ require 'rdoc'
 # - <tt>.c</tt> (C code file): markup is parsed from C comments.
 # - <tt>.rdoc</tt> (RDoc text file): markup is parsed from the entire file.
 #
-# In Ruby or C file, a comment that immediately precedes the definition
-# of a Ruby class, module, method, alias, constant, or attribute
-# becomes the documentation for that defined object.
-# \RDoc ignores other such comments that do not precede object definitions.
+# The comment associated with
+# o Ruby class, module, method, alias, constant, or attribute
+# becomes the documentation for that defined object:
+#
+# - In a Ruby file, that comment immediately precedes
+#   the definition of the object.
+# - In a C file, that comment immediately precedes
+#   the function that implements the object.
+#
+# In either a Ruby or a C file,
+# \RDoc ignores comments that do not precede object definitions.
 #
 # In an \RDoc file, the text is not associated with any code object,
 # but may (depending on how the documentation is built),

--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -29,16 +29,31 @@ require 'rdoc'
 #   see <tt>:nodoc:</tt>, <tt>:doc:</tt>, and <tt>:notnew</tt>.
 # - \RDoc directives in single-line comments;
 #   see other {Directives}[rdoc-ref:RDoc::MarkupReference@Directives].
-# - The Ruby code itself;
+# - The Ruby code itself (but not from C code);
 #   see {Documentation Derived from Ruby Code}[rdoc-ref:RDoc::MarkupReference@Documentation+Derived+from+Ruby+Code]
 #
 # == Markup in Comments
 #
-# A single-line or multi-line comment that immediately precedes
-# the definition of a class, module, method, alias, constant, or attribute
-# becomes the documentation for that defined object.
+# The treatment of markup in comments varies according to the type of file:
 #
-# (\RDoc ignores other such comments that do not precede definitions.)
+# - <tt>.rb</tt> (Ruby code file): markup is parsed from Ruby comments;
+#   see {Code Comments}[rdoc-ref:doc/syntax/comments.rdoc].
+# - <tt>.c</tt> (C code file): markup is parsed from C comments;
+#   see {C Comments}[https://www.w3schools.com/c/c_comments.php].
+# - <tt>.rdoc</tt> (RDoc text file): markup is parsed from the entire file.
+#
+# In Ruby or C file, a comment that immediately precedes the definition
+# of a Ruby class, module, method, alias, constant, or attribute
+# becomes the documentation for that defined object.
+# \RDoc ignores other such comments that do not precede object definitions.
+#
+# In an \RDoc file, the text is not associated with any code object,
+# but may (depending on how the documentation is built),
+# become a separate page.
+#
+# Almost all examples on this page are all RDoc-like;
+# that is, they have no comment markers like Ruby <tt>#</tt>
+# or C <tt>/* ... */</tt>.
 #
 # === Margins
 #
@@ -82,11 +97,11 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # \RDoc produces HTML and command-line documentation for Ruby projects.
-#   # \RDoc includes the rdoc and ri tools for generating and displaying
-#   # documentation from the command-line.
-#   #
-#   # You'll love it.
+#   \RDoc produces HTML and command-line documentation for Ruby projects.
+#   \RDoc includes the rdoc and ri tools for generating and displaying
+#   documentation from the command-line.
+#
+#   You'll love it.
 #
 # Rendered HTML:
 # >>>
@@ -118,15 +133,15 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # This is not verbatim text.
-#   #
-#   #   This is verbatim text.
-#   #     Whitespace is honored.     # See?
-#   #       Whitespace is honored.     # See?
-#   #
-#   #   This is still the same verbatim text block.
-#   #
-#   # This is not verbatim text.
+#   This is not verbatim text.
+#
+#     This is verbatim text.
+#       Whitespace is honored.     # See?
+#         Whitespace is honored.     # See?
+#
+#     This is still the same verbatim text block.
+#
+#   This is not verbatim text.
 #
 # Rendered HTML:
 # >>>
@@ -253,13 +268,13 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # - An item.
-#   # - Another.
-#   # - An item spanning
-#   #   multiple lines.
-#   #
-#   # * Yet another.
-#   # - Last one.
+#   - An item.
+#   - Another.
+#   - An item spanning
+#     multiple lines.
+#
+#   * Yet another.
+#   - Last one.
 #
 # Rendered HTML:
 # >>>
@@ -279,13 +294,13 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # 100. An item.
-#   # 10. Another.
-#   # 1. An item spanning
-#   #    multiple lines.
-#   #
-#   # 1. Yet another.
-#   # 1000. Last one.
+#   100. An item.
+#   10. Another.
+#   1. An item spanning
+#      multiple lines.
+#
+#   1. Yet another.
+#   1000. Last one.
 #
 # Rendered HTML:
 # >>>
@@ -305,13 +320,13 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # z. An item.
-#   # y. Another.
-#   # x. An item spanning
-#   #    multiple lines.
-#   #
-#   # x. Yet another.
-#   # a. Last one.
+#   z. An item.
+#   y. Another.
+#   x. An item spanning
+#      multiple lines.
+#
+#   x. Yet another.
+#   a. Last one.
 #
 # Rendered HTML:
 # >>>
@@ -330,13 +345,13 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # [foo] An item.
-#   # bat:: Another.
-#   # [bag] An item spanning
-#   #       multiple lines.
-#   #
-#   # [bar baz] Yet another.
-#   # bam:: Last one.
+#   [foo] An item.
+#   bat:: Another.
+#   [bag] An item spanning
+#         multiple lines.
+#
+#   [bar baz] Yet another.
+#   bam:: Last one.
 #
 # Rendered HTML:
 # >>>
@@ -355,20 +370,20 @@ require 'rdoc'
 #
 # Examples:
 #
-#   # = Section 1
-#   # == Section 1.1
-#   # === Section 1.1.1
-#   # === Section 1.1.2
-#   # == Section 1.2
-#   # = Section 2
-#   # = Foo
-#   # == Bar
-#   # === Baz
-#   # ==== Bam
-#   # ===== Bat
-#   # ====== Bad
-#   # ============Still a Heading (Level 6)
-#   # \== Not a Heading
+#   = Section 1
+#   == Section 1.1
+#   === Section 1.1.1
+#   === Section 1.1.2
+#   == Section 1.2
+#   = Section 2
+#   = Foo
+#   == Bar
+#   === Baz
+#   ==== Bam
+#   ===== Bat
+#   ====== Bad
+#   ============Still a Heading (Level 6)
+#   \== Not a Heading
 #
 # ==== Horizontal Rules
 #
@@ -376,14 +391,14 @@ require 'rdoc'
 #
 # Example input:
 #
-#   # ------
-#   # Stuff between.
-#   #
-#   # \--- Not a horizontal rule.
-#   #
-#   # -- Also not a horizontal rule.
-#   #
-#   # ---
+#   ------
+#   Stuff between.
+#
+#   \--- Not a horizontal rule.
+#
+#   -- Also not a horizontal rule.
+#
+#   ---
 #
 # Rendered HTML:
 # >>>
@@ -595,23 +610,23 @@ require 'rdoc'
 #
 # Examples:
 #
-#   # _Word_ in paragraph.
-#   # - _Word_ in bullet list item.
-#   # 1. _Word_ in numbered list item.
-#   # a. _Word_ in lettered list item.
-#   # [_word_] _Word_ in labeled list item.
-#   # ====== _Word_ in heading
+#   _Word_ in paragraph.
+#   - _Word_ in bullet list item.
+#   1. _Word_ in numbered list item.
+#   a. _Word_ in lettered list item.
+#   [_word_] _Word_ in labeled list item.
+#   ====== _Word_ in heading
 #
 # Any text may be italicized via HTML tag +i+ or +em+.
 #
 # Examples:
 #
-#   # <i>Two words</i> in paragraph.
-#   # - <i>Two words</i> in bullet list item.
-#   # 1. <i>Two words</i> in numbered list item.
-#   # a. <i>Two words</i> in lettered list item.
-#   # [<i>Two words</i>] <i>Two words</i> in labeled list item.
-#   # ====== <i>Two words</i> in heading
+#   <i>Two words</i> in paragraph.
+#   - <i>Two words</i> in bullet list item.
+#   1. <i>Two words</i> in numbered list item.
+#   a. <i>Two words</i> in lettered list item.
+#   [<i>Two words</i>] <i>Two words</i> in labeled list item.
+#   ====== <i>Two words</i> in heading
 #
 # ==== Bold
 #
@@ -619,23 +634,23 @@ require 'rdoc'
 #
 # Examples:
 #
-#   # *Word* in paragraph.
-#   # - *Word* in bullet list item.
-#   # 1. *Word* in numbered list item.
-#   # a. *Word* in lettered list item.
-#   # [*word*] *Word* in labeled list item.
-#   # ====== *Word* in heading
+#   *Word* in paragraph.
+#   - *Word* in bullet list item.
+#   1. *Word* in numbered list item.
+#   a. *Word* in lettered list item.
+#   [*word*] *Word* in labeled list item.
+#   ====== *Word* in heading
 #
 # Any text may be made bold via HTML tag +b+.
 #
 # Examples:
 #
-#   # <b>Two words</b> in paragraph.
-#   # - <b>Two words</b> in bullet list item.
-#   # 1. <b>Two words</b> in numbered list item.
-#   # a. <b>Two words</b> in lettered list item.
-#   # [<b>Two words</b>] <b>Two words</b> in labeled list item.
-#   # ====== <b>Two words</b> in heading
+#   <b>Two words</b> in paragraph.
+#   - <b>Two words</b> in bullet list item.
+#   1. <b>Two words</b> in numbered list item.
+#   a. <b>Two words</b> in lettered list item.
+#   [<b>Two words</b>] <b>Two words</b> in labeled list item.
+#   ====== <b>Two words</b> in heading
 #
 # ==== Monofont
 #
@@ -644,23 +659,23 @@ require 'rdoc'
 #
 # Examples:
 #
-#   # +Word+ in paragraph.
-#   # - +Word+ in bullet list item.
-#   # 1. +Word+ in numbered list item.
-#   # a. +Word+ in lettered list item.
-#   # [+word+] +Word+ in labeled list item.
-#   # ====== +Word+ in heading
+#   +Word+ in paragraph.
+#   - +Word+ in bullet list item.
+#   1. +Word+ in numbered list item.
+#   a. +Word+ in lettered list item.
+#   [+word+] +Word+ in labeled list item.
+#   ====== +Word+ in heading
 #
 # Any text may be made monofont via HTML tag +tt+ or +code+.
 #
 # Examples:
 #
-#   # <tt>Two words</tt> in paragraph.
-#   # - <tt>Two words</tt> in bullet list item.
-#   # 1. <tt>Two words</tt> in numbered list item.
-#   # a. <tt>Two words</tt> in lettered list item.
-#   # [<tt>Two words</tt>] <tt>Two words</tt> in labeled list item.
-#   # ====== <tt>Two words</tt> in heading
+#   <tt>Two words</tt> in paragraph.
+#   - <tt>Two words</tt> in bullet list item.
+#   1. <tt>Two words</tt> in numbered list item.
+#   a. <tt>Two words</tt> in lettered list item.
+#   [<tt>Two words</tt>] <tt>Two words</tt> in labeled list item.
+#   ====== <tt>Two words</tt> in heading
 #
 # ==== Escaping Text Markup
 #
@@ -1008,10 +1023,10 @@ class RDoc::MarkupReference
   #
   # Here is the <tt>:call-seq:</tt> directive given for the method:
   #
-  #   # :call-seq:
-  #   #   call_seq_directive(foo, bar)
-  #   #   Can be anything -> bar
-  #   #   Also anything more -> baz or bat
+  #   :call-seq:
+  #     call_seq_directive(foo, bar)
+  #     Can be anything -> bar
+  #     Also anything more -> baz or bat
   #
   def call_seq_directive
     nil

--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -30,7 +30,7 @@ require 'rdoc'
 # - \RDoc directives in single-line comments;
 #   see other {Directives}[rdoc-ref:RDoc::MarkupReference@Directives].
 # - The Ruby code itself (but not from C code);
-#   see {Documentation Derived from Ruby Code}[rdoc-ref:RDoc::MarkupReference@Documentation+Derived+from+Ruby+Code]
+#   see {Documentation Derived from Ruby Code}[rdoc-ref:RDoc::MarkupReference@Documentation+Derived+from+Ruby+Code].
 #
 # == Markup in Comments
 #


### PR DESCRIPTION
- Add remarks about example formats (almost none with `#` or `/* ... */`).
- Remove leading `#` from most examples.