### PR TITLE
Add keydown event listener to focus on search field

### DIFF
--- a/lib/rdoc/generator/template/darkfish/_sidebar_search.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_search.rhtml
@@ -3,7 +3,7 @@
     <div id="search-field-wrapper">
       <input id="search-field" role="combobox" aria-label="Search"
              aria-autocomplete="list" aria-controls="search-results"
-             type="text" name="search" placeholder="Search" spellcheck="false"
+             type="text" name="search" placeholder="Search (/) for a class, method, ..." spellcheck="false"
              title="Type to search, Up and Down to navigate, Enter to load">
     </div>
 

--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -78,7 +78,20 @@ function hookSearch() {
   search.scrollIntoView = search.scrollInWindow;
 };
 
+function hookFocus() {
+  document.addEventListener("keydown", (event) => {
+    if (document.activeElement.tagName === 'INPUT') {
+      return;
+    }
+    if (event.key === "/") {
+      event.preventDefault();
+      document.querySelector('#search-field').focus();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   hookSourceViews();
   hookSearch();
+  hookFocus();
 });


### PR DESCRIPTION
Pressing the shortcut key (`/`, as seen at [Ruby on Rails API](https://api.rubyonrails.org/)) to focus on the search form.