### PR TITLE
Fix ruby script in "test_parse_method_bracket"

### DIFF
--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -1960,10 +1960,10 @@ end
   def test_parse_method_bracket
     util_parser <<-RUBY
 class C
-  def [] end
-  def self.[] end
-  def []= end
-  def self.[]= end
+  def []; end
+  def self.[]; end
+  def []=; end
+  def self.[]=; end
 end
     RUBY
 


### PR DESCRIPTION
Because it's syntax error.