### PR TITLE
Update RuboCop task in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,5 +106,7 @@ else
   RuboCop::RakeTask.new(:rubocop) do |t|
     t.options = [*parsed_files]
   end
-  task :build => [:generate, "rubocop:auto_correct"]
+  is_newer_rubocop = RuboCop.const_defined?(:Version) && Gem::Version.new(RuboCop::Version::STRING) >= '1.31.0'
+  rubocop_task = is_newer_rubocop ? "rubocop:autocorrect" : "rubocop:auto_correct"
+  task :build => [:generate, rubocop_task]
 end


### PR DESCRIPTION
If the RuboCop version is 1.31 or later then use `rubocop:autocorrect` task instead of deprecated `rubocop:auto_correct`
in the `Rakefile`. Otherwise use the conventional `rubocop:auto_correct` task.

See also: RuboCop changelog > [1.31.0 (2022-06-27) - Changes](https://github.com/rubocop/rubocop/blob/aa65208d54944334f18f8e7c955c276ebe634dd9/CHANGELOG.md#changes-5) > https://github.com/rubocop/rubocop/pull/10709