### PR TITLE
Remove unused abbrev require

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'abbrev'
 require 'optparse'
 
 begin


### PR DESCRIPTION
This library originally used [`abbrev`](https://github.com/ruby/abbrev) to expand abbreviations into fully-qualified classes, but that was replaced in
https://github.com/ruby/rdoc/commit/f9ffe6684e2afeac65c62bf1a5a2fce729f21001

`abbrev` is no longer used anywhere, so this commit removes the require.