### PR TITLE
Change `CONTRIBUTING.md` to direct readers to rdoc's GitHub Actions page

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -34,8 +34,7 @@ RDoc uses bundler for development.  To get ready to work on RDoc run:
 This will install all the necessary dependencies for development with rake,
 generate documentation and run the tests for the first time.
 
-If the tests don't pass on the first run check the {Travis CI page for
-RDoc}[https://travis-ci.org/ruby/rdoc] to see if there are any known failures
+If the tests don't pass on the first run check the {GitHub Actions page}[https://github.com/ruby/rdoc/actions] to see if there are any known failures
 (there shouldn't be).
 
 You can now use `rake` and `autotest` to run the tests.


### PR DESCRIPTION
This is pretty minor.

I was going through the CONTRIBUTING.md because I was interested in contributing to the repo and noticed that it directs us to check a Travis CI page if test fail to see if they might be known failures.

However, I saw that the last run was from 3 years ago and that rdoc now uses GitHub Actions.

I decided to just go ahead and update the link.