### PR TITLE
Delay `require "readline"` in case the terminal is in raw mode

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 require 'optparse'
 
-begin
-  require 'readline'
-rescue LoadError
-end
-
 require_relative '../../rdoc'
 
 require_relative 'formatter' # For RubyGems backwards compatibility
@@ -1079,6 +1074,10 @@ or the PAGER environment variable.
   def interactive
     puts "\nEnter the method name you want to look up."
 
+    begin
+      require 'readline'
+    rescue LoadError
+    end
     if defined? Readline then
       Readline.completion_proc = method :complete
       puts "You can use tab to autocomplete."


### PR DESCRIPTION
`require "rdoc/ri/driver"` turns the terminal in cooked mode because it requires readline.
readline is necessary only in interactive mode, so how about to delay it.

