### PR TITLE
Fix up Relative loading (#821)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,14 +37,12 @@ task ghpages: :rdoc do
 end
 
 Rake::TestTask.new(:normal_test) do |t|
-  t.libs = []
   t.verbose = true
   t.deps = :generate
   t.test_files = FileList["test/**/test_*.rb"].exclude("test/rdoc/test_rdoc_rubygems_hook.rb")
 end
 
 Rake::TestTask.new(:rubygems_test) do |t|
-  t.libs = []
   t.verbose = true
   t.deps = :generate
   t.pattern = "test/rdoc/test_rdoc_rubygems_hook.rb"


### PR DESCRIPTION
Since also the template files are searched from the `$LOAD_PATH`, the current library should not be removed.