### PR TITLE
Fix fragile tests

### DIFF
--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -598,7 +598,7 @@ class TestRDocRIDriver < RDoc::TestCase
     assert_match %r%^= Attributes:%, out
     assert_match %r%^  attr_accessor attr%, out
 
-    assert_equal 1, out.scan(/-\n/).length
+    assert_equal 1, out.scan(/^-{50,}$/).length, out
 
     refute_match %r%Foo::Bar#blah%, out
   end
@@ -622,7 +622,7 @@ class TestRDocRIDriver < RDoc::TestCase
     assert_match %r%^= Attributes:%, out
     assert_match %r%^  attr_accessor attr%, out
 
-    assert_equal 6, out.scan(/-\n/).length
+    assert_equal 6, out.scan(/^-{50,}$/).length, out
 
     assert_match %r%Foo::Bar#blah%, out
   end


### PR DESCRIPTION
When the temporary path is long enough, the formatter may fold the path and may hit a hyphen at the end of line, and miscounted.