### PR TITLE
Fix to use KeyboardEvent.key over keyCode

### DIFF
--- a/lib/rdoc/generator/template/darkfish/js/search.js
+++ b/lib/rdoc/generator/template/darkfish/js/search.js
@@ -15,9 +15,9 @@ Search.prototype = Object.assign({}, Navigation, new function() {
   this.init = function() {
     var _this = this;
     var observer = function(e) {
-      switch(e.keyCode) {
-        case 38: // Event.KEY_UP
-        case 40: // Event.KEY_DOWN
+      switch(e.key) {
+        case 'ArrowUp':
+        case 'ArrowDown':
           return;
       }
       _this.search(_this.input.value);

--- a/lib/rdoc/generator/template/json_index/js/navigation.js
+++ b/lib/rdoc/generator/template/json_index/js/navigation.js
@@ -23,24 +23,24 @@ Navigation = new function() {
 
   this.onkeydown = function(e) {
     if (!this.navigationActive) return;
-    switch(e.keyCode) {
-      case 37: //Event.KEY_LEFT:
+    switch(e.key) {
+      case 'ArrowLeft':
         if (this.moveLeft()) e.preventDefault();
         break;
-      case 38: //Event.KEY_UP:
-        if (e.keyCode == 38 || e.ctrlKey) {
+      case 'ArrowUp':
+        if (e.key == 'ArrowUp' || e.ctrlKey) {
           if (this.moveUp()) e.preventDefault();
         }
         break;
-      case 39: //Event.KEY_RIGHT:
+      case 'ArrowRight':
         if (this.moveRight()) e.preventDefault();
         break;
-      case 40: //Event.KEY_DOWN:
-        if (e.keyCode == 40 || e.ctrlKey) {
+      case 'ArrowDown':
+        if (e.key == 'ArrowDown' || e.ctrlKey) {
           if (this.moveDown()) e.preventDefault();
         }
         break;
-      case 13: //Event.KEY_RETURN:
+      case 'Enter':
         if (this.current) e.preventDefault();
         this.select(this.current);
         break;


### PR DESCRIPTION
`KeyboardEvent.keyCode` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode), so this replaces them with `KeyboardEvent.key`.