### PR TITLE
Actually execute RDoc document task for coverage

### DIFF
--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -259,6 +259,7 @@ class RDoc::Task < Rake::TaskLib
         args = opts + @rdoc_files
 
         $stderr.puts "rdoc #{args.join ' '}" if Rake.application.options.trace
+        RDoc::RDoc.new.document args
       end
     end
 

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -209,6 +209,13 @@ rdoc_include:
     assert @options.force_update
   end
 
+  def test_parse_coverage_C
+    @options.parse %w[-C]
+
+    assert @options.coverage_report
+    assert @options.force_update
+  end
+
   def test_parse_coverage_no
     @options.parse %w[--no-dcov]
 
@@ -219,6 +226,19 @@ rdoc_include:
     @options.parse %w[--dcov=1]
 
     assert_equal 1, @options.coverage_report
+  end
+
+  def test_parse_coverage_C_level_1
+    @options.parse %w[-C1]
+
+    assert_equal 1, @options.coverage_report
+  end
+
+  def test_parse_coverage_C_level_0
+    @options.parse %w[-C0]
+
+    assert_equal 0, @options.coverage_report
+    assert @options.force_update
   end
 
   def test_parse_dash_p


### PR DESCRIPTION
There aren't currently any functional tests for the coverage task, I spent about 30 minutes but gave up. This is a small enough change, and I've tested it locally with Rails.

Was able to add some tiny coverage for `-C` flag however.