### PR TITLE
Add breadcrumb list

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -298,19 +298,19 @@ class RDoc::ClassModule < RDoc::Context
   ##
   # Return array of full_name splitted by +::+.
 
-  def namespaces
+  def nesting_namespaces
     @namespaces ||= full_name.split("::").reject(&:empty?)
   end
 
   ##
-  # Return array of fully qualified namespaces.
+  # Return array of fully qualified nesting namespaces.
   #
   # For example, if full_name is +A::B::C+, this method returns <code>["A", "A::B", "A::B::C"]</code>
 
-  def fully_qualified_namespaces
-    return namespaces if namespaces.length < 2
-    @fqns ||= namespaces.map.with_index do |_, i|
-      namespaces[0..i].join("::")
+  def fully_qualified_nesting_namespaces
+    return nesting_namespaces if nesting_namespaces.length < 2
+    @fqns ||= nesting_namespaces.map.with_index do |_, i|
+      nesting_namespaces[0..i].join("::")
     end
   end
 

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -296,6 +296,25 @@ class RDoc::ClassModule < RDoc::Context
   end
 
   ##
+  # Return array of full_name splitted by +::+.
+
+  def namespaces
+    @namespaces ||= full_name.split("::").reject(&:empty?)
+  end
+
+  ##
+  # Return array of fully qualified namespaces.
+  #
+  # For example, if full_name is +A::B::C+, this method returns <code>["A", "A::B", "A::B::C"]</code>
+
+  def fully_qualified_namespaces
+    return namespaces if namespaces.length < 2
+    @fqns ||= namespaces.map.with_index do |_, i|
+      namespaces[0..i].join("::")
+    end
+  end
+
+  ##
   # TODO: filter included items by #display?
 
   def marshal_dump # :nodoc:

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -309,8 +309,8 @@ class RDoc::ClassModule < RDoc::Context
 
   def fully_qualified_nesting_namespaces
     return nesting_namespaces if nesting_namespaces.length < 2
-    @fqns ||= nesting_namespaces.map.with_index do |_, i|
-      nesting_namespaces[0..i].join("::")
+    @fqns ||= nesting_namespaces.inject([]) do |list, n|
+      list << (list.empty? ? n : "#{list.last}::#{n}")
     end
   end
 

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -353,6 +353,8 @@ class RDoc::Generator::Darkfish
     asset_rel_prefix = rel_prefix + @asset_rel_path
     svninfo          = get_svninfo(current)
 
+    breadcrumb = generate_namespaces_breadcrumb(current, rel_prefix)
+
     @title = "#{klass.type} #{klass.full_name} - #{@options.title}"
 
     debug_msg "  rendering #{out_file}"
@@ -827,5 +829,23 @@ class RDoc::Generator::Darkfish
     content << generate_ancestor_list(ancestors, klass)
 
     content << '</li></ul>'
+  end
+
+  private
+
+  def namespaces_to_class_modules klass
+    tree = {}
+
+    klass.namespaces.zip(klass.fully_qualified_namespaces) do |ns, fqns|
+      tree[ns] = @store.classes_hash[fqns] || @store.modules_hash[fqns]
+    end
+
+    tree
+  end
+
+  def generate_namespaces_breadcrumb klass, rel_prefix
+    namespaces_to_class_modules(klass).map do |namespace, class_module|
+      { name: namespace, path: (rel_prefix + class_module.path).to_s, self: klass.full_name == class_module.full_name }
+    end
   end
 end

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -353,7 +353,7 @@ class RDoc::Generator::Darkfish
     asset_rel_prefix = rel_prefix + @asset_rel_path
     svninfo          = get_svninfo(current)
 
-    breadcrumb = generate_namespaces_breadcrumb(current, rel_prefix)
+    breadcrumb = generate_nesting_namespaces_breadcrumb(current, rel_prefix)
 
     @title = "#{klass.type} #{klass.full_name} - #{@options.title}"
 
@@ -833,18 +833,18 @@ class RDoc::Generator::Darkfish
 
   private
 
-  def namespaces_to_class_modules klass
+  def nesting_namespaces_to_class_modules klass
     tree = {}
 
-    klass.namespaces.zip(klass.fully_qualified_namespaces) do |ns, fqns|
+    klass.nesting_namespaces.zip(klass.fully_qualified_nesting_namespaces) do |ns, fqns|
       tree[ns] = @store.classes_hash[fqns] || @store.modules_hash[fqns]
     end
 
     tree
   end
 
-  def generate_namespaces_breadcrumb klass, rel_prefix
-    namespaces_to_class_modules(klass).map do |namespace, class_module|
+  def generate_nesting_namespaces_breadcrumb klass, rel_prefix
+    nesting_namespaces_to_class_modules(klass).map do |namespace, class_module|
       path = class_module ? (rel_prefix + class_module.path).to_s : ""
       { name: namespace, path: path, self: klass.full_name == class_module&.full_name }
     end

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -845,7 +845,8 @@ class RDoc::Generator::Darkfish
 
   def generate_namespaces_breadcrumb klass, rel_prefix
     namespaces_to_class_modules(klass).map do |namespace, class_module|
-      { name: namespace, path: (rel_prefix + class_module.path).to_s, self: klass.full_name == class_module.full_name }
+      path = class_module ? (rel_prefix + class_module.path).to_s : ""
+      { name: namespace, path: path, self: klass.full_name == class_module&.full_name }
     end
   end
 end

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -18,17 +18,20 @@
 </nav>
 
 <main role="main" aria-labelledby="<%=h klass.aref %>">
-  <ol role="navigation" aria-label="breadcrumb" class="breadcrumb">
-    <% breadcrumb.each do |namespace| %>
-    <li>
-      <% if namespace[:self] %>
-      <span><%= namespace[:name] %></span>
-      <% else %>
-      <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span>::</span>
+  <%# If nesting level is 1, breadcrumb list is not needed %>
+  <% if breadcrumb.size > 1 %>
+    <ol role="navigation" aria-label="breadcrumb" class="breadcrumb">
+      <% breadcrumb.each do |namespace| %>
+      <li>
+        <% if namespace[:self] %>
+        <span><%= namespace[:name] %></span>
+        <% else %>
+        <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span>::</span>
+        <% end %>
+      </li>
       <% end %>
-    </li>
-    <% end %>
-  </ol>
+    </ol>
+  <% end %>
 
   <h1 id="<%=h klass.aref %>" class="anchor-link <%= klass.type %>">
     <%= klass.type %> <%= klass.full_name %>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -17,8 +17,8 @@
   <%= render '_footer.rhtml' %>
 </nav>
 
-<nav role="navigation" aria-label="breadcrumb" class="breadcrumb">
-  <ol>
+<main role="main" aria-labelledby="<%=h klass.aref %>">
+  <ol role="navigation" aria-label="breadcrumb" class="breadcrumb">
     <% breadcrumb.each do |namespace| %>
     <li>
       <% if namespace[:self] %>
@@ -29,9 +29,7 @@
     </li>
     <% end %>
   </ol>
-</nav>
 
-<main role="main" aria-labelledby="<%=h klass.aref %>">
   <h1 id="<%=h klass.aref %>" class="anchor-link <%= klass.type %>">
     <%= klass.type %> <%= klass.full_name %>
   </h1>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -17,6 +17,20 @@
   <%= render '_footer.rhtml' %>
 </nav>
 
+<nav role="navigation" aria-label="breadcrumb" class="breadcrumb">
+  <ol>
+    <% breadcrumb.each do |namespace| %>
+    <li>
+      <% if namespace[:self] %>
+      <span><%= namespace[:name] %></span>
+      <% else %>
+      <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span>::</span>
+      <% end %>
+    </li>
+    <% end %>
+  </ol>
+</nav>
+
 <main role="main" aria-labelledby="<%=h klass.aref %>">
   <h1 id="<%=h klass.aref %>" class="anchor-link <%= klass.type %>">
     <%= klass.type %> <%= klass.full_name %>

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -199,25 +199,16 @@ nav h3,
   font-size: 1em;
 }
 
-nav.breadcrumb {
+ol.breadcrumb {
+  display: flex;
+
+  padding: 0;
+  margin: 0 0 1em;
+}
+
+ol.breadcrumb li {
   display: block;
-  float: unset;
-  width: unset;
-  height: unset;
-  border: none;
-  position: unset;
-  top: unset;
-  padding-top: 10px;
-  padding-left: 20px;
-  margin-bottom: 1em;
-}
-
-nav.breadcrumb ol {
-  display: inline-block;
-}
-
-nav.breadcrumb li {
-  display: inline-block;
+  list-style: none;
   font-size: 125%;
 }
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -199,6 +199,28 @@ nav h3,
   font-size: 1em;
 }
 
+nav.breadcrumb {
+  display: block;
+  float: unset;
+  width: unset;
+  height: unset;
+  border: none;
+  position: unset;
+  top: unset;
+  padding-top: 10px;
+  padding-left: 20px;
+  margin-bottom: 1em;
+}
+
+nav.breadcrumb ol {
+  display: inline-block;
+}
+
+nav.breadcrumb li {
+  display: inline-block;
+  font-size: 125%;
+}
+
 nav ul,
 nav dl,
 nav p {

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1526,26 +1526,26 @@ class TestRDocClassModule < XrefTestCase
     assert_equal [a, c], @c1.extends
   end
 
-  def test_namespaces
+  def test_nesting_namespaces
     cm1 = RDoc::ClassModule.new "A"
-    assert_equal ["A"], cm1.namespaces
+    assert_equal ["A"], cm1.nesting_namespaces
 
     cm2 = RDoc::ClassModule.new "A::B"
-    assert_equal ["A", "B"], cm2.namespaces
+    assert_equal ["A", "B"], cm2.nesting_namespaces
 
     cm3 = RDoc::ClassModule.new "::A::B::C"
-    assert_equal ["A", "B", "C"], cm3.namespaces
+    assert_equal ["A", "B", "C"], cm3.nesting_namespaces
   end
 
-  def test_fully_qualified_namespaces
+  def test_fully_qualified_nesting_namespaces
     cm1 = RDoc::ClassModule.new "A"
-    assert_equal ["A"], cm1.fully_qualified_namespaces
+    assert_equal ["A"], cm1.fully_qualified_nesting_namespaces
 
     cm2 = RDoc::ClassModule.new "A::B"
-    assert_equal ["A", "A::B"], cm2.fully_qualified_namespaces
+    assert_equal ["A", "A::B"], cm2.fully_qualified_nesting_namespaces
 
     cm3 = RDoc::ClassModule.new "::A::B::C"
-    assert_equal ["A", "A::B", "A::B::C"], cm3.fully_qualified_namespaces
+    assert_equal ["A", "A::B", "A::B::C"], cm3.fully_qualified_nesting_namespaces
   end
 
   class TestRDocClassModuleMixins < XrefTestCase

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1526,6 +1526,28 @@ class TestRDocClassModule < XrefTestCase
     assert_equal [a, c], @c1.extends
   end
 
+  def test_namespaces
+    cm1 = RDoc::ClassModule.new "A"
+    assert_equal ["A"], cm1.namespaces
+
+    cm2 = RDoc::ClassModule.new "A::B"
+    assert_equal ["A", "B"], cm2.namespaces
+
+    cm3 = RDoc::ClassModule.new "::A::B::C"
+    assert_equal ["A", "B", "C"], cm3.namespaces
+  end
+
+  def test_fully_qualified_namespaces
+    cm1 = RDoc::ClassModule.new "A"
+    assert_equal ["A"], cm1.fully_qualified_namespaces
+
+    cm2 = RDoc::ClassModule.new "A::B"
+    assert_equal ["A", "A::B"], cm2.fully_qualified_namespaces
+
+    cm3 = RDoc::ClassModule.new "::A::B::C"
+    assert_equal ["A", "A::B", "A::B::C"], cm3.fully_qualified_namespaces
+  end
+
   class TestRDocClassModuleMixins < XrefTestCase
     def setup
       super


### PR DESCRIPTION
## Motivation
When reading several modules has deeply nested namespaces like OpenSSL, the breadcrumb list is very useful.
In Japanese document (called rurema) has breadcrumb like this.

![image](https://github.com/user-attachments/assets/9b439d16-f755-413e-8b45-19891f873006)


So, I introduce breadcrumb into rdoc.
I tested on `ruby/rdoc` and `ruby/ruby`.

### ruby/rdoc
https://user-images.githubusercontent.com/4487291/217001797-6ace375e-b3a8-4e23-beab-081d561f68ae.mp4

### ruby/ruby
https://user-images.githubusercontent.com/4487291/217002054-b9b632b3-7c81-4d52-ad83-a76e71dd9934.mp4


## Changes
Add methods to `RDoc::ClassModule` to build breadcrumb metadata.

* `RDoc::ClassModule#nesting_namespaces`
  * returns array of namespaces that splitted `full_name` by `::`
* `RDoc::ClassModule#fully_qualified_nesting_namespaces`
  * returns an array of fully qualified namespaces
  * To find `RDoc::ClassModule` instance from `RDoc::Store#classes_hash` and `RDoc::Store#modules_hash`

Add private methods to `RDoc::Generator::Darkfish` to build breadcrumb data for easy-to-use template erb.

* `namespaces_to_class_modules`
  * generate hash e.g. ``{ "RDoc" => `RDoc::NormalModule` instance, "ClassModule" => `RDoc::NormalModule` instance }``
* `generate_namespaces_breadcrumb`
  * generate array e.g. `[{:name=>"RDoc", :path=>"../RDoc.html", :self=>false}, {:name=>"ClassModule", :path=>"../RDoc/ClassModule.html", :self=>true}]`

Then, display the breadcrumb in the class template.

## My concerns
* Should be displayed breadcrumb on top-level module/class?
* Should be escape class/module name?
* Should be made configurable to enable or disable breadcrumb?