### PR TITLE
Fix `RDoc::Parser::Ruby` not being documented

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -8,6 +8,9 @@
 #       by Keiju ISHITSUKA (Nippon Rational Inc.)
 #
 
+require 'ripper'
+require_relative 'ripper_state_lex'
+
 ##
 # Extracts code elements from a source file returning a TopLevel object
 # containing the constituent file elements.
@@ -137,9 +140,6 @@
 #
 # Note that by default, the :method: directive will be ignored if there is a
 # standard rdocable item following it.
-
-require 'ripper'
-require_relative 'ripper_state_lex'
 
 class RDoc::Parser::Ruby < RDoc::Parser
 


### PR DESCRIPTION
The calls to `require` prevent the class from being documented.

Right now https://ruby.github.io/rdoc/RDoc/Parser/Ruby.html looks like this:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/3535/217245648-5d81657a-cf5c-4e6f-89cf-16bd952d9c1f.png">

Same is true at https://docs.ruby-lang.org/en/3.2/RDoc/Parser/Ruby.html.

This fixes it by moving the requires above the documentation comment.

After:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/3535/217245928-f5148c08-7b83-4ea3-9bc4-7e86151bf152.png">
