### PR TITLE
Prefer to use File.readlines instead of IO.readlines

### DIFF
--- a/lib/rdoc/rd/block_parser.ry
+++ b/lib/rdoc/rd/block_parser.ry
@@ -572,7 +572,7 @@ def get_included(file)
     file_name = File.join dir, file
 
     if File.exist? file_name then
-      included = IO.readlines file_name
+      included = File.readlines file_name
       break
     end
   end


### PR DESCRIPTION
Some of IO methods leads to vulnerability of command injection. This usage is safe, but I want to suppress CodeQL warnings.