### PR TITLE
Use github pages action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Build with RDoc
         # Outputs to the './_site' directory by default
         run: rake rdoc
-        env:
-          JEKYLL_ENV: production
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy RDoc site to Pages
+
+on:
+  push:
+    branches: [ 'master' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@92aece5fc9c784ab66851c1e702b1bd5885a51f2 # v1.139.0
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with RDoc
+        # Outputs to the './_site' directory by default
+        run: rake rdoc
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.rvmrc
 /TAGS
 /html
+/_site
 /lib/rdoc/rd/block_parser.rb
 /lib/rdoc/rd/inline_parser.rb
 /lib/rdoc/markdown.rb

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :default => :test
 RDoc::Task.new do |doc|
   doc.main = 'README.rdoc'
   doc.title = "rdoc #{RDoc::VERSION} Documentation"
-  doc.rdoc_dir = 'html'
+  doc.rdoc_dir = '_site' # for github pages
   doc.rdoc_files = FileList.new %w[lib/**/*.rb *.rdoc doc/rdoc/markup_reference.rb] - PARSER_FILES
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require_relative 'lib/rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-task :docs    => :generate
 task :test    => [:normal_test, :rubygems_test]
 
 PARSER_FILES = %w[
@@ -25,15 +24,6 @@ RDoc::Task.new do |doc|
   doc.title = "rdoc #{RDoc::VERSION} Documentation"
   doc.rdoc_dir = '_site' # for github pages
   doc.rdoc_files = FileList.new %w[lib/**/*.rb *.rdoc doc/rdoc/markup_reference.rb] - PARSER_FILES
-end
-
-task ghpages: :rdoc do
-  `git checkout gh-pages`
-  require "fileutils"
-  FileUtils.rm_rf "/tmp/html"
-  FileUtils.mv "html", "/tmp"
-  FileUtils.rm_rf "*"
-  FileUtils.cp_r Dir.glob("/tmp/html/*"), "."
 end
 
 Rake::TestTask.new(:normal_test) do |t|


### PR DESCRIPTION
Now, our documentation page by `gh-pages` is steal status. I try to update this site continuously with GitHub Actions.