### PR TITLE
Isolate root dir if specified

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -565,9 +565,10 @@ class RDoc::Options
 
     @op_dir ||= 'doc'
 
-    @rdoc_include << "." if @rdoc_include.empty?
     root = @root.to_s
-    @rdoc_include << root unless @rdoc_include.include?(root)
+    if @rdoc_include.empty? || !@rdoc_include.include?(root)
+      @rdoc_include << root
+    end
 
     @exclude = self.exclude
 

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -119,7 +119,7 @@ class RDoc::RDoc
   # +files+.
 
   def gather_files files
-    files = ["."] if files.empty?
+    files = [@options.root.to_s] if files.empty?
 
     file_list = normalized_file_list files, true, @options.exclude
 


### PR DESCRIPTION
This ensures only files from the root directory are chosen, in order to allow a clean build from outside the source directory.