### PR TITLE
wip: support rails mattr_accessor variants

### DIFF
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -191,6 +191,7 @@ module RDoc
   autoload :GhostMethod,    "#{__dir__}/rdoc/ghost_method"
   autoload :MetaMethod,     "#{__dir__}/rdoc/meta_method"
   autoload :Attr,           "#{__dir__}/rdoc/attr"
+  autoload :Mattr,           "#{__dir__}/rdoc/mattr"
 
   autoload :Constant,       "#{__dir__}/rdoc/constant"
   autoload :Mixin,          "#{__dir__}/rdoc/mixin"

--- a/lib/rdoc/mattr.rb
+++ b/lib/rdoc/mattr.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+##
+# An attribute created by \#mattr_reader, \#mattr_writer or
+# \#mattr_accessor
+
+class RDoc::Mattr < RDoc::MethodAttr
+
+  ##
+  # 3::
+  #   RDoc 4
+  #    Added parent name and class
+  #    Added section title
+
+  MARSHAL_VERSION = 3 # :nodoc:
+
+  ##
+  # Is the attribute readable ('R'), writable ('W') or both ('RW')?
+
+  attr_accessor :rw
+
+  ##
+  # Creates a new Mattr with body +text+, +name+, read/write status +rw+ and
+  # +comment+.  +singleton+ marks this as a class attribute.
+
+  def initialize(text, name, rw, comment, singleton = false)
+    super text, name
+
+    @rw = rw
+    @singleton = singleton
+    self.comment = comment
+  end
+
+  ##
+  # Mattrs are equal when their names, singleton and rw are identical
+
+  def == other
+    self.class == other.class and
+      self.name == other.name and
+      self.rw == other.rw and
+      self.singleton == other.singleton
+  end
+
+  ##
+  # Add +an_alias+ as an attribute in +context+.
+
+  def add_alias(an_alias, context)
+    new_attr = self.class.new(self.text, an_alias.new_name, self.rw,
+                              self.comment, self.singleton)
+
+    new_attr.record_location an_alias.file
+    new_attr.visibility = self.visibility
+    new_attr.is_alias_for = self
+    @aliases << new_attr
+    context.add_attribute new_attr
+    new_attr
+  end
+
+  ##
+  # The #aref prefix for mattrs
+
+  def aref_prefix
+    'mattr'
+  end
+
+  ##
+  # Attributes never call super.  See RDoc::AnyMethod#calls_super
+  #
+  # An RDoc::Mattr can show up in the method list in some situations (see
+  # Gem::ConfigFile)
+
+  def calls_super # :nodoc:
+    false
+  end
+
+  ##
+  # Returns mattr_reader, mattr_writer or mattr_accessor as appropriate.
+
+  def definition
+    case @rw
+    when 'RW' then 'mattr_accessor'
+    when 'R'  then 'mattr_reader'
+    when 'W'  then 'mattr_writer'
+    end
+  end
+
+  def inspect # :nodoc:
+    alias_for = @is_alias_for ? " (alias for #{@is_alias_for.name})" : nil
+    visibility = self.visibility
+    visibility = "forced #{visibility}" if force_documentation
+    "#<%s:0x%x %s %s (%s)%s>" % [
+      self.class, object_id,
+      full_name,
+      rw,
+      visibility,
+      alias_for,
+    ]
+  end
+
+  ##
+  # Dumps this Mattr for use by ri.  See also #marshal_load
+
+  def marshal_dump
+    [ MARSHAL_VERSION,
+      @name,
+      full_name,
+      @rw,
+      @visibility,
+      parse(@comment),
+      singleton,
+      @file.relative_name,
+      @parent.full_name,
+      @parent.class,
+      @section.title
+    ]
+  end
+
+  ##
+  # Loads this Mattr from +array+.  For a loaded Mattr the following
+  # methods will return cached values:
+  #
+  # * #full_name
+  # * #parent_name
+
+  def marshal_load array
+    initialize_visibility
+
+    @aliases      = []
+    @parent       = nil
+    @parent_name  = nil
+    @parent_class = nil
+    @section      = nil
+    @file         = nil
+
+    version        = array[0]
+    @name          = array[1]
+    @full_name     = array[2]
+    @rw            = array[3]
+    @visibility    = array[4]
+    @comment       = array[5]
+    @singleton     = array[6] || false # MARSHAL_VERSION == 0
+    #                      7 handled below
+    @parent_name   = array[8]
+    @parent_class  = array[9]
+    @section_title = array[10]
+
+    @file = RDoc::TopLevel.new array[7] if version > 1
+
+    @parent_name ||= @full_name.split('#', 2).first
+  end
+
+  def pretty_print q # :nodoc:
+    q.group 2, "[#{self.class.name} #{full_name} #{rw} #{visibility}", "]" do
+      unless comment.empty? then
+        q.breakable
+        q.text "comment:"
+        q.breakable
+        q.pp @comment
+      end
+    end
+  end
+
+  def to_s # :nodoc:
+    "#{definition} #{name} in: #{parent}"
+  end
+
+  ##
+  # Mattrs do not have token streams.
+  #
+  # An RDoc::Mattr can show up in the method list in some situations (see
+  # Gem::ConfigFile)
+
+  def token_stream # :nodoc:
+  end
+
+end
+

--- a/lib/rdoc/thread_mattr.rb
+++ b/lib/rdoc/thread_mattr.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+##
+# An thread mattributes created by \#thread_mattr_accessor
+
+class RDoc::ThreadMattr < RDoc::MethodAttr
+
+  ##
+  # 3::
+  #   RDoc 4
+  #    Added parent name and class
+  #    Added section title
+
+  MARSHAL_VERSION = 3 # :nodoc:
+
+  ##
+  # Is the attribute readable ('R'), writable ('W') or both ('RW')?
+
+  attr_accessor :rw
+
+  ##
+  # Creates a new ThreadMattr with body +text+, +name+, read/write status +rw+ and
+  # +comment+.  +singleton+ marks this as a class attribute.
+
+  def initialize(text, name, rw, comment, singleton = false)
+    super text, name
+
+    @rw = rw
+    @singleton = singleton
+    self.comment = comment
+  end
+
+  ##
+  # Thread Mattrs are equal when their names, singleton and rw are identical
+
+  def == other
+    self.class == other.class and
+      self.name == other.name and
+      self.rw == other.rw and
+      self.singleton == other.singleton
+  end
+
+  ##
+  # Add +an_alias+ as a threaded mattribute in +context+.
+
+  def add_alias(an_alias, context)
+    new_attr = self.class.new(self.text, an_alias.new_name, self.rw,
+                              self.comment, self.singleton)
+
+    new_attr.record_location an_alias.file
+    new_attr.visibility = self.visibility
+    new_attr.is_alias_for = self
+    @aliases << new_attr
+    context.add_attribute new_attr
+    new_attr
+  end
+
+  ##
+  # The #aref prefix for threaded mattributes
+
+  def aref_prefix
+    'thread_mattr'
+  end
+
+  ##
+  # Attributes never call super.  See RDoc::AnyMethod#calls_super
+  #
+  # An RDoc::Attr can show up in the method list in some situations (see
+  # Gem::ConfigFile)
+
+  def calls_super # :nodoc:
+    false
+  end
+
+  ##
+  # Returns attr_reader, attr_writer or attr_accessor as appropriate.
+
+  def definition
+    case @rw
+    when 'RW' then 'thread_mattr_accessor'
+    when 'R'  then 'thread_mattr_reader'
+    when 'W'  then 'thread_mattr_writer'
+    end
+  end
+
+  def inspect # :nodoc:
+    alias_for = @is_alias_for ? " (alias for #{@is_alias_for.name})" : nil
+    visibility = self.visibility
+    visibility = "forced #{visibility}" if force_documentation
+    "#<%s:0x%x %s %s (%s)%s>" % [
+      self.class, object_id,
+      full_name,
+      rw,
+      visibility,
+      alias_for,
+    ]
+  end
+
+  ##
+  # Dumps this ThreadMattr for use by ri.  See also #marshal_load
+
+  def marshal_dump
+    [ MARSHAL_VERSION,
+      @name,
+      full_name,
+      @rw,
+      @visibility,
+      parse(@comment),
+      singleton,
+      @file.relative_name,
+      @parent.full_name,
+      @parent.class,
+      @section.title
+    ]
+  end
+
+  ##
+  # Loads this ThreadMattr from +array+.  For a loaded ThreadMattr the following
+  # methods will return cached values:
+  #
+  # * #full_name
+  # * #parent_name
+
+  def marshal_load array
+    initialize_visibility
+
+    @aliases      = []
+    @parent       = nil
+    @parent_name  = nil
+    @parent_class = nil
+    @section      = nil
+    @file         = nil
+
+    version        = array[0]
+    @name          = array[1]
+    @full_name     = array[2]
+    @rw            = array[3]
+    @visibility    = array[4]
+    @comment       = array[5]
+    @singleton     = array[6] || false # MARSHAL_VERSION == 0
+    #                      7 handled below
+    @parent_name   = array[8]
+    @parent_class  = array[9]
+    @section_title = array[10]
+
+    @file = RDoc::TopLevel.new array[7] if version > 1
+
+    @parent_name ||= @full_name.split('#', 2).first
+  end
+
+  def pretty_print q # :nodoc:
+    q.group 2, "[#{self.class.name} #{full_name} #{rw} #{visibility}", "]" do
+      unless comment.empty? then
+        q.breakable
+        q.text "comment:"
+        q.breakable
+        q.pp @comment
+      end
+    end
+  end
+
+  def to_s # :nodoc:
+    "#{definition} #{name} in: #{parent}"
+  end
+
+  ##
+  # Thread mattributes do not have token streams.
+  #
+  # An RDoc::ThreadMattr can show up in the method list in some situations (see
+  # Gem::ConfigFile)
+
+  def token_stream # :nodoc:
+  end
+
+end
+

--- a/test/rdoc/test_rdoc_mattr.rb
+++ b/test/rdoc/test_rdoc_mattr.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+class TestRDocMattr < RDoc::TestCase
+
+  def setup
+    super
+
+    @a = RDoc::Mattr.new nil, 'mattr_accessor', 'RW', ''
+  end
+
+  def test_aref
+    m = RDoc::Mattr.new nil, 'mattr_accessor', 'RW', nil
+
+    assert_equal 'mattr-i-mattr_accessor', m.aref
+  end
+
+  def test_arglists
+    assert_nil @a.arglists
+  end
+
+  def test_block_params
+    assert_nil @a.block_params
+  end
+
+  def test_call_seq
+    assert_nil @a.call_seq
+  end
+
+  def test_definition
+    assert_equal 'mattr_accessor', @a.definition
+
+    @a.rw = 'R'
+
+    assert_equal 'mattr_reader', @a.definition
+
+    @a.rw = 'W'
+
+    assert_equal 'mattr_writer', @a.definition
+  end
+
+  def test_full_name
+    assert_equal '(unknown)#mattr_accessor', @a.full_name
+  end
+
+  def test_marshal_dump
+    tl = @store.add_file 'file.rb'
+
+    @a.comment = 'this is a comment'
+    @a.record_location tl
+
+    cm = tl.add_class RDoc::NormalClass, 'Klass'
+    cm.add_mattr @a
+
+    section = cm.sections.first
+
+    loaded = Marshal.load Marshal.dump @a
+    loaded.store = @store
+
+    assert_equal @a, loaded
+
+    comment = RDoc::Markup::Document.new(
+                RDoc::Markup::Paragraph.new('this is a comment'))
+
+    assert_equal comment,          loaded.comment
+    assert_equal 'file.rb',        loaded.file.relative_name
+    assert_equal 'Klass#mattr_accessor',     loaded.full_name
+    assert_equal 'mattr_accessor', loaded.name
+    assert_equal 'RW',             loaded.rw
+    assert_equal false,            loaded.singleton
+    assert_equal :public,          loaded.visibility
+    assert_equal tl,               loaded.file
+    assert_equal cm,               loaded.parent
+    assert_equal section,          loaded.section
+  end
+
+  def test_marshal_dump_singleton
+    tl = @store.add_file 'file.rb'
+
+    @a.comment = 'this is a comment'
+    @a.record_location tl
+
+    cm = tl.add_class RDoc::NormalClass, 'Klass'
+    cm.add_mattr @a
+
+    section = cm.sections.first
+
+    @a.rw = 'R'
+    @a.singleton = true
+    @a.visibility = :protected
+
+    loaded = Marshal.load Marshal.dump @a
+    loaded.store = @store
+
+    assert_equal @a, loaded
+
+    comment = RDoc::Markup::Document.new(
+                RDoc::Markup::Paragraph.new('this is a comment'))
+
+    assert_equal comment,                 loaded.comment
+    assert_equal 'Klass::mattr_accessor', loaded.full_name
+    assert_equal 'mattr_accessor',        loaded.name
+    assert_equal 'R',                     loaded.rw
+    assert_equal true,                    loaded.singleton
+    assert_equal :protected,              loaded.visibility
+    assert_equal tl,                      loaded.file
+    assert_equal cm,                      loaded.parent
+    assert_equal section,                 loaded.section
+  end
+
+  def test_params
+    assert_nil @a.params
+  end
+
+  def test_singleton
+    refute @a.singleton
+  end
+
+  def test_type
+    assert_equal 'instance', @a.type
+
+    @a.singleton = true
+    assert_equal 'class', @a.type
+  end
+
+end


### PR DESCRIPTION
This is just an early proof-of-concept, but the idea is that we can hold a reference to the following rails extensive attributes API so they can be displayed and searchable from `api.ror.org`.

* `mattr_*`
* `cattr_*`
* `thread_mattr_accessor`
* `thread_cattr_accessor`

This should be just a lot of copy and paste, and adding tests, happy to hand this off if anyone is interested!