### PR TITLE
Drop the support for 2.5 or earlier because of CVE-2021-31799

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -226,7 +226,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.rdoc_options = ["--main", "README.rdoc"]
   s.extra_rdoc_files += s.files.grep(%r[\A[^\/]+\.(?:rdoc|md)\z])
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
   s.add_dependency 'psych', '>= 4.0.0'


### PR DESCRIPTION
`TestRDocRDoc#test_remove_unparseable_CVE_2021_31799` doesn't pass on 2.5 in fact.