### PR TITLE
Fix link to RDoc::Task on README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -46,7 +46,7 @@ contain just Markup-style markup (with or without leading '#' comment
 markers).  If directory names are passed to RDoc, they are scanned
 recursively for C and Ruby source files only.
 
-To generate documentation using +rake+ see RDoc::Task[https://ruby.github.io/rdoc/RDocTask.html].
+To generate documentation using +rake+ see RDoc::Task[https://ruby.github.io/rdoc/RDoc/Task.html].
 
 To generate documentation programmatically:
 


### PR DESCRIPTION
<https://ruby.github.io/rdoc/RDocTask.html> returns 404 Not Found.
