### PR TITLE
Improve `<summary>` CSS on sidebar

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -309,23 +309,26 @@ dl.note-list dt {
   background: url(../images/arrow_up.png) no-repeat right center;
 }
 
-.nav-section details summary {
+.nav-section details > summary {
   display: block;
 }
 
-.nav-section details summary::-webkit-details-marker {
+.nav-section details > summary::-webkit-details-marker {
   display: none;
 }
 
-.nav-section details summary:before {
+.nav-section details > summary::before {
   content: "";
 }
 
-.nav-section details summary:after {
-  content: "  \25B6"; /* BLACK RIGHT-POINTING TRIANGLE */
+.nav-section details > summary::after {
+  content: "\25B6"; /* BLACK RIGHT-POINTING TRIANGLE */
+  font-size: 0.8em;
+  margin-left: 0.4em;
 }
-.nav-section details[open] > summary:after {
-  content: "  \25BD"; /* WHITE DOWN-POINTING TRIANGLE */
+
+.nav-section details[open] > summary::after {
+  content: "\25BD"; /* WHITE DOWN-POINTING TRIANGLE */
 }
 
 /* @end */


### PR DESCRIPTION
- Use a smaller font size for the toggle symbol. (Currently, it seems a little too large)
- Use the child combinator (`>`) to unify selectors.
- Use `margin-left` instead of whitespace within the `content` property.
- Use `::` instead of outdated `:` for the pseudo-element symbol. (See https://developer.mozilla.org/en-US/docs/Web/CSS/::before)

Examples with Chrome 113:

| Before | After |
|--------|--------|
| <img width="89" alt="image" src="https://github.com/ruby/rdoc/assets/473530/847c238f-a1c3-4c79-a840-c648525a5965"> | <img width="87" alt="image" src="https://github.com/ruby/rdoc/assets/473530/6ffa7dfb-5beb-4a22-a3ed-e44f5c6a676e"> |
| <img width="90" alt="image" src="https://github.com/ruby/rdoc/assets/473530/a4eee9e4-2efc-489b-b247-8567175b6472"> | <img width="94" alt="image" src="https://github.com/ruby/rdoc/assets/473530/d73b4bda-5974-4355-9d9a-4db7129a3ee8"> |

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary

Note: Please feel free to close this PR if you disagree (since it reflects my preference).