### PR TITLE
Improve layout CSS

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -17,6 +17,14 @@ body {
   background: #fafafa;
   font-family: Lato, sans-serif;
   font-weight: 300;
+
+  /* Layout */
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
+
+body > :last-child {
+  grid-column: 1 / 3;
 }
 
 h1 span,
@@ -181,21 +189,25 @@ table tr:nth-child(even) td {
 /* @group Top-Level Structure */
 
 nav {
-  float: left;
-  width: 260px;
   font-family: Helvetica, sans-serif;
   font-size: 14px;
   border-right: 1px solid #ccc;
   position: sticky;
   top: 0;
   overflow: auto;
+
+  /* Layout */
+  width: 260px; /* fallback */
+  width: max(50px, 20vw);
+  min-width: 50px;
+  max-width: 80vw;
   height: calc(100vh - 100px); /* reduce the footer height */
+  resize: horizontal;
 }
 
 main {
   display: block;
-  margin: 0 2em 5em 260px;
-  padding-left: 20px;
+  margin: 1em;
   min-width: 340px;
   font-size: 16px;
 }
@@ -214,7 +226,6 @@ main h6 {
 }
 
 #validator-badges {
-  clear: both;
   margin: 1em 1em 2em;
   font-size: smaller;
 }


### PR DESCRIPTION
- Use the `grid` property for the page layout.
  - https://caniuse.com/css-grid
- Adjust the `<main>` margin.
- Make the sidebar responsive and resizable.
  - https://caniuse.com/css-math-functions
  - https://caniuse.com/css-resize

Note that all modern browsers support the new CSS properties and functions used by this change.

| Before | After |
|--------|--------|
| <img width="944" alt="Screenshot 2023-05-27 at 0 41 17" src="https://github.com/ruby/rdoc/assets/473530/942da4fb-f1ca-4288-a167-5f3f5446938e"> | <img width="941" alt="Screenshot 2023-05-27 at 0 41 29" src="https://github.com/ruby/rdoc/assets/473530/16a3c987-0978-4cc9-91f5-4b2776933be8"> |

### Resizable ([`resize`](https://developer.mozilla.org/en-US/docs/Web/CSS/resize)):

<img width="940" alt="Screenshot 2023-05-27 at 0 42 52" src="https://github.com/ruby/rdoc/assets/473530/abf92047-1eca-4d0d-b4f6-db5c8e87a427">
