### PR TITLE
Add HTML fragment references for constants

### DIFF
--- a/lib/rdoc/constant.rb
+++ b/lib/rdoc/constant.rb
@@ -60,6 +60,13 @@ class RDoc::Constant < RDoc::CodeObject
   end
 
   ##
+  # HTML fragment reference for this Constant
+
+  def aref
+    "#constant-#{full_name}"
+  end
+
+  ##
   # A constant is documented if it has a comment, or is an alias
   # for a documented class or module.
 

--- a/test/rdoc/test_rdoc_constant.rb
+++ b/test/rdoc/test_rdoc_constant.rb
@@ -9,6 +9,10 @@ class TestRDocConstant < XrefTestCase
     @const = @c1.constants.first
   end
 
+  def test_aref
+    assert_equal '#constant-C1::CONST', @const.aref
+  end
+
   def test_documented_eh
     top_level = @store.add_file 'file.rb'
 


### PR DESCRIPTION
In large libraries with a lot of constants (Rails for example), it would be nice to deep link to these constants.