### PR TITLE
Embedded racc parser for potability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,7 @@ parsed_files = PARSER_FILES.map do |parser_file|
     when '.ry' # need racc
       racc = Gem.bin_path 'racc', 'racc'
       rb_file = parser_file.gsub(/\.ry\z/, ".rb")
-      ruby "#{racc} -l -o #{rb_file} #{parser_file}"
+      ruby "#{racc} -l -E -o #{rb_file} #{parser_file}"
       open(rb_file, 'r+') do |f|
         newtext = "# frozen_string_literal: true\n#{f.read}"
         f.rewind


### PR DESCRIPTION
The current `rdoc/rd/inline_parser.rb` and `rdoc/rd/block_parser.rb` have `require "racc/parser"` for external dependency. We should avoid to depend it for RD parser.