### PR TITLE
Improve CSS for "toggle source" hovering over one more method signatures

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -567,7 +567,7 @@ main .method-click-advice {
   line-height: 20px;
   background: url(../images/zoom.png) no-repeat right top;
 }
-main .method-heading:hover .method-click-advice {
+main .method-header:hover .method-click-advice {
   visibility: visible;
 }
 


### PR DESCRIPTION
This PR improves the behavior of showing the "toggle source" element on mouseover.

For example, when a method has one more signatures by using `:call-seq:`,

```ruby
# :call-seq:
#   foo {|element| ... } -> self
#   foo -> new_enumeration
def foo
end
```

The current CSS doesn't show "toggle source" even when hovering the second signature `foo -> new_enumeration`.
But this change will show "toggle source" always when hovering over any signature.

For details about the `.method-header` element, see `lib/rdoc/generator/template/darkfish/class.rhtml`:
https://github.com/ruby/rdoc/blob/0e060c69f51ec4a877e5cde69b31d47eaeb2a2b9/lib/rdoc/generator/template/darkfish/class.rhtml#L101-L124

For example, see https://docs.ruby-lang.org/en/3.2/Array.html#method-i-delete

### Test locally

1. Add `:call-seq:` temporarily like this:

```diff
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -198,4 +198,9 @@ module RDoc
   autoload :Extend,         "#{__dir__}/rdoc/extend"
   autoload :Require,        "#{__dir__}/rdoc/require"
 
+  # :call-seq:
+  #   foo {|element| ... } -> self
+  #   foo -> new_enumeration
+  def foo
+  end
 end
```

2. Run `bundle exec rake rerdoc` to build
3. Run `open _site/RDoc.html`
    - <img width="561" alt="image" src="https://github.com/ruby/rdoc/assets/473530/316ea6db-ba75-4674-83bf-430c087598e2">
