### PR TITLE
Tentatively ignore errors on TruffleRuby head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
       run: bundle exec rake
       env:
         RUBYOPT: --enable-frozen_string_literal
+      continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
     - if: ${{ matrix.ruby == 'head' && startsWith(matrix.os, 'ubuntu') }}
       run: bundle exec rake rdoc
     - if: ${{ matrix.ruby == 'head' && startsWith(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
TruffleRuby changed somewhere between f403dd53..315e774d.

```
$ truffleruby -v -e 'def parseable?(code);eval("BEGIN {return true}\n#{code}");rescue SyntaxError; false; end' -e 'p parseable?("")'
truffleruby 23.1.0-dev-b64cd1d4, like ruby 3.1.3, GraalVM CE Native [x86_64-darwin]
(eval):1:in `parseable?': unexpected return (LocalJumpError)
	from -e:1:in `parseable?'
	from -e:2:in `<main>'
```