### PR TITLE
handle symbols declared with %s

### DIFF
--- a/lib/rdoc/parser/ripper_state_lex.rb
+++ b/lib/rdoc/parser/ripper_state_lex.rb
@@ -368,7 +368,7 @@ class RDoc::Parser::RipperStateLex
   private def get_symbol_tk(tk)
     is_symbol = true
     symbol_tk = Token.new(tk.line_no, tk.char_no, :on_symbol)
-    if ":'" == tk[:text] or ':"' == tk[:text]
+    if ":'" == tk[:text] or ':"' == tk[:text] or tk[:text].start_with?('%s')
       tk1 = get_string_tk(tk)
       symbol_tk[:text] = tk1[:text]
       symbol_tk[:state] = tk1[:state]

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -3205,6 +3205,14 @@ RUBY
     assert_nil @parser.parse_symbol_in_arg
   end
 
+  def test_parse_percent_symbol
+    content = '%s[foo bar]'
+    util_parser content
+    tk = @parser.get_tk
+    assert_equal :on_symbol, tk[:kind]
+    assert_equal content, tk[:text]
+  end
+
   def test_parse_statements_alias_method
     content = <<-CONTENT
 class A


### PR DESCRIPTION
Close #1030

Symbols declared with `%s[symbol]` the same way :'symbol', the entire string is used as a symbol token.