### PR TITLE
Use a more portable way to check if code is parseable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
-      versions: '["truffleruby"]'
+
   test:
     needs: ruby-versions
     strategy:
@@ -20,6 +18,8 @@ jobs:
         exclude:
           - os: windows-latest
             ruby: truffleruby
+          - os: windows-latest
+            ruby: truffleruby-head
           - os: windows-latest
             ruby: jruby
           - os: windows-latest

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -430,7 +430,9 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
   def parseable? text
     verbose, $VERBOSE = $VERBOSE, nil
-    eval("BEGIN {return true}\n#{text}")
+    catch(:valid) do
+      eval("BEGIN { throw :valid, true }\n#{text}")
+    end
   rescue SyntaxError
     false
   ensure


### PR DESCRIPTION
* The same as used in irb: https://github.com/ruby/irb/pull/134/files
* And in `Forwardable._valid_method?`.
* This works on all Ruby implementations, unlike `return` in BEGIN which can be quite difficult to support.