### PR TITLE
[DOC] Link fixes

### DIFF
--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -6,8 +6,8 @@
 # Each comment may have a different markup format set by #format=.  By default
 # 'rdoc' is used.  The :markup: directive tells RDoc which format to use.
 #
-# See RDoc::Markup@Other+directives for instructions on adding an alternate
-# format.
+# See RDoc::MarkupReference@Directive+for+Specifying+RDoc+Source+Format.
+
 
 class RDoc::Comment
 

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -178,7 +178,7 @@
 # [dingus]: http://daringfireball.net/projects/markdown/dingus
 # [GFM]: https://github.github.com/gfm/
 # [pegmarkdown]: https://github.com/jgm/peg-markdown
-# [PHPE]: http://michelf.com/projects/php-markdown/extra/#def-list
+# [PHPE]: https://michelf.ca/projects/php-markdown/extra/#def-list
 # [syntax]: http://daringfireball.net/projects/markdown/syntax
 #--
 # Last updated to jgm/peg-markdown commit 8f8fc22ef0


### PR DESCRIPTION
- Fixes an internal link to a heading.
- Changes link target to avoid redirection (which caused the link checker to report as broken).