### PR TITLE
Drop code for old versions

### DIFF
--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -133,12 +133,7 @@ class RDoc::Comment
   # HACK dubious
 
   def encode! encoding
-    # TODO: Remove this condition after Ruby 2.2 EOL
-    if RUBY_VERSION < '2.3.0'
-      @text = @text.force_encoding encoding
-    else
-      @text = String.new @text, encoding: encoding
-    end
+    @text = String.new @text, encoding: encoding
     self
   end
 

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -124,12 +124,7 @@ module RDoc::Encoding
     if text.kind_of? RDoc::Comment
       text.encode! encoding
     else
-      # TODO: Remove this condition after Ruby 2.2 EOL
-      if RUBY_VERSION < '2.3.0'
-        text.force_encoding encoding
-      else
-        String.new text, encoding: encoding
-      end
+      String.new text, encoding: encoding
     end
   end
 

--- a/lib/rdoc/erbio.rb
+++ b/lib/rdoc/erbio.rb
@@ -20,12 +20,8 @@ class RDoc::ERBIO < ERB
   ##
   # Defaults +eoutvar+ to 'io', otherwise is identical to ERB's initialize
 
-  def initialize str, safe_level = nil, legacy_trim_mode = nil, legacy_eoutvar = 'io', trim_mode: nil, eoutvar: 'io'
-    if RUBY_VERSION >= '2.6'
-      super(str, trim_mode: trim_mode, eoutvar: eoutvar)
-    else
-      super(str, safe_level, legacy_trim_mode, legacy_eoutvar)
-    end
+  def initialize str, trim_mode: nil, eoutvar: 'io'
+    super(str, trim_mode: trim_mode, eoutvar: eoutvar)
   end
 
   ##

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -778,11 +778,7 @@ class RDoc::Generator::Darkfish
       erbout = "_erbout_#{file_var}"
     end
 
-    if RUBY_VERSION >= '2.6'
-      template = klass.new template, trim_mode: '-', eoutvar: erbout
-    else
-      template = klass.new template, nil, '-', erbout
-    end
+    template = klass.new template, trim_mode: '-', eoutvar: erbout
     @template_cache[file] = template
     template
   end


### PR DESCRIPTION
We have already dropped the support for 2.5 or earlier because of CVE-2021-31799.