### PR TITLE
test/rdoc/test_rdoc_generator_json_index.rb: Use assert_equal.

### DIFF
--- a/test/rdoc/test_rdoc_generator_json_index.rb
+++ b/test/rdoc/test_rdoc_generator_json_index.rb
@@ -105,7 +105,7 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     generated_file = Pathname(File.join @tmpdir, 'js/navigation.js')
 
     # This is dirty hack on JRuby
-    assert orig_file.mtime.inspect == generated_file.mtime.inspect,
+    assert_equal orig_file.mtime.inspect, generated_file.mtime.inspect,
       '.js files should be the same timestamp of original'
 
     json = File.read 'js/search_index.js'


### PR DESCRIPTION
Related to https://github.com/ruby/rdoc/issues/1048.

Use `assert_equal` instead of of `assert`. It's better because assert_equal prints the values when it fails. I want to see the actual values in the failing case.

The `assert_equal` prints the values like this.

```
assert_equal 'a', 'b', 'dummy'
```

```
dummy
<"a"> expected but was
<"b">
```

