### PR TITLE
Fix TIDYLINK after braces (#1015)

### DIFF
--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -90,7 +90,7 @@ class RDoc::Markup::Formatter
 
   def add_regexp_handling_TIDYLINK
     @markup.add_regexp_handling(/(?:
-                                  \{.*?\} |    # multi-word label
+                                  \{[^{}]*\} | # multi-word label
                                   \b[^\s{}]+? # single-word label
                                  )
 

--- a/test/rdoc/test_rdoc_markup_formatter.rb
+++ b/test/rdoc/test_rdoc_markup_formatter.rb
@@ -104,6 +104,12 @@ class TestRDocMarkupFormatter < RDoc::TestCase
     formatted = document.accept @to
 
     assert_equal '<{foo}[rdoc-label:bar]>.', formatted
+
+    document = doc(para('<tt>{abc}</tt>: {foo}[rdoc-label:bar].'))
+
+    formatted = document.accept @to
+
+    assert_equal '<code>{abc}</code>: <{foo}[rdoc-label:bar]>.', formatted
   end
 
   def test_parse_url


### PR DESCRIPTION
TIDYLINK multi-word label should not include braces.