### PR TITLE
Fix `NoMethodError` for `tokens_to_s` method

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -105,7 +105,7 @@ module RDoc::TokenStream
   # Current token stream
 
   def token_stream
-    @token_stream
+    @token_stream || []
   end
 
   ##

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -112,7 +112,7 @@ module RDoc::TokenStream
   # Returns a string representation of the token stream
 
   def tokens_to_s
-    token_stream.compact.map { |token| token[:text] }.join ''
+    token_stream.compact.map { |token| token[:text] }.join
   end
 
 end

--- a/test/rdoc/test_rdoc_token_stream.rb
+++ b/test/rdoc/test_rdoc_token_stream.rb
@@ -53,5 +53,14 @@ class TestRDocTokenStream < RDoc::TestCase
     end.new
 
     assert_equal "foo 'bar'", foo.tokens_to_s
+
+    foo = Class.new do
+      include RDoc::TokenStream
+
+      def initialize
+        @token_stream = nil
+      end
+    end.new
+    assert_equal "", foo.tokens_to_s
   end
 end


### PR DESCRIPTION
Calling `tokens_to_s` gets an error if `token_stream` is nil:

```
undefined method `compact' for nil:NilClass (NoMethodError)
```

So, fall back to an empty array if `@token_stream` is `nil`.

## The case `token_stream` is nil

```rb
> rdoc_method.inspect
=> "#<RDoc::AnyMethod:0x5b090 AbstractController::Translation#l (public) (alias for localize)>"
> rdoc_method.token_stream
=> nil
```