### PR TITLE
fix: Return empty string when `token_stream` is `nil`

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -105,14 +105,14 @@ module RDoc::TokenStream
   # Current token stream
 
   def token_stream
-    @token_stream || []
+    @token_stream
   end
 
   ##
   # Returns a string representation of the token stream
 
   def tokens_to_s
-    token_stream.compact.map { |token| token[:text] }.join ''
+    Array(token_stream).compact.map { |token| token[:text] }.join ''
   end
 
 end

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -112,7 +112,7 @@ module RDoc::TokenStream
   # Returns a string representation of the token stream
 
   def tokens_to_s
-    Array(token_stream).compact.map { |token| token[:text] }.join ''
+    (token_stream or return '').compact.map { |token| token[:text] }.join ''
   end
 
 end

--- a/test/rdoc/test_rdoc_token_stream.rb
+++ b/test/rdoc/test_rdoc_token_stream.rb
@@ -39,6 +39,13 @@ class TestRDocTokenStream < RDoc::TestCase
     assert_equal '', RDoc::TokenStream.to_html([])
   end
 
+  def test_token_stream
+    foo = Class.new do
+      include RDoc::TokenStream
+    end.new
+    assert_equal nil, foo.token_stream
+  end
+
   def test_tokens_to_s
     foo = Class.new do
       include RDoc::TokenStream


### PR DESCRIPTION
The change in #1055 could be a breaking change (see. https://github.com/ruby/rdoc/pull/1055#issuecomment-1816762305).

As a simple workaround, return empty string when `token_stream` is `nil`.

Additionally, a test for `test_token_stream` has been added.