### PR TITLE
Place a space between certain character class letters only

### DIFF
--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -218,7 +218,7 @@ class RDoc::Markup::Parser
 
         break if peek_token.first == :BREAK
 
-        data << ' ' if skip :NEWLINE
+        data << ' ' if skip :NEWLINE and /#{SPACE_SEPARATED_LETTER_CLASS}\z/o.match?(data)
       else
         unget
         break

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -202,7 +202,9 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   def accept_paragraph paragraph
     @res << "\n<p>"
     text = paragraph.text @hard_break
-    text = text.gsub(/\r?\n/, ' ')
+    text = text.gsub(/(#{SPACE_SEPARATED_LETTER_CLASS})?\K\r?\n(?=(?(1)(#{SPACE_SEPARATED_LETTER_CLASS})?))/o) {
+      defined?($2) && ' '
+    }
     @res << to_html(text)
     @res << "</p>\n"
   end

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -309,4 +309,10 @@ module RDoc::Text
     res.join.strip
   end
 
+  ##
+  # Character class to be separated by a space when concatenating
+  # lines.
+
+  SPACE_SEPARATED_LETTER_CLASS = /[\p{Nd}\p{Lc}\p{Pc}]/
+
 end

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -257,7 +257,7 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def accept_paragraph_break
-    assert_equal "\n<p>hello<br> world</p>\n", @to.res.join
+    assert_equal "\n<p>hello<br>world</p>\n", @to.res.join
   end
 
   def accept_paragraph_i
@@ -391,11 +391,31 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def test_accept_paragraph_newline
+    hellos = ["hello", "\u{393 3b5 3b9 3ac} \u{3c3 3bf 3c5}"]
+    worlds = ["world", "\u{3ba 3cc 3c3 3bc 3bf 3c2}"]
+    ohayo, sekai = %W"\u{304a 306f 3088 3046} \u{4e16 754c}"
+
+    hellos.product(worlds) do |hello, world|
+      @to.start_accepting
+      @to.accept_paragraph para("#{hello}\n", "#{world}\n")
+      assert_equal "\n<p>#{hello} #{world}</p>\n", @to.res.join
+    end
+
+    hellos.each do |hello|
+      @to.start_accepting
+      @to.accept_paragraph para("#{hello}\n", "#{sekai}\n")
+      assert_equal "\n<p>#{hello}#{sekai}</p>\n", @to.res.join
+    end
+
+    worlds.each do |world|
+      @to.start_accepting
+      @to.accept_paragraph para("#{ohayo}\n", "#{world}\n")
+      assert_equal "\n<p>#{ohayo}#{world}</p>\n", @to.res.join
+    end
+
     @to.start_accepting
-
-    @to.accept_paragraph para("hello\n", "world\n")
-
-    assert_equal "\n<p>hello world </p>\n", @to.res.join
+    @to.accept_paragraph para("#{ohayo}\n", "#{sekai}\n")
+    assert_equal "\n<p>#{ohayo}#{sekai}</p>\n", @to.res.join
   end
 
   def test_accept_heading_output_decoration


### PR DESCRIPTION
### Basis
Japanese text is not usually space-separated per words, and can be folded at almost any places except for around some punctuations.
That means, line breaks in Japanese sentences should be removed and not replaced with spaces like in English sentences.

### Problem
However, RDoc blindly replaces line breaks with spaces, resulting in very unnatural gaps in Japanese text, highlighted in the screenshot below.

<img width="729" alt="image" src="https://github.com/ruby/rdoc/assets/16700/2bc05219-4376-41bf-bef0-316d5f75e4f9">

This makes it impossible to select words by double-clicking, for example.

### Fix
With this patch, only line breaks between `SPACE_SEPARATED_LETTER_CLASS` characters will be replaced with spaces.

<img width="729" alt="image" src="https://github.com/ruby/rdoc/assets/16700/ea9bf8f6-5af1-43dc-a0a2-cd60a852dbea">

`SPACE_SEPARATED_LETTER_CLASS` includes `Decimal_Number`, `Cased_Letter`, and `Connector_Punctuation` for now, as an analog to `\w`.