### PR TITLE
Re-enable tests with truffleruby-head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head
-          - os: ubuntu-latest
-            ruby: truffleruby-head
-          - os: macos-latest
-            ruby: truffleruby-head
           - os: windows-latest
             ruby: jruby
           - os: windows-latest


### PR DESCRIPTION
Revert "Disable truffleruby-head because of stringio native gem"

This reverts commit ab4084b1814224dd86446a270c8451ae70675e2c.
stringio 3.1.0 has been released.