### PR TITLE
Allow any single-word token upto 2 before C method implementation

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -582,12 +582,12 @@ class RDoc::Parser::C < RDoc::Parser
     | ^\s*\#\s*define\s+(\w+)\s+(\w+)
     }xm) do
       case
-      when $1
-        table[$3] = [:func_def, $1, $2, $~.offset(2)] if !table[$3] || table[$3][0] != :func_def
-      when $4
-        table[$6] = [:macro_def, $4, $5, $~.offset(5), $7] if !table[$6] || table[$6][0] == :macro_alias
-      when $8
-        table[$8] ||= [:macro_alias, $9]
+      when name = $3
+        table[name] = [:func_def, $1, $2, $~.offset(2)] if !(t = table[name]) || t[0] != :func_def
+      when name = $6
+        table[name] = [:macro_def, $4, $5, $~.offset(5), $7] if !(t = table[name]) || t[0] == :macro_alias
+      when name = $8
+        table[name] ||= [:macro_alias, $9]
       end
     end
     table

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -575,9 +575,8 @@ class RDoc::Parser::C < RDoc::Parser
     table = {}
     file_content.scan(%r{
       ((?>/\*.*?\*/\s*)?)
-      ((?:(?:\w+)\s+)?
-        (?:intern\s+)?VALUE\s+(\w+)
-        \s*(?:\([^)]*\))(?:[^\);]|$))
+      ((?:\w+\s+){0,2} VALUE\s+(\w+)
+        \s*(?:\([^\)]*\))(?:[^\);]|$))
     | ((?>/\*.*?\*/\s*))^\s*(\#\s*define\s+(\w+)\s+(\w+))
     | ^\s*\#\s*define\s+(\w+)\s+(\w+)
     }xm) do

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -1373,6 +1373,36 @@ Init_Foo(void) {
     assert_equal "DLL_LOCAL VALUE\nother_function() {\n}", code
   end
 
+  def test_find_body_static_inline
+    content = <<-EOF
+/*
+ * a comment for other_function
+ */
+static inline VALUE
+other_function() {
+}
+
+void
+Init_Foo(void) {
+    VALUE foo = rb_define_class("Foo", rb_cObject);
+
+    rb_define_method(foo, "my_method", other_function, 0);
+}
+    EOF
+
+    klass = util_get_class content, 'foo'
+    other_function = klass.method_list.first
+
+    assert_equal 'my_method', other_function.name
+    assert_equal "a comment for other_function",
+                 other_function.comment.text
+    assert_equal '()', other_function.params
+
+    code = other_function.token_stream.first[:text]
+
+    assert_equal "static inline VALUE\nother_function() {\n}", code
+  end
+
   def test_find_modifiers_call_seq
     comment = RDoc::Comment.new <<-COMMENT
 call-seq:


### PR DESCRIPTION
Previously only unknown word `intern` is allowed between a single-word token before a C method.
Now any single-word token, such as `inline` which is used for `ArithmeticSequence` in enumerator.c, is allowed instead.