### PR TITLE
Fix C const comment

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -944,8 +944,7 @@ class RDoc::Parser::C < RDoc::Parser
         if new_definition.empty? then # Default to literal C definition
           new_definition = definition
         else
-          new_definition = new_definition.gsub("\:", ":")
-          new_definition = new_definition.gsub("\\", '\\')
+          new_definition = new_definition.gsub(/\\([\\:])/, '\1')
         end
 
         new_definition.sub!(/\A(\s+)/, '')

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -938,10 +938,10 @@ class RDoc::Parser::C < RDoc::Parser
     # "/* definition: comment */" form.  The literal ':' and '\' characters
     # can be escaped with a backslash.
     if type.downcase == 'const' then
-      no_match, new_definition, new_comment = comment.text.split(/(\A.*):/)
+      if /\A(.+?)?:(?!\S)/ =~ comment.text
+        new_definition, new_comment = $1, $'
 
-      if no_match and no_match.empty? then
-        if new_definition.empty? then # Default to literal C definition
+        if !new_definition # Default to literal C definition
           new_definition = definition
         else
           new_definition = new_definition.gsub(/\\([\\:])/, '\1')

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -460,7 +460,7 @@ VALUE mFoo = rb_define_module_under(rb_mKernel, "Foo");
   end
 
   def test_do_constants
-    content = <<-EOF
+    content = <<-'EOF'
 #include <ruby.h>
 
 void Init_foo(){

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -475,6 +475,9 @@ void Init_foo(){
    /* TEST\:TEST: Checking to see if escaped colon works */
    rb_define_const(cFoo, "TEST", rb_str_new2("TEST:TEST"));
 
+   /* TEST: TEST:Checking to see if only word-ending colon works */
+   rb_define_const(cFoo, "TEST2", rb_str_new2("TEST:TEST"));
+
    /* \\: The file separator on MS Windows */
    rb_define_const(cFoo, "MSEPARATOR", rb_str_new2("\\"));
 
@@ -537,6 +540,9 @@ void Init_foo(){
                  constants.shift
     assert_equal ['TEST', 'TEST:TEST',
                   'Checking to see if escaped colon works   '],
+                 constants.shift
+    assert_equal ['TEST2', 'TEST',
+                  'TEST:Checking to see if only word-ending colon works   '],
                  constants.shift
     assert_equal ['MSEPARATOR', '\\',
                   'The file separator on MS Windows   '],


### PR DESCRIPTION
Fix `RDoc::Parser::C#handle_constants`.

- [Backslashes here](https://github.com/ruby/rdoc/pull/1062/files#diff-096b64562401e3ee2e4dc61e8e1eaefc7d4a3e978d49be0293c1352c09842febL947-L948) are eaten at parse time, these `gsub`s do nothing.
- The [`content` literal in `TestRDocParserC#test_do_constants`](https://github.com/ruby/rdoc/pull/1062/files#diff-f680760110060910d7955f8d10ae92a8d41186e76bf4d017cd05833e1cd0486eL463) is not using single quotes, so the backslashes are eaten at parse time too and the above bug has not been tested.
- Limit colon separating the new definition to the first word-ending colon, not to split strings including colons, e.g., URLs and Windows path names.