### PR TITLE
Fix support for `rb_file_const` and `rb_curses_define_const`

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -756,17 +756,27 @@ class RDoc::Parser::C < RDoc::Parser
   def gen_const_table file_content
     table = {}
     @content.scan(%r{
-      ((?>^\s*/\*.*?\*/\s+))
-        rb_define_(\w+)\((?:\s*(?:\w+),)?\s*
-                           "(\w+)"\s*,
+      (?<doc>(?>^\s*/\*.*?\*/\s+))
+        rb_define_(?<type>\w+)\(\s*(?:\w+),\s*
+                           "(?<name>\w+)"\s*,
                            .*?\)\s*;
+    |  (?<doc>(?>^\s*/\*.*?\*/\s+))
+        rb_file_(?<type>const)\(\s*
+                           "(?<name>\w+)"\s*,
+                           .*?\)\s*;
+    |  (?<doc>(?>^\s*/\*.*?\*/\s+))
+        rb_curses_define_(?<type>const)\(\s*
+                           (?<name>\w+)
+                           \s*\)\s*;
     | Document-(?:const|global|variable):\s
-        ((?:\w+::)*\w+)
-        \s*?\n((?>.*?\*/))
+        (?<name>(?:\w+::)*\w+)
+        \s*?\n(?<doc>(?>.*?\*/))
     }mxi) do
-      case
-      when $1 then table[[$2, $3]] = $1
-      when $4 then table[$4] = "/*\n" + $5
+      name, doc, type = $~.values_at(:name, :doc, :type)
+      if type
+        table[[type, name]] = doc
+      else
+        table[name] = "/*\n" + doc
       end
     end
     table

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -583,8 +583,6 @@ void Init_curses(){
   mCurses = rb_define_module("Curses");
 
   /*
-   * Document-const: Curses::COLOR_BLACK
-   *
    * Value of the color black
    */
   rb_curses_define_const(COLOR_BLACK);
@@ -609,8 +607,7 @@ void Init_curses(){
   def test_do_constants_file
     content = <<-EOF
 void Init_File(void) {
-  /*  Document-const: LOCK_SH
-   *
+  /*
    *  Shared lock
    */
   rb_file_const("LOCK_SH", INT2FIX(LOCK_SH));


### PR DESCRIPTION
Constant definitions using these functions have been supported, but since RDoc::Parser::C#gen_const_table did not consider other than `rb_define_const` the documents for them have not been found, without `Document-const` direvtive.

Fixes https://github.com/ruby/rdoc/issues/1067