### PR TITLE
Ignore `locale` at `write_options`

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -105,6 +105,7 @@ class RDoc::Options
     generator_name
     generator_options
     generators
+    locale
     op_dir
     page_dir
     option_parser

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -68,7 +68,6 @@ class TestRDocOptions < RDoc::TestCase
       'exclude'              => %w[~\z \.orig\z \.rej\z \.bak\z \.gemspec\z],
       'hyperlink_all'        => false,
       'line_numbers'         => false,
-      'locale'               => nil,
       'locale_dir'           => 'locale',
       'locale_name'          => nil,
       'main_page'            => nil,
@@ -900,6 +899,28 @@ rdoc_include:
   def test_no_skip_test_value
     @options.parse %w[--no-skipping-tests]
     assert_equal false, @options.skip_tests
+  end
+
+  def test_locale_name_default
+    temp_dir do
+      @options.parse %w[]
+      assert_equal 'locale', @options.instance_variable_get(:@locale_dir)
+      assert_nil @options.instance_variable_get(:@locale_name)
+      assert_nil @options.locale
+      @options.finish
+      assert_nil @options.locale
+    end
+  end
+
+  def test_locale_name
+    temp_dir do
+      @options.parse %w[--locale fr]
+      assert_equal 'locale', @options.instance_variable_get(:@locale_dir)
+      assert_equal 'fr', @options.instance_variable_get(:@locale_name)
+      assert_nil @options.locale
+      @options.finish
+      assert_equal 'fr', @options.locale.name
+    end
   end
 
   class DummyCoder < Hash


### PR DESCRIPTION
`@locale` is set from `@locale_name` and loaded from `@locale_dir` after `write_options`, and `RDoc::I18n::Locale` does not seem to expected to be loaded.