### PR TITLE
Singleton visibility

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1453,6 +1453,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
     meth = RDoc::AnyMethod.new get_tkread, name
     look_for_directives_in meth, comment
     meth.singleton = single == SINGLE ? true : singleton
+    if singleton
+      # `current_line_visibility' is useless because it works against
+      # the normal method named as same as the singleton method, after
+      # the latter was defined.  Of course these are different things.
+      container.current_line_visibility = :public
+    end
 
     record_location meth
     meth.line   = line_no

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1782,6 +1782,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     nest = 1
     save_visibility = container.visibility
+    container.visibility = :public unless current_method
 
     non_comment_seen = true
 

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -927,6 +927,8 @@ class TestRDocContext < XrefTestCase
     assert_equal :private, @c6.find_method_named('priv6').visibility
     assert_equal :protected, @c6.find_method_named('prot6').visibility
     assert_equal :public, @c6.find_method_named('pub6').visibility
+    assert_equal :public, @c6.find_method_named('s_pub1').visibility
+    assert_equal :public, @c6.find_method_named('s_pub3').visibility
   end
 
   def util_visibilities

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -928,7 +928,11 @@ class TestRDocContext < XrefTestCase
     assert_equal :protected, @c6.find_method_named('prot6').visibility
     assert_equal :public, @c6.find_method_named('pub6').visibility
     assert_equal :public, @c6.find_method_named('s_pub1').visibility
+    assert_equal :public, @c6.find_method_named('s_pub2').visibility
     assert_equal :public, @c6.find_method_named('s_pub3').visibility
+    assert_equal :public, @c6.find_method_named('s_pub4').visibility
+    assert_equal :private, @c6.find_method_named('s_priv1').visibility
+    assert_equal :protected, @c6.find_method_named('s_prot1').visibility
   end
 
   def util_visibilities

--- a/test/rdoc/xref_data.rb
+++ b/test/rdoc/xref_data.rb
@@ -74,6 +74,7 @@ class C6
   def priv4() end
   public def pub5() end
   def priv5() end
+  def self.s_pub1() end
 
   protected
   private def priv6() end
@@ -82,6 +83,7 @@ class C6
   def prot5() end
   public def pub6() end
   def prot6() end
+  def self.s_pub3() end
 end
 
 class C7

--- a/test/rdoc/xref_data.rb
+++ b/test/rdoc/xref_data.rb
@@ -75,6 +75,11 @@ class C6
   public def pub5() end
   def priv5() end
   def self.s_pub1() end
+  class << self
+    def s_pub2() end
+    private
+    def s_priv1() end
+  end
 
   protected
   private def priv6() end
@@ -84,6 +89,11 @@ class C6
   public def pub6() end
   def prot6() end
   def self.s_pub3() end
+  class << self
+    def s_pub4() end
+    protected
+    def s_prot1() end
+  end
 end
 
 class C7


### PR DESCRIPTION
For this code, `M.foo` and `M.bar` are parsed as private class methods, while both are defined as public.
```ruby
module M
  private

  class << self
    def foo
    end
  end

  def self.bar
  end
end

p M.methods(false)
```
