### PR TITLE
Fix ri completion to always return candidates start with a given name

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -744,7 +744,7 @@ or the PAGER environment variable.
     complete_klass  name, klass, selector, method, completions
     complete_method name, klass, selector,         completions
 
-    completions.sort.uniq
+    completions.uniq.select {|s| s.start_with? name }.sort
   end
 
   def complete_klass name, klass, selector, method, completions # :nodoc:
@@ -779,7 +779,15 @@ or the PAGER environment variable.
         completions << "#{klass}#{selector}"
       end
 
-      completions.concat methods
+      methods.each do |klass_sel_method|
+        match = klass_sel_method.match(/^(.+)(#|\.|::)([^#.:]+)$/)
+        # match[2] is `::` for class method and `#` for instance method.
+        # To be consistent with old completion that completes `['Foo#i', 'Foo::c']` for `Foo.`,
+        # `.` should be a wildcard for both `#` and `::` here.
+        if match && match[2] == selector || selector == '.'
+          completions << match[1] + selector + match[3]
+        end
+      end
     end
   end
 

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -537,7 +537,7 @@ class TestRDocRIDriver < RDoc::TestCase
     assert_equal %w[    Foo::Bar], @driver.complete('Foo::B')
 
     assert_equal %w[Foo#Bar],           @driver.complete('Foo#'),   'Foo#'
-    assert_equal %w[Foo#Bar  Foo::bar], @driver.complete('Foo.'),   'Foo.'
+    assert_equal %w[Foo.Bar  Foo.bar],  @driver.complete('Foo.'),   'Foo.'
     assert_equal %w[Foo::Bar Foo::bar], @driver.complete('Foo::'),  'Foo::'
 
     assert_equal %w[         Foo::bar], @driver.complete('Foo::b'), 'Foo::b'
@@ -548,7 +548,9 @@ class TestRDocRIDriver < RDoc::TestCase
 
     assert_equal %w[Foo::Bar#i_method], @driver.complete('Foo::Bar#')
 
-    assert_equal %w[Foo::Bar#i_method Foo::Bar::c_method Foo::Bar::new],
+    assert_equal %w[Foo::Bar::c_method Foo::Bar::new], @driver.complete('Foo::Bar::')
+
+    assert_equal %w[Foo::Bar.c_method Foo::Bar.i_method Foo::Bar.new],
                  @driver.complete('Foo::Bar.')
   end
 


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20171

RDoc has a test code like this
```ruby
assert_equal %w[Foo#Bar  Foo::bar], @driver.complete('Foo.')
```
Reline doesn't accept this completion list because it does not start from `'Foo.'`

To make it work with Reline, `completion_proc` should always return a list of string that starts with the given completion_target text.

This will also fix this weird behavior in Ruby 3.2 using readline
```
>> Array.t[TAB]
↓
>> Array
(tab complete deletes text)
```
