### PR TITLE
[DOC] Improve documentation of `:include:` directive file search

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -641,9 +641,9 @@ require 'rdoc'
 #     The file content is shifted to have the same indentation as the colon
 #     at the start of the directive.
 #
-#     The file is searched for in the directories
-#     given with the <tt>--include</tt> command-line option,
-#     or by default in the current directory.
+#     The file is searched for in the directory containing the current file,
+#     and then in each of the directories given with the <tt>--include</tt>
+#     command-line option.
 #
 #   For C code, the directive may appear in a stand-alone comment
 #


### PR DESCRIPTION
The current documentation is incorrect.

1.  "The current directory" is searched before the `--include` directories.

    See:
    https://github.com/ruby/rdoc/blob/4e14158255ad8de64041105470d88f66b6e22e98/lib/rdoc/markup/pre_process.rb#L288-L296

2. "Searching the file by default in the current directory" could be read as "searching the file in the directory from which RDoc is run". This is incorrect, as the file is first searched in the directory containing the current documented file.
