### PR TITLE
Don't document aliases with trailing `:nodoc` directive

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -789,8 +789,10 @@ class RDoc::Parser::Ruby < RDoc::Parser
     al.line   = line_no
 
     read_documentation_modifiers al, RDoc::ATTR_MODIFIERS
-    context.add_alias al
-    @stats.add_alias al
+    if al.document_self or not @track_visibility
+      context.add_alias al
+      @stats.add_alias al
+    end
 
     al
   end

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -3065,6 +3065,28 @@ RUBY
     assert_nil m.params, 'Module parameter not removed'
   end
 
+  def test_parse_statements_nodoc_identifier_alias
+    klass = @top_level.add_class RDoc::NormalClass, 'Foo'
+
+    util_parser "\nalias :old :new # :nodoc:"
+
+    @parser.parse_statements klass, RDoc::Parser::Ruby::NORMAL, nil
+
+    assert_empty klass.aliases
+    assert_empty klass.unmatched_alias_lists
+  end
+
+  def test_parse_statements_nodoc_identifier_alias_method
+    klass = @top_level.add_class RDoc::NormalClass, 'Foo'
+
+    util_parser "\nalias_method :old :new # :nodoc:"
+
+    @parser.parse_statements klass, RDoc::Parser::Ruby::NORMAL, nil
+
+    assert_empty klass.aliases
+    assert_empty klass.unmatched_alias_lists
+  end
+
   def test_parse_statements_stopdoc_alias
     klass = @top_level.add_class RDoc::NormalClass, 'Foo'
 


### PR DESCRIPTION
Attribute readers and writers can be marked as `:nodoc` to keep them undocumented:

```ruby
attr_reader :name # :nodoc:
```

For aliases this behaviour should be the same:

```ruby
alias_method :old :new # :nodoc:
```