### PR TITLE
Add support for meta tags

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -780,4 +780,19 @@ class RDoc::Generator::Darkfish
     template
   end
 
+  # Returns an excerpt of the content for usage in meta description tags
+  def excerpt(content)
+    text = content.is_a?(RDoc::Comment) ? content.text : content
+
+    # Match from a capital letter to the first period, discarding any links, so
+    # that we don't end up matching badges in the README
+    first_paragraph_match = text.match(/[A-Z][^\.:\/]+\./)
+    return text[0...150].gsub(/\n/, " ").squeeze(" ") unless first_paragraph_match
+
+    extracted_text = first_paragraph_match[0]
+    second_paragraph = first_paragraph_match.post_match.match(/[A-Z][^\.:\/]+\./)
+    extracted_text << " " << second_paragraph[0] if second_paragraph
+
+    extracted_text[0...150].gsub(/\n/, " ").squeeze(" ")
+  end
 end

--- a/lib/rdoc/generator/template/darkfish/_head.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_head.rhtml
@@ -3,6 +3,28 @@
 
 <title><%= h @title %></title>
 
+<%- if defined?(klass) -%>
+  <meta name="keywords" content="ruby,<%= h "#{klass.type},#{klass.full_name}" %>">
+
+  <%- if klass.comment.empty? -%>
+    <meta name="description" content="Documentation for the <%= h "#{klass.full_name} #{klass.type}" %>">
+  <%- else -%>
+    <meta name="description" content="<%= h "#{klass.type} #{klass.full_name}: #{excerpt(klass.comment)}" %>">
+  <%- end -%>
+<%- elsif defined?(file) -%>
+  <meta name="keywords" content="ruby,documentation,<%= h file.page_name %>">
+  <meta name="description" content="<%= h "#{file.page_name}: #{excerpt(file.comment)}" %>">
+<%- elsif @title -%>
+  <meta name="keywords" content="ruby,documentation,<%= h @title %>">
+
+  <%- if @options.main_page and
+      main_page = @files.find { |f| f.full_name == @options.main_page } then %>
+    <meta name="description" content="<%= h "#{@title}: #{excerpt(main_page.comment)}" %>">
+  <%- else -%>
+    <meta name="description" content="Documentation for <%= h @title %>">
+  <%- end -%>
+<%- end -%>
+
 <script type="text/javascript">
   var rdoc_rel_prefix = "<%= h asset_rel_prefix %>/";
   var index_rel_prefix = "<%= h rel_prefix %>/";


### PR DESCRIPTION
## Motivation

Without being able to add SEO meta tags, such as `description` or `keywords`, documentation websites generated by RDoc often don't rank well in search engines. For example, Ruby's official documentation (generated by RDoc), is rarely the first result when searching for "Ruby documentation".

I think it would be really beneficial to allow developers to define meta tags for improving the SEO of their RDoc generated websites - and Ruby itself can benefit from it.

## Implementation

I split the implementation by commit:
1. Added `meta_tags` to options
2. Added `meta_tags` to the `RDoc::Task`
3. Used the `meta_tags` to create the entries in the HTML
4. Started using `meta_tags` for RDoc's own documentation

## Concerns

My main concern with this implementation is the format of the `meta_tags` option. I used a hash to provide flexibility in which meta tags the users can define. I believe the flexibility is important, because there are many meta tags and trying to account for all of them would be impractical (e.g.: `keywords`, `description`, `og:description`, `og:title` and so many others).

However, the current implementation of RDoc only allows for CLI-style options. Every option has to be passed as if it were coming from the command line (e.g.: `--something=otherthing`). This makes passing a hash to the `meta_tags` option quite weird. I'm currently converting it into a JSON, so that I can parse it back into a hash after the `OptionParse` extracts the options.

I don't really like the approach, but my two arguments for proposing this solution are:

1. If we're going to support meta tags, I believe flexibility is needed. There's no point in supporting only `keywords` and `description` as two hardcoded options
2. Refactoring RDoc to allow for options that don't conform to the CLI style is a bigger effort

Let me know what you think about this.

## Testing this change

1. Switch to this branch
2. Run `bundle exec rake rerdoc` to generate the website
4. Verify that the `_site/index.html` contains the following tags
```html
<meta name="keywords" content="...">
<meta name="description" content="...">
```