### PR TITLE
Fix ToRdoc generating incorrect {label,name}-lists

### DIFF
--- a/lib/rdoc/markup/to_bs.rb
+++ b/lib/rdoc/markup/to_bs.rb
@@ -41,6 +41,31 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   end
 
   ##
+  # Prepares the visitor for consuming +list_item+
+
+  def accept_list_item_start list_item
+    type = @list_type.last
+
+    case type
+    when :NOTE, :LABEL then
+      bullets = Array(list_item.label).map do |label|
+        attributes(label).strip
+      end.join "\n"
+
+      bullets << ":\n" unless bullets.empty?
+
+      @prefix = ' ' * @indent
+      @indent += 2
+      @prefix << bullets + (' ' * @indent)
+    else
+      bullet = type == :BULLET ? '*' :  @list_index.last.to_s + '.'
+      @prefix = (' ' * @indent) + bullet.ljust(bullet.length + 1)
+      width = bullet.length + 1
+      @indent += width
+    end
+  end
+
+  ##
   # Turns on or off regexp handling for +convert_string+
 
   def annotate tag

--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -145,11 +145,19 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
 
     case type
     when :NOTE, :LABEL then
-      bullets = Array(list_item.label).map do |label|
+      stripped_labels = Array(list_item.label).map do |label|
         attributes(label).strip
-      end.join "\n"
+      end
 
-      bullets << ":\n" unless bullets.empty?
+      bullets = case type
+      when :NOTE
+        stripped_labels.map { |b| "#{b}::" }
+      when :LABEL
+        stripped_labels.map { |b| "[#{b}]" }
+      end
+
+      bullets = bullets.join("\n")
+      bullets << "\n" unless stripped_labels.empty?
 
       @prefix = ' ' * @indent
       @indent += 2

--- a/test/rdoc/test_rdoc_markup_to_rdoc.rb
+++ b/test/rdoc/test_rdoc_markup_to_rdoc.rb
@@ -69,7 +69,7 @@ class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase
   end
 
   def accept_list_item_end_label
-    assert_equal "cat:\n", @to.res.join
+    assert_equal "[cat]\n", @to.res.join
     assert_equal 0, @to.indent, 'indent'
   end
 
@@ -79,7 +79,7 @@ class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase
   end
 
   def accept_list_item_end_note
-    assert_equal "cat:\n", @to.res.join
+    assert_equal "cat::\n", @to.res.join
     assert_equal 0, @to.indent, 'indent'
   end
 
@@ -100,7 +100,7 @@ class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase
 
   def accept_list_item_start_label
     assert_equal [""], @to.res
-    assert_equal "cat:\n  ", @to.prefix
+    assert_equal "[cat]\n  ", @to.prefix
 
     assert_equal 2, @to.indent
   end
@@ -115,7 +115,7 @@ class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase
 
   def accept_list_item_start_note
     assert_equal [""], @to.res
-    assert_equal "cat:\n  ", @to.prefix
+    assert_equal "cat::\n  ", @to.prefix
 
     assert_equal 2, @to.indent
   end
@@ -243,16 +243,16 @@ class TestRDocMarkupToRDoc < RDoc::Markup::TextFormatterTestCase
   end
 
   def accept_list_item_start_note_2
-    assert_equal "<tt>teletype</tt>:\n  teletype description\n\n", @to.res.join
+    assert_equal "<tt>teletype</tt>::\n  teletype description\n\n", @to.res.join
   end
 
   def accept_list_item_start_note_multi_description
-    assert_equal "label:\n  description one\n\n  description two\n\n",
+    assert_equal "label::\n  description one\n\n  description two\n\n",
                  @to.res.join
   end
 
   def accept_list_item_start_note_multi_label
-    assert_equal "one\ntwo:\n  two headers\n\n", @to.res.join
+    assert_equal "one::\ntwo::\n  two headers\n\n", @to.res.join
   end
 
   def accept_paragraph_b
@@ -355,8 +355,8 @@ bar ::
     NOTE_LIST
 
     expected = <<-EXPECTED
-foo
-bar:
+foo::
+bar::
   hi
 
     EXPECTED


### PR DESCRIPTION
Previously, trying to round-trip label-list and name-lists with the ToRdoc converter was not possible:

```ruby
doc = <<~RDOC
foo ::
bar ::
  hi
RDOC

markup = RDoc::Markup.parse(doc)
markup # => [doc: [list: NOTE [item: ["foo ", "bar"]; [para: "hi"]]]]

rt = RDoc::Markup::ToRdoc.new.convert(markup)
rt # => "foo\nbar:\n  hi\n\n"

rt_markup = RDoc::Markup.parse(rt)
rt_markup # => [doc: [para: "foo ", "bar:"], [verb: "hi\n"]]
```

This commit addresses the issue by fixing ToRdoc to generate output that can be properly reparsed by RDoc. ToRdoc tests additionally needed to be updated for the new output.

The old implementation of `accept_list_item_start` was copied to ToBs because those tests did not pass with the new changes and I am unfamiliar with the `backspace` format.

After:

```ruby
doc = <<~RDOC
foo ::
bar ::
  hi
RDOC

markup = RDoc::Markup.parse(doc)
markup # => [doc: [list: NOTE [item: ["foo ", "bar"]; [para: "hi"]]]]

rt = RDoc::Markup::ToRdoc.new.convert(markup)
rt # => "foo::\nbar::\n  hi\n\n"

rt_markup = RDoc::Markup.parse(rt)
rt_markup # => [doc: [list: NOTE [item: ["foo", "bar"]; [para: "hi"], blankline]]]
```