### PR TITLE
Fix ToMarkdown missing newlines for label-lists

### DIFF
--- a/lib/rdoc/markup/to_markdown.rb
+++ b/lib/rdoc/markup/to_markdown.rb
@@ -45,8 +45,6 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   # Finishes consumption of `list`
 
   def accept_list_end list
-    @res << "\n"
-
     super
   end
 
@@ -59,6 +57,8 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
               4
             when :NOTE, :LABEL then
               use_prefix
+
+              @res << "\n"
 
               4
             else
@@ -81,11 +81,11 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
         attributes(label).strip
       end.join "\n"
 
-      bullets << "\n:"
+      bullets << "\n" unless bullets.empty?
 
       @prefix = ' ' * @indent
       @indent += 4
-      @prefix << bullets + (' ' * (@indent - 1))
+      @prefix << bullets << ":" << (' ' * (@indent - 1))
     else
       bullet = type == :BULLET ? '*' : @list_index.last.to_s + '.'
       @prefix = (' ' * @indent) + bullet.ljust(4)

--- a/test/rdoc/test_rdoc_markup_to_markdown.rb
+++ b/test/rdoc/test_rdoc_markup_to_markdown.rb
@@ -69,7 +69,7 @@ class TestRDocMarkupToMarkdown < RDoc::Markup::TextFormatterTestCase
   end
 
   def accept_list_item_end_label
-    assert_equal "cat\n:   ", @to.res.join
+    assert_equal "cat\n:   \n", @to.res.join
     assert_equal 0, @to.indent, 'indent'
   end
 
@@ -79,7 +79,7 @@ class TestRDocMarkupToMarkdown < RDoc::Markup::TextFormatterTestCase
   end
 
   def accept_list_item_end_note
-    assert_equal "cat\n:   ", @to.res.join
+    assert_equal "cat\n:   \n", @to.res.join
     assert_equal 0, @to.indent, 'indent'
   end
 
@@ -319,9 +319,7 @@ words words words words
     expected = <<-EXPECTED
 *   l1
     *   l1.1
-
 *   l2
-
     EXPECTED
 
     assert_equal expected, @to.end_accepting
@@ -342,7 +340,6 @@ words words words words
           third
 
         * second
-
 
     EXPECTED
 


### PR DESCRIPTION
Ref rails/rails#50759

Previously, using ToMarkdown on a label-list would generate output that could not be reparsed by the RDoc::Markdown parser:

```
md = <<~MD
apple
: a red fruit

banana
: a yellow fruit
MD

doc = RDoc::Markdown.parse(md)
doc # => [doc: [list: NOTE [item: ["apple"]; [para: "a red fruit"]], [item: ["banana"]; [para: "a yellow fruit"]]]]

new_md = doc.accept(RDoc::Markup::ToMarkdown.new)
new_md # => "apple\n:   a red fruit\nbanana\n:   a yellow fruit\n\n"

new_doc = RDoc::Markdown.parse(new_md)
new_doc # => [doc: [list: NOTE [item: ["apple"]; [para: "a red fruit\nbanana\n: a yellow fruit"]]]]
```

The issue is that the [PHP Markdown Extra spec][1] requires a newline after each definition list item, but ToMarkdown was not putting newlines between label-list items.

This commit fixes the issue by properly appending a newline after each label-list item so that the output of ToMarkdown can be reparsed by RDoc::Markdown:

```
md = <<~MD
apple
: a red fruit

banana
: a yellow fruit
MD

doc = RDoc::Markdown.parse(mdoc)
doc # => [doc: [list: NOTE [item: ["apple"]; [para: "a red fruit"]], [item: ["banana"]; [para: "a yellow fruit"]]]]

new_md = doc.accept(RDoc::Markup::ToMarkdown.new)
new_md # => "apple\n:   a red fruit\n\nbanana\n:   a yellow fruit\n\n"

new_doc = RDoc::Markdown.parse(new_md)
new_doc # => [doc: [list: NOTE [item: ["apple"]; [para: "a red fruit"]], [item: ["banana"]; [para: "a yellow fruit"]]]]
```

[1]: https://michelf.ca/projects/php-markdown/extra/#def-list