### PR TITLE
Allow rich definition list labels for Markdown

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -1237,7 +1237,7 @@ DefinitionListItem = ( DefinitionListLabel+ ):label
                        list_items
                      }
 
-DefinitionListLabel = StrChunk:label @Sp @Newline
+DefinitionListLabel = Inline:label @Sp @Newline
                       { label }
 
 DefinitionListDefinition = @NonindentSpace ":" @Space Inlines:a @BlankLine+

--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -305,6 +305,25 @@ that also extends to two lines
     assert_equal expected, doc
   end
 
+  def test_parse_definition_list_rich_label
+    doc = parse <<-MD
+`one`
+:    This is a definition
+
+**two**
+:    This is another definition
+    MD
+
+    expected = doc(
+      list(:NOTE,
+        item(%w[<code>one</code>],
+          para("This is a definition")),
+        item(%w[*two*],
+          para("This is another definition"))))
+
+    assert_equal expected, doc
+  end
+
   def test_parse_definition_list_no
     @parser.definition_lists = false
 


### PR DESCRIPTION
Previously, any sort of "rich" markup for a definition list's label would cause the Markdown parser to not recognize a definition list:

```ruby
md = <<~md
`one`
:    This is a definition
md

doc = RDoc::Markdown.parse(md)
doc # => [doc: [para: "<code>one</code>\n: This is a definition"]]
```

This commit tweaks the grammar for Markdown definition lists so that labels can include "rich" markup such as bold (`**`), code (```), etc:

```ruby
md = <<~md
`one`
:    This is a definition
md

doc = RDoc::Markdown.parse(md)
doc # => [doc: [list: NOTE [item: ["<code>one</code>"]; [para: "This is a definition"]]]]
```

The [PHP Markdown Extra][1] Spec does not seem to specify whether or not this should be allowed, but it is allowed in the RDoc format:

```ruby
rdoc = <<~rdoc
+code+::
    This is a definition
rdoc

doc = RDoc::Markup.parse(rdoc)
doc # => [doc: [list: NOTE [item: ["+code+"]; [para: "This is a definition"]]]]
```

so accepting this change increases the parity of the two formats.

[1]: https://michelf.ca/projects/php-markdown/extra/#def-list