### PR TITLE
Revert "Test only with truffleruby-head"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
 
   test:
     needs: ruby-versions
@@ -18,12 +16,11 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            ruby: truffleruby-head
-          - os: macos-latest
-            ruby: truffleruby-head
         exclude:
+          - os: windows-latest
+            ruby: truffleruby
+          - os: windows-latest
+            ruby: truffleruby-head
           - os: windows-latest
             ruby: jruby
           - os: windows-latest


### PR DESCRIPTION
* This reverts commit 2361a8a8862025e3f414dab62dd442a40a121616.
* truffleruby 24.0.0 is out and has the fix, see https://github.com/ruby/rdoc/pull/1095