### PR TITLE
cleanup: Remove `webcvs` option and cvs-related code

### DIFF
--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -41,20 +41,6 @@ module RDoc::Generator::Markup
     @formatter.code_object = self
     @formatter
   end
-
-  ##
-  # Build a webcvs URL starting for the given +url+ with +full_path+ appended
-  # as the destination path.  If +url+ contains '%s' +full_path+ will be
-  # will replace the %s using sprintf on the +url+.
-
-  def cvs_url(url, full_path)
-    if /%s/ =~ url then
-      sprintf url, full_path
-    else
-      url + full_path
-    end
-  end
-
 end
 
 class RDoc::CodeObject
@@ -137,23 +123,5 @@ end
 class RDoc::Context::Section
 
   include RDoc::Generator::Markup
-
-end
-
-class RDoc::TopLevel
-
-  ##
-  # Returns a URL for this source file on some web repository.  Use the -W
-  # command line option to set.
-
-  def cvs_url
-    url = @store.rdoc.options.webcvs
-
-    if /%s/ =~ url then
-      url % @relative_name
-    else
-      url + @relative_name
-    end
-  end
 
 end

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -326,11 +326,6 @@ class RDoc::Options
   attr_accessor :verbosity
 
   ##
-  # URL of web cvs frontend
-
-  attr_accessor :webcvs
-
-  ##
   # Minimum visibility of a documented method. One of +:public+, +:protected+,
   # +:private+ or +:nodoc+.
   #
@@ -387,7 +382,6 @@ class RDoc::Options
     @update_output_dir = true
     @verbosity = 1
     @visibility = :protected
-    @webcvs = nil
     @write_options = false
     @encoding = Encoding::UTF_8
     @charset = @encoding.name
@@ -415,7 +409,6 @@ class RDoc::Options
     @template_dir   = map['template_dir']
     @title          = map['title']
     @visibility     = map['visibility']
-    @webcvs         = map['webcvs']
 
     @rdoc_include = sanitize_path map['rdoc_include']
     @static_path  = sanitize_path map['static_path']
@@ -447,7 +440,6 @@ class RDoc::Options
     @template_dir   = map['template_dir']   if map.has_key?('template_dir')
     @title          = map['title']          if map.has_key?('title')
     @visibility     = map['visibility']     if map.has_key?('visibility')
-    @webcvs         = map['webcvs']         if map.has_key?('webcvs')
 
     if map.has_key?('rdoc_include')
       @rdoc_include = sanitize_path map['rdoc_include']
@@ -474,8 +466,7 @@ class RDoc::Options
       @tab_width      == other.tab_width      and
       @template       == other.template       and
       @title          == other.title          and
-      @visibility     == other.visibility     and
-      @webcvs         == other.webcvs
+      @visibility     == other.visibility
   end
 
   ##
@@ -1025,7 +1016,7 @@ Usage: #{opt.program_name} [options] [names...]
              "name of the current file will be",
              "substituted; if the URL doesn't contain a",
              "'\%s', the filename will be appended to it.") do |value|
-        @webcvs = value
+               # It does nothing but exists for compatibility
       end
 
       opt.separator nil

--- a/test/rdoc/test_rdoc_generator_markup.rb
+++ b/test/rdoc/test_rdoc_generator_markup.rb
@@ -27,14 +27,6 @@ class TestRDocGeneratorMarkup < RDoc::TestCase
     assert_equal '../index.html', as_href('Foo/Bar.html')
   end
 
-  def test_cvs_url
-    assert_equal 'http://example/this_page',
-                 cvs_url('http://example/', 'this_page')
-
-    assert_equal 'http://example/?page=this_page&foo=bar',
-                 cvs_url('http://example/?page=%s&foo=bar', 'this_page')
-  end
-
   def test_description
     @comment = '= Hello'
 

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -81,7 +81,6 @@ class TestRDocOptions < RDoc::TestCase
       'template_stylesheets' => [],
       'title'                => nil,
       'visibility'           => :protected,
-      'webcvs'               => nil,
       'skip_tests'           => true,
     }
 


### PR DESCRIPTION
`webcvs` option is used for `cvs_url` method only, but `cvs_url` method seems NOT be used anywhere.