### PR TITLE
chore(bin): Add `bin/console` for better DX

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'rdoc'
+
+# This is the easy way to prepare various kinds of RDoc objects.
+require_relative '../doc/rdoc/markup_reference'
+
+require 'irb'
+IRB.start(__FILE__)


### PR DESCRIPTION
I wanted to try RDoc methods and noticed there's no `bin` dir. This `bin/console` loads `doc/rdoc/markup_reference` for easy testing and debugging.