### PR TITLE
RDoc task should include top-level .md files too

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ RDoc::Task.new do |doc|
   doc.main = 'README.rdoc'
   doc.title = "rdoc #{RDoc::VERSION} Documentation"
   doc.rdoc_dir = '_site' # for github pages
-  doc.rdoc_files = FileList.new %w[lib/**/*.rb *.rdoc doc/rdoc/markup_reference.rb] - PARSER_FILES
+  doc.rdoc_files = FileList.new %w[lib/**/*.rb *.rdoc *.md doc/rdoc/markup_reference.rb] - PARSER_FILES
 end
 
 task "coverage" do


### PR DESCRIPTION
Otherwise, `ri.md` and `ExampleMarkdown.md` will not be included in the generated documentation.

**before**

<img width="50%" alt="Screenshot 2024-07-06 at 22 40 01" src="https://github.com/ruby/rdoc/assets/5079556/dd55e651-1439-4919-9f3f-4fd2f4683a33">

**after**

<img width="50%" alt="Screenshot 2024-07-06 at 22 40 31" src="https://github.com/ruby/rdoc/assets/5079556/85151c41-7b46-4837-8572-d23049f9ee2c">
