### PR TITLE
lint: Remove unreachable code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ Layout/SpaceBeforeComma:
 
 Layout/SpaceAfterComma:
   Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -395,7 +395,6 @@ The internal error was:
     $stderr.puts e.backtrace.join("\n\t") if $DEBUG_RDOC
 
     raise e
-    nil
   end
 
   ##


### PR DESCRIPTION
This is an attempt to utilize RuboCop further.
RuboCop was added in 9262fdd43a3a87403dc095e096f968576cd611d9 but only a few rules have been enabled.
I believe we can utilize RuboCop more for better code quality, especially with Lint cops.
This is the first step to enable other Lint cops.
This commit also exclude some auto generated files.