### PR TITLE
[DOC] Mods about markup formats

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -532,7 +532,8 @@ require 'rdoc'
 #
 #   - Appears on a line by itself.
 #   - Specifies the format for the \RDoc input;
-#     parameter +type+ is one of +markdown+, +rd+, +rdoc+, +tomdoc+.
+#     parameter +type+ is one of: +rdoc+ (the default), +markdown+, +rd+, +tomdoc+.
+#     See {Markup Formats}[rdoc-ref:RDoc::Markup@Markup+Formats].
 #
 # ===== Directives for HTML Output
 #

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -16,7 +16,7 @@
 #
 # - +rdoc+:
 #   the +RDoc+ markup format;
-#   see RDoc::Markup.
+#   see RDoc::MarkupReference.
 # - +markdown+:
 #   The +markdown+ markup format as described in
 #   the {Markdown Guide}[https://www.markdownguide.org];

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -10,19 +10,24 @@
 # RDoc::Markup and other markup formats do no output formatting, this is
 # handled by the RDoc::Markup::Formatter subclasses.
 #
-# = Supported Formats
+# = Markup Formats
 #
-# Besides the RDoc::Markup format, the following formats are built in to RDoc:
+# +RDoc+ supports these markup formats:
 #
-# markdown::
-#   The markdown format as described by
-#   http://daringfireball.net/projects/markdown/.  See RDoc::Markdown for
-#   details on the parser and supported extensions.
-# rd::
-#   The rdtool format.  See RDoc::RD for details on the parser and format.
-# tomdoc::
-#   The TomDoc format as described by http://tomdoc.org/.  See RDoc::TomDoc
-#   for details on the parser and supported extensions.
+# - +rdoc+:
+#   the +RDoc+ markup format;
+#   see RDoc::Markup.
+# - +markdown+:
+#   The +markdown+ markup format as described in
+#   the {Markdown Guide}[https://www.markdownguide.org];
+#   see RDoc::Markdown.
+# - +rd+:
+#   the +rd+ markup format format;
+#   see RDoc::RD.
+# - +tomdoc+:
+#   the TomDoc format as described in
+#   {TomDoc for Ruby}[http://tomdoc.org];
+#   see RDoc::TomDoc.
 #
 # You can choose a markup format using the following methods:
 #

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -233,9 +233,9 @@ class RDoc::Options
   attr_accessor :main_page
 
   ##
-  # The default markup format.  The default is 'rdoc'.  'markdown', 'tomdoc'
-  # and 'rd' are also built-in.
-
+  # The markup format.
+  # One of: +rdoc+ (the default), +markdown+, +rd+, +tomdoc+.
+  # See {Markup Formats}[rdoc-ref:RDoc::Markup@Markup+Formats].
   attr_accessor :markup
 
   ##

--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -104,9 +104,8 @@ class RDoc::Task < Rake::TaskLib
   attr_accessor :name
 
   ##
-  # Comment markup format.  rdoc, rd and tomdoc are supported.  (default is
-  # 'rdoc')
-
+  # The markup format; one of: +rdoc+ (the default), +markdown+, +rd+, +tomdoc+.
+  # See {Markup Formats}[rdoc-ref:RDoc::Markup@Markup+Formats].
   attr_accessor :markup
 
   ##

--- a/lib/rdoc/tom_doc.rb
+++ b/lib/rdoc/tom_doc.rb
@@ -3,13 +3,7 @@
 
 # A parser for TomDoc based on TomDoc 1.0.0-rc1 (02adef9b5a)
 #
-# The TomDoc specification can be found at:
-#
-# http://tomdoc.org
-#
-# The latest version of the TomDoc specification can be found at:
-#
-# https://github.com/mojombo/tomdoc/blob/master/tomdoc.md
+# The TomDoc specification can be found at http://tomdoc.org.
 #
 # To choose TomDoc as your only default format see RDoc::Options@Saved+Options
 # for instructions on setting up a <code>.rdoc_options</code> file to store


### PR DESCRIPTION
Clarifies (I hope) some things about markup formats.

I've purposely not mentioned `markup` as an alias for `rdoc` because I think it invites confusion.