### PR TITLE
Follow up changes for Prism Ruby parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
       run: bundle exec rake
       env:
         RUBYOPT: --enable-frozen_string_literal
+    - name: Run test with Prism parser
+      run: bundle exec rake
+      env:
+        RUBYOPT: --enable-frozen_string_literal
+        RDOC_USE_PRISM_PARSER: true
     - if: ${{ matrix.ruby == 'head' && startsWith(matrix.os, 'ubuntu') }}
       run: bundle exec rake rdoc
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      # 2.7 breaks `test_parse_statements_nodoc_identifier_alias_method`
+      min_version: 3.0
 
   test:
     needs: ruby-versions

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'test-unit-ruby-core'
   gem 'rubocop', '>= 1.31.0'
   gem 'gettext'
+  gem 'prism', '>= 0.30.0'
 end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -11,6 +11,9 @@
 if ENV['RDOC_USE_PRISM_PARSER']
   require 'rdoc/parser/prism_ruby'
   RDoc::Parser.const_set(:Ruby, RDoc::Parser::PrismRuby)
+  puts "========================================================================="
+  puts "RDoc is using the experimental Prism parser to generate the documentation"
+  puts "========================================================================="
   return
 end
 

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -230,9 +230,8 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.rdoc_options = ["--main", "README.rdoc"]
   s.extra_rdoc_files += s.files.grep(%r[\A[^\/]+\.(?:rdoc|md)\z])
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
-  s.add_dependency 'prism', '>= 0.30.0'
   s.add_dependency 'psych', '>= 4.0.0'
 end


### PR DESCRIPTION
1. When running RDoc with the Prism Ruby parser, there should be a clear message output
2. We should run tests with `RDOC_USE_PRISM_PARSER` on CI too
3. Since the Prism Ruby parser is optional and disabled by default, it doesn't make sense to require `prism` as dependency just yet