### PR TITLE
Remove unnecessary `file_name` parameter from `Parser#initialize`

### DIFF
--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -191,7 +191,7 @@ class RDoc::Parser
 
     content = remove_modeline content
 
-    parser.new top_level, file_name, content, options, stats
+    parser.new top_level, content, options, stats
   rescue SystemCallError
     nil
   end
@@ -252,12 +252,12 @@ class RDoc::Parser
   # RDoc::Markup::PreProcess object is created which allows processing of
   # directives.
 
-  def initialize top_level, file_name, content, options, stats
+  def initialize top_level, content, options, stats
     @top_level = top_level
     @top_level.parser = self.class
     @store = @top_level.store
 
-    @file_name = file_name
+    @file_name = top_level.absolute_name
     @content = content
     @options = options
     @stats = stats

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -168,7 +168,7 @@ class RDoc::Parser::C < RDoc::Parser
   # Prepares for parsing a C file.  See RDoc::Parser#initialize for details on
   # the arguments.
 
-  def initialize top_level, file_name, content, options, stats
+  def initialize top_level, content, options, stats
     super
 
     @known_classes = RDoc::KNOWN_CLASSES.dup

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -18,7 +18,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
   attr_accessor :visibility
   attr_reader :container, :singleton
 
-  def initialize(top_level, file_name, content, options, stats)
+  def initialize(top_level, content, options, stats)
     super
 
     content = handle_tab_width(content)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -170,7 +170,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Creates a new Ruby parser.
 
-  def initialize(top_level, file_name, content, options, stats)
+  def initialize(top_level, content, options, stats)
     super
 
     content = handle_tab_width(content)

--- a/lib/rdoc/parser/simple.rb
+++ b/lib/rdoc/parser/simple.rb
@@ -14,7 +14,7 @@ class RDoc::Parser::Simple < RDoc::Parser
   ##
   # Prepare to parse a plain file
 
-  def initialize(top_level, file_name, content, options, stats)
+  def initialize(top_level, content, options, stats)
     super
 
     preprocess = RDoc::Markup::PreProcess.new @file_name, @options.rdoc_include

--- a/test/rdoc/test_rdoc_parser.rb
+++ b/test/rdoc/test_rdoc_parser.rb
@@ -310,7 +310,7 @@ class RDocParserTest < RDoc::TestCase
 
   def test_initialize
     with_top_level("file.rb", "") do |top_level, content|
-      @RP.new top_level, top_level.absolute_name, content, @options, nil
+      @RP.new top_level, content, @options, nil
 
       assert_equal @RP, top_level.parser
     end

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -138,7 +138,7 @@ class TestRDocParserC < RDoc::TestCase
       @fn => { 'cSomeExtSingle' => 'SomeExtSingle' }
     }
 
-    parser = RDoc::Parser::C.new @top_level, @fn, '', @options, @stats
+    parser = RDoc::Parser::C.new @top_level, '', @options, @stats
 
     expected = { 'cSomeExt' => some_ext }
     assert_equal expected, parser.classes
@@ -2144,7 +2144,7 @@ void Init_Blah(void) {
   end
 
   def util_parser content = ''
-    RDoc::Parser::C.new @top_level, @fn, content, @options, @stats
+    RDoc::Parser::C.new @top_level, content, @options, @stats
   end
 
 end

--- a/test/rdoc/test_rdoc_parser_changelog.rb
+++ b/test/rdoc/test_rdoc_parser_changelog.rb
@@ -474,8 +474,7 @@ ChangeLog
   end
 
   def util_parser content = ''
-    RDoc::Parser::ChangeLog.new \
-      @top_level, @tempfile.path, content, @options, @stats
+    RDoc::Parser::ChangeLog.new @top_level, content, @options, @stats
   end
 
   def log_entry(*a)

--- a/test/rdoc/test_rdoc_parser_markdown.rb
+++ b/test/rdoc/test_rdoc_parser_markdown.rb
@@ -55,7 +55,7 @@ class TestRDocParserMarkdown < RDoc::TestCase
   end
 
   def util_parser content
-    RDoc::Parser::Markdown.new @top_level, @fn, content, @options, @stats
+    RDoc::Parser::Markdown.new @top_level, content, @options, @stats
   end
 
 end

--- a/test/rdoc/test_rdoc_parser_prism_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_prism_ruby.rb
@@ -1996,7 +1996,7 @@ class TestRDocParserPrismRuby < RDoc::TestCase
   end
 
   def util_parser(content)
-    @parser = RDoc::Parser::PrismRuby.new @top_level, @filename, content, @options, @stats
+    @parser = RDoc::Parser::PrismRuby.new @top_level, content, @options, @stats
     @parser.scan
   end
 end
@@ -2010,7 +2010,7 @@ class TestRDocParserRubyWithPrismRubyTestCases < RDoc::TestCase
   end
 
   def util_parser(content)
-    @parser = RDoc::Parser::Ruby.new @top_level, @filename, content, @options, @stats
+    @parser = RDoc::Parser::Ruby.new @top_level, content, @options, @stats
     @parser.scan
   end
 end unless ENV['RDOC_USE_PRISM_PARSER']

--- a/test/rdoc/test_rdoc_parser_rd.rb
+++ b/test/rdoc/test_rdoc_parser_rd.rb
@@ -49,7 +49,7 @@ class TestRDocParserRd < RDoc::TestCase
   end
 
   def util_parser content
-    RDoc::Parser::RD.new @top_level, @fn, content, @options, @stats
+    RDoc::Parser::RD.new @top_level, content, @options, @stats
   end
 
 end

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -4087,8 +4087,7 @@ end
   end
 
   def util_parser(content)
-    @parser = RDoc::Parser::Ruby.new @top_level, @filename, content, @options,
-                                     @stats
+    @parser = RDoc::Parser::Ruby.new @top_level, content, @options, @stats
   end
 
   def util_two_parsers(first_file_content, second_file_content)

--- a/test/rdoc/test_rdoc_parser_simple.rb
+++ b/test/rdoc/test_rdoc_parser_simple.rb
@@ -109,7 +109,7 @@ contents of a string.
   end
 
   def util_parser(content)
-    RDoc::Parser::Simple.new @top_level, @fn, content, @options, @stats
+    RDoc::Parser::Simple.new @top_level, content, @options, @stats
   end
 
 end

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -116,7 +116,7 @@ class TestRDocStore < XrefTestCase
     some_ext   = c_file.add_class RDoc::NormalClass, 'SomeExt'
                  c_file.add_class RDoc::SingleClass, 'SomeExtSingle'
 
-    c_parser = RDoc::Parser::C.new c_file, 'ext.c', '', options, nil
+    c_parser = RDoc::Parser::C.new c_file, '', options, nil
 
     c_parser.classes['cSomeExt']             = some_ext
     c_parser.singleton_classes['s_cSomeExt'] = 'SomeExtSingle'
@@ -698,7 +698,7 @@ class TestRDocStore < XrefTestCase
     some_ext   = c_file.add_class RDoc::NormalClass, 'SomeExt'
                  c_file.add_class RDoc::SingleClass, 'SomeExtSingle'
 
-    c_parser = RDoc::Parser::C.new c_file, 'ext.c', '', options, nil
+    c_parser = RDoc::Parser::C.new c_file, '', options, nil
 
     c_parser.classes['cSomeExt']             = some_ext
     c_parser.singleton_classes['s_cSomeExt'] = 'SomeExtSingle'

--- a/test/rdoc/xref_test_case.rb
+++ b/test/rdoc/xref_test_case.rb
@@ -20,8 +20,7 @@ class XrefTestCase < RDoc::TestCase
 
     stats = RDoc::Stats.new @store, 0
 
-    parser = RDoc::Parser::Ruby.new @xref_data, @file_name, XREF_DATA, @options,
-                                    stats
+    parser = RDoc::Parser::Ruby.new @xref_data, XREF_DATA, @options, stats
 
     @example_md = @store.add_file 'EXAMPLE.md'
     @example_md.parser = RDoc::Parser::Markdown


### PR DESCRIPTION
Similar to #1135, the `file_name` argument's value should be the name as `top_level.absolute_name`. So passing it separately is not necessary.