### PR TITLE
Fix flaky test: prevent regexp match to tempdir path

### DIFF
--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -194,7 +194,7 @@ class TestRDocRDoc < RDoc::TestCase
       File.write('.document', "a.rb\n""b.rb\n")
       expected_files << a
 
-      @rdoc.options.exclude = Regexp.new(['b.rb'].join('|'))
+      @rdoc.options.exclude = /b\.rb$/
       @rdoc.normalized_file_list [File.realpath(dir)]
     end
 


### PR DESCRIPTION
`test_normalized_file_list_with_dot_doc_overridden_by_exclude_option` randomly fails.

http://ci.rvm.jp/results/master-no-rjit@ruby-sp2-noble-docker/5239423
In this case, file path `"/tmp/rubytest.ob1rbw/d20240802-764731-bboa2z/a.rb"` matches to regexp exclude path `/b.rb/`.
`rubytest.ob1rbw` part includes `b1rb` and it matched to `/b.rb/`.

## `\.` and `$`
Note that tmpdir path might also include period (in `rubytest.xxxxxx` part) and there is a chance that tmpdir might match to `/t\.rb/` so I appended `$` to avoid it.



