### PR TITLE
Fix darkfish responsiveness issue on screens between 1024px and ~1650px 

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -223,7 +223,8 @@ nav {
 
 main {
   display: block;
-  margin: 3em 1em 1em;
+  margin: 3em auto 1em;
+  padding: 0 1em; /* Add padding to keep space between main content and sidebar/right side of the screen */
   min-width: 340px;
   font-size: 16px;
   width: 100%;
@@ -232,8 +233,7 @@ main {
 
 @media (min-width: 1024px) {
   main {
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: 300px;
   }
 }
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -214,13 +214,6 @@ nav {
   background: white;
 }
 
-@media (min-width: 1024px) {
-  nav {
-    min-height: unset;
-    height: calc(100vh - 100px); /* reduce the footer height */
-  }
-}
-
 main {
   display: block;
   margin: 3em auto 1em;
@@ -729,6 +722,10 @@ pre {
 #search-results pre {
   margin: 0.5em;
   font-family: "Source Code Pro", Monaco, monospace;
+}
+
+footer {
+  z-index: 20;
 }
 
 /* @end */

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -9,6 +9,10 @@
 /* vim: ft=css et sw=2 ts=2 sts=2 */
 /* Base Green is: #6C8C22 */
 
+:root {
+  --sidebar-width: 300px;
+}
+
 .hide { display: none !important; }
 
 * { padding: 0; margin: 0; }
@@ -209,7 +213,7 @@ nav {
   z-index: 10;
 
   /* Layout */
-  width: 300px;
+  width: var(--sidebar-width);
   min-height: 100vh;
   background: white;
 }
@@ -226,7 +230,7 @@ main {
 
 @media (min-width: 1024px) {
   main {
-    margin-left: 300px;
+    margin-left: var(--sidebar-width);
   }
 }
 


### PR DESCRIPTION
In that range, the sidebar would be displayed and cover part of the content. This PR fixes that by adding a left margin to the content when the screen size is greater than 1024px.

I also improved how the footer is displayed: instead of cutting the sidebar short to avoid covering it, we can increase the footer's z-index instead.

## Before

<img width="80%" alt="Screenshot 2024-08-04 at 14 46 41" src="https://github.com/user-attachments/assets/814565be-608a-4a93-bc7a-845a3b3d7407">

## After

<img width="80%" alt="Screenshot 2024-08-04 at 14 46 53" src="https://github.com/user-attachments/assets/d8e030f2-a191-45f3-be4b-9874f781bb2b">

<img width="80%" alt="Screenshot 2024-08-04 at 15 09 42" src="https://github.com/user-attachments/assets/1b15f61d-2926-4e31-a2a0-5562ddb19e08">

