### PR TITLE
Use ascii chatacter in HTML file to fix ruby ci failure

### DIFF
--- a/lib/rdoc/generator/template/darkfish/_sidebar_toggle.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_toggle.rhtml
@@ -1,3 +1,3 @@
 <button id="navigation-toggle" class="navigation-toggle" aria-label="Toggle sidebar" aria-expanded="true" aria-controls="navigation">
-  <span aria-hidden>☰</span>
+  <span aria-hidden>&#9776;</span>
 </button>


### PR DESCRIPTION
Running test with ascii encoding fails `LANG="" rake test`
```
Error: test_document_with_dry_run(TestRDocRDoc): RDoc::Error: error generating index.html: "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
```
http://ci.rvm.jp/logfiles/brlog.trunk.20240805-004507#L1586

Just like RDoc uses `&rarr;` instead of `→` in output html, this pull request changes `☰` to `&#9776;` to make the output html ascii-only again.