### PR TITLE
Fix sidebar scroll and footer display

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -677,7 +677,6 @@ class RDoc::Generator::Darkfish
     return body if body =~ /<html/
 
     head_file = @template_dir + '_head.rhtml'
-    footer_file = @template_dir + '_footer.rhtml'
 
     <<-TEMPLATE
 <!DOCTYPE html>
@@ -687,8 +686,6 @@ class RDoc::Generator::Darkfish
 #{head_file.read}
 
 #{body}
-
-#{footer_file.read}
     TEMPLATE
   end
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -209,6 +209,7 @@ nav {
   border-right: 1px solid #ccc;
   position: fixed;
   top: 0;
+  bottom: 0;
   overflow: auto;
   z-index: 10;
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -24,7 +24,9 @@ body {
 
   /* Layout */
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  min-height: 100vh;
+  margin: 0;
 }
 
 body > :last-child {
@@ -210,16 +212,34 @@ nav {
   position: fixed;
   top: 0;
   bottom: 0;
-  overflow: auto;
+  overflow: hidden;
   z-index: 10;
 
   /* Layout */
   width: var(--sidebar-width);
   min-height: 100vh;
   background: white;
+
+  display: flex;
+  flex-direction: column;
+}
+
+nav[hidden] {
+  display: none;
+}
+
+nav #project-metadata {
+  overflow: auto; /* Make the content scrollable */
+  flex: 1; /* Take up remaining space */
+}
+
+nav footer {
+  padding: 1em;
+  border-top: 1px solid #ccc;
 }
 
 main {
+  flex: 1;
   display: block;
   margin: 3em auto 1em;
   padding: 0 1em; /* Add padding to keep space between main content and sidebar/right side of the screen */
@@ -727,10 +747,6 @@ pre {
 #search-results pre {
   margin: 0.5em;
   font-family: "Source Code Pro", Monaco, monospace;
-}
-
-footer {
-  z-index: 20;
 }
 
 /* @end */

--- a/lib/rdoc/generator/template/darkfish/index.rhtml
+++ b/lib/rdoc/generator/template/darkfish/index.rhtml
@@ -12,6 +12,8 @@
     <%= render '_sidebar_pages.rhtml' %>
     <%= render '_sidebar_classes.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main">


### PR DESCRIPTION
1. The sidebar scroll is broken because #1148 made `nav`'s height not properly constrained. Adding `bottom: 0` fixes it.
2. With 1), however, the footer display would break again. And there is no good solution to fix it as placing it directly inside `body` but displaying it only in `nav`, while wanting to make it adjustable for scrolling, has been proven problematic. So I decided to move the `footer` element inside `nav` and do the corresponding css adjustments for it.

The demo below shows that the sidebar's content is now scrollable again, with the footer stick to the bottom while sidebar is being scrolled.

https://github.com/user-attachments/assets/93733fa5-425b-430e-9fb0-25a27983e621

