### PR TITLE
[doc] Mention `.document` file in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -60,6 +60,10 @@ To generate documentation programmatically:
   rdoc.document options
   # see RDoc::RDoc
 
+You can specify the target files for document generation with +.document+ file in the project root directory.
++.document+ file contains a list of file and directory names including comment lines starting with '#'.
+See https://github.com/ruby/rdoc/blob/master/.document as an example.
+
 == Writing Documentation
 
 To write documentation for RDoc place a comment above the class, module,

--- a/README.rdoc
+++ b/README.rdoc
@@ -61,7 +61,7 @@ To generate documentation programmatically:
   # see RDoc::RDoc
 
 You can specify the target files for document generation with +.document+ file in the project root directory.
-+.document+ file contains a list of file and directory names including comment lines starting with '#'.
++.document+ file contains a list of file and directory names including comment lines starting with +#+.
 See https://github.com/ruby/rdoc/blob/master/.document as an example.
 
 == Writing Documentation

--- a/README.rdoc
+++ b/README.rdoc
@@ -61,7 +61,7 @@ To generate documentation programmatically:
   # see RDoc::RDoc
 
 You can specify the target files for document generation with +.document+ file in the project root directory.
-+.document+ file contains a list of file and directory names including comment lines starting with +#+.
++.document+ file contains a list of file and directory names including comment lines starting with '#'.
 See https://github.com/ruby/rdoc/blob/master/.document as an example.
 
 == Writing Documentation


### PR DESCRIPTION
Rdoc has `.document` file in its root directory, allowing us to determine which files are the target for documentation. However, this fact is not mentioned anywhere in the doc including README, which makes it quite difficult to utilize this feature. This commit adds a mention to `.document` file in README so that users can find the feature more easily.

One thing I'm not sure is if it's the right place. Currently README includes some usage information, which can be a separate file.