### PR TITLE
Fix sidebar scroll again and add missing footer back

### DIFF
--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -16,6 +16,8 @@
     <%= render '_sidebar_extends.rhtml' %>
     <%= render '_sidebar_methods.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main" aria-labelledby="<%=h klass.aref %>">

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -8,14 +8,11 @@
   </div>
 
   <%= render '_sidebar_table_of_contents.rhtml' %>
-
-  <div id="class-metadata">
-    <%= render '_sidebar_sections.rhtml' %>
-    <%= render '_sidebar_parent.rhtml' %>
-    <%= render '_sidebar_includes.rhtml' %>
-    <%= render '_sidebar_extends.rhtml' %>
-    <%= render '_sidebar_methods.rhtml' %>
-  </div>
+  <%= render '_sidebar_sections.rhtml' %>
+  <%= render '_sidebar_parent.rhtml' %>
+  <%= render '_sidebar_includes.rhtml' %>
+  <%= render '_sidebar_extends.rhtml' %>
+  <%= render '_sidebar_methods.rhtml' %>
 
   <%= render '_footer.rhtml' %>
 </nav>

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -212,7 +212,7 @@ nav {
   position: fixed;
   top: 0;
   bottom: 0;
-  overflow: hidden;
+  overflow: auto;
   z-index: 10;
 
   /* Layout */
@@ -226,11 +226,6 @@ nav {
 
 nav[hidden] {
   display: none;
-}
-
-nav #project-metadata {
-  overflow: auto; /* Make the content scrollable */
-  flex: 1; /* Take up remaining space */
 }
 
 nav footer {
@@ -286,7 +281,7 @@ nav .nav-section {
   margin-top: 2em;
   border-top: 2px solid #aaa;
   font-size: 90%;
-  overflow: hidden;
+  flex: 1;
 }
 
 nav h2 {

--- a/lib/rdoc/generator/template/darkfish/index.rhtml
+++ b/lib/rdoc/generator/template/darkfish/index.rhtml
@@ -4,14 +4,11 @@
 <nav id="navigation" role="navigation">
   <div id="project-navigation">
     <%= render '_sidebar_navigation.rhtml' %>
-
     <%= render '_sidebar_search.rhtml' %>
   </div>
 
-  <div id="project-metadata">
-    <%= render '_sidebar_pages.rhtml' %>
-    <%= render '_sidebar_classes.rhtml' %>
-  </div>
+  <%= render '_sidebar_pages.rhtml' %>
+  <%= render '_sidebar_classes.rhtml' %>
 
   <%= render '_footer.rhtml' %>
 </nav>

--- a/lib/rdoc/generator/template/darkfish/page.rhtml
+++ b/lib/rdoc/generator/template/darkfish/page.rhtml
@@ -12,6 +12,8 @@
   <div id="project-metadata">
     <%= render '_sidebar_pages.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main" aria-label="Page <%=h file.full_name%>">

--- a/lib/rdoc/generator/template/darkfish/page.rhtml
+++ b/lib/rdoc/generator/template/darkfish/page.rhtml
@@ -8,10 +8,7 @@
   </div>
 
   <%= render '_sidebar_table_of_contents.rhtml' %>
-
-  <div id="project-metadata">
-    <%= render '_sidebar_pages.rhtml' %>
-  </div>
+  <%= render '_sidebar_pages.rhtml' %>
 
   <%= render '_footer.rhtml' %>
 </nav>

--- a/lib/rdoc/generator/template/darkfish/servlet_not_found.rhtml
+++ b/lib/rdoc/generator/template/darkfish/servlet_not_found.rhtml
@@ -2,14 +2,13 @@
 <%= render '_sidebar_toggle.rhtml' %>
 
 <nav id="navigation" role="navigation">
-  <%= render '_sidebar_navigation.rhtml' %>
-
-  <%= render '_sidebar_search.rhtml' %>
-
-  <div id="project-metadata">
-    <%= render '_sidebar_pages.rhtml' %>
-    <%= render '_sidebar_classes.rhtml' %>
+  <div id="project-navigation">
+    <%= render '_sidebar_navigation.rhtml' %>
+    <%= render '_sidebar_search.rhtml' %>
   </div>
+
+  <%= render '_sidebar_pages.rhtml' %>
+  <%= render '_sidebar_classes.rhtml' %>
 
   <%= render '_footer.rhtml' %>
 </nav>

--- a/lib/rdoc/generator/template/darkfish/servlet_not_found.rhtml
+++ b/lib/rdoc/generator/template/darkfish/servlet_not_found.rhtml
@@ -10,6 +10,8 @@
     <%= render '_sidebar_pages.rhtml' %>
     <%= render '_sidebar_classes.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main">

--- a/lib/rdoc/generator/template/darkfish/servlet_root.rhtml
+++ b/lib/rdoc/generator/template/darkfish/servlet_root.rhtml
@@ -12,7 +12,8 @@
     <%= render '_sidebar_search.rhtml' %>
   </div>
 
-<%= render '_sidebar_installed.rhtml' %>
+  <%= render '_sidebar_installed.rhtml' %>
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main">

--- a/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
@@ -7,6 +7,8 @@
 
     <%= render '_sidebar_search.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 <main role="main">
 <h1 class="class"><%= h @title %></h1>

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -115,7 +115,7 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
     assert_match(%r[Klass/Inner\.html".*>Inner<], summary)
 
     klass = File.binread('Klass.html')
-    klassnav = klass[%r[<div class="nav-section">.*<div id="class-metadata">]m]
+    klassnav = klass[%r[<div class="nav-section">.*]m]
     assert_match(
       %r[<li>\s*<details open>\s*<summary>\s*<a href=\S+>Heading 1</a>\s*</summary>\s*<ul]m,
       klassnav


### PR DESCRIPTION
1. In #1152 I only added footer to `index.html` but forgot about other pages. So I added it back to them in this PR.
2. I standardized sidebar `nav`'s structure to be:
    ```erb
    <nav id="navigation" role="navigation">
      <div id="project-navigation">
        <%= render '_sidebar_navigation.rhtml' %>
        <%= render '_sidebar_search.rhtml' %>
      </div>
      <!-- if the page originally has it -->
      <%= render '_sidebar_table_of_contents.rhtml' %>
    
      <!-- sidebar content for the page -->
    
      <%= render '_footer.rhtml' %>
    </nav>
    ```
    And removed unnecessary divs like `#project-metadata` or `#class-metadata` as they were never referenced
3. I changed `nav`'s default overflow setting to `auto` so we don't need to make individual elements to be scrollable.

## Demo

https://github.com/user-attachments/assets/e0a12a60-36d8-40ef-a01e-1fcde8fb995f


