### PR TITLE
Make summary triangle appear in correct place when summary text overflows to next line

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -239,14 +239,15 @@ nav ul li details {
 
 nav ul li details > summary {
   list-style: none;  /* Remove the default marker */
+  position: relative; /* So that the open/close triangle can position itself absolutely inside */
 }
 
 nav ul li details > summary::after {
   content: '▶';  /* Unicode right-pointing triangle */
   position: absolute;
   font-size: 0.8em;
-  top: 0.3em;
-  padding-left: 0.2em;
+  bottom: 0.1em;
+  margin-left: 0.3em;
   transition: transform 0.2s ease;
 }
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/8aed89ba-893b-4db9-89e4-1f70f5d83230)

After:

![image](https://github.com/user-attachments/assets/75a19d5f-eed7-4c56-a080-d2be5affdb38)
