### PR TITLE
Add home page link to output message

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -520,6 +520,7 @@ The internal error was:
       Dir.chdir @options.op_dir do
         unless @options.quiet then
           $stderr.puts "\nGenerating #{@generator.class.name.sub(/^.*::/, '')} format into #{Dir.pwd}..."
+          $stderr.puts "\nYou can visit the home page at: \e]8;;file://#{Dir.pwd}/index.html\e\\file://#{Dir.pwd}/index.html\e]8;;\e\\"
         end
 
         @generator.generate


### PR DESCRIPTION
The link is clickable in the terminal and opens the home page in the browser:

<img width="70%" alt="Screenshot 2024-08-27 at 23 12 47" src="https://github.com/user-attachments/assets/86639c41-240b-49a4-b2cd-fbd12cc372ea">

This will make it easier for users to visit the generated document.