### PR TITLE
[DOC] Fix links

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -918,10 +918,6 @@ require 'rdoc'
 #
 #   - Linked: <tt>https://github.com</tt> links to https://github.com.
 #
-# [Protocol +www+]
-#
-#   - Linked: <tt>www.yahoo.com</tt> links to www.yahoo.com.
-#
 # [Protocol +ftp+]
 #
 #   - Linked: <tt>ftp://nosuch.site</tt> links to ftp://nosuch.site.

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -21,7 +21,7 @@ $DEBUG_RDOC = nil
 # see RDoc::Markup and refer to <tt>rdoc --help</tt> for command line usage.
 #
 # If you want to set the default markup format see
-# RDoc::Markup@Supported+Formats
+# RDoc::Markup@Markup+Formats
 #
 # If you want to store rdoc configuration in your gem (such as the default
 # markup format) see RDoc::Options@Saved+Options


### PR DESCRIPTION
Fixes link in `lib/rdoc.rb`.

Removes link in `doc/rdoc/markup_reference.rb`.
