### PR TITLE
Add more space after magnifying glass

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -307,7 +307,7 @@ main h6 {
 
 #search-field {
   width: 100%;
-  padding: 0.5em 1em 0.5em 2em;
+  padding: 0.5em 1em 0.5em 2.5em;
   border: 1px solid var(--border-color);
   border-radius: 20px;
   font-size: 14px;


### PR DESCRIPTION
This adds 0.5rem more space after the magnifying glass. I feel this looks a bit nicer. 🥳 

| Before | After |
|-|-|
| ![Screenshot 2024-09-06 at 21 28 29](https://github.com/user-attachments/assets/cb9a73fb-59ad-4589-ae30-74ae0f6b0990) | ![Screenshot 2024-09-06 at 21 28 08](https://github.com/user-attachments/assets/43e38e13-cdf6-4cbc-b810-54c6420ce224) |
