### PR TITLE
Add scroll-margin-top on all :target elements

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -84,6 +84,7 @@ h5:target,
 h6:target {
   margin-left: -10px;
   border-left: 10px solid #f1edba;
+  scroll-margin-top: 1rem;
 }
 
 /* 4. Links */


### PR DESCRIPTION
This sets `scroll-margin-top` on all `h1` through `h6` when applied with the element state `target`. This happens when you click a link and are taking to that anchor (with `#`). 

`scroll-margin-top` adds a margin of `1rem` where it jumps to, adding a bit of space at the top of the page.

| Before | After |
|-|-|
| ![Screenshot 2024-09-06 at 21 44 07](https://github.com/user-attachments/assets/4a92dd61-d3a4-45e4-be69-aa3c6dd0423d) | ![Screenshot 2024-09-06 at 21 43 51](https://github.com/user-attachments/assets/b7123ccc-0314-49eb-9ebd-dfe8d117a758) |
