### PR TITLE
Use pointer cursor for navigation toggle

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -223,6 +223,7 @@ nav a:hover {
   position: fixed;
   top: 10px;
   left: 20px;
+  cursor: pointer;
 }
 
 #navigation-toggle[aria-expanded="true"] {


### PR DESCRIPTION
~~This hides the `#navigation-toggle` class, if the screen is larger than 1024px.~~

It also adds a proper pointer icon, if you can indeed see and click it.

![Screenshot 2024-09-06 at 22 08 11](https://github.com/user-attachments/assets/236d5516-8d43-4c64-a6a2-19097cab6b40)
