### PR TITLE
Improve method source toggling

### DIFF
--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -109,7 +109,11 @@
                     gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
             </span>
             <%- if i == 0 and method.token_stream then -%>
-            <span class="method-click-advice">Toggle source</span>
+            <div class="method-controls">
+              <details class="method-click-advice">
+                <summary>Source</summary>
+              </details>
+            </div>
             <%- end -%>
           </div>
           <%-   end -%>
@@ -119,10 +123,14 @@
           </div>
           <%- else -%>
           <div class="method-heading">
-            <span class="method-name"><%= h method.name %></span><span
-              class="method-args"><%= h method.param_seq %></span>
+            <span class="method-name"><%= h method.name %></span>
+            <span class="method-args"><%= h method.param_seq %></span>
             <%- if method.token_stream then -%>
-            <span class="method-click-advice">Toggle source</span>
+            <div class="method-controls">
+              <details class="method-click-advice">
+                <summary>Source</summary>
+              </details>
+            </div>
             <%- end -%>
           </div>
           <%- end -%>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -130,6 +130,11 @@
 
         <%- unless method.skip_description? then -%>
         <div class="method-description">
+          <%- if method.token_stream then -%>
+          <div class="method-source-code" id="<%= method.html_name %>-source">
+            <pre><%= method.markup_code %></pre>
+          </div>
+          <%- end -%>
           <%- if method.comment then -%>
           <%= method.description.strip %>
           <%- else -%>
@@ -143,12 +148,6 @@
                   method.formatter.link(method.superclass_method.full_name, method.superclass_method.full_name) : nil
               %>
             </div>
-          <%- end -%>
-
-          <%- if method.token_stream then -%>
-          <div class="method-source-code" id="<%= method.html_name %>-source">
-            <pre><%= method.markup_code %></pre>
-          </div>
           <%- end -%>
         </div>
         <%- end -%>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -109,7 +109,7 @@
                     gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
             </span>
             <%- if i == 0 and method.token_stream then -%>
-            <span class="method-click-advice">click to toggle source</span>
+            <span class="method-click-advice">Toggle source</span>
             <%- end -%>
           </div>
           <%-   end -%>
@@ -122,7 +122,7 @@
             <span class="method-name"><%= h method.name %></span><span
               class="method-args"><%= h method.param_seq %></span>
             <%- if method.token_stream then -%>
-            <span class="method-click-advice">click to toggle source</span>
+            <span class="method-click-advice">Toggle source</span>
             <%- end -%>
           </div>
           <%- end -%>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -110,7 +110,7 @@
             </span>
             <%- if i == 0 and method.token_stream then -%>
             <div class="method-controls">
-              <details class="method-click-advice">
+              <details class="method-source-toggle">
                 <summary>Source</summary>
               </details>
             </div>
@@ -127,7 +127,7 @@
             <span class="method-args"><%= h method.param_seq %></span>
             <%- if method.token_stream then -%>
             <div class="method-controls">
-              <details class="method-click-advice">
+              <details class="method-source-toggle">
                 <summary>Source</summary>
               </details>
             </div>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -101,40 +101,34 @@
       <div id="<%= method.aref %>" class="method-detail <%= method.is_alias_for ? "method-alias" : '' %>">
         <div class="method-header">
           <%- if (call_seq = method.call_seq) then -%>
-          <%-   call_seq.strip.split("\n").each_with_index do |call_seq, i| -%>
-          <div class="method-heading">
-            <span class="method-callseq">
-              <%= h(call_seq.strip.
-                    gsub( /^\w+\./m, '')).
-                    gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
-            </span>
-            <%- if i == 0 and method.token_stream then -%>
-            <div class="method-controls">
-              <details class="method-source-toggle">
-                <summary>Source</summary>
-              </details>
-            </div>
+            <%- call_seq.strip.split("\n").each_with_index do |call_seq, i| -%>
+              <div class="method-heading">
+                <span class="method-callseq">
+                  <%= h(call_seq.strip.
+                        gsub( /^\w+\./m, '')).
+                        gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
+                </span>
+              </div>
             <%- end -%>
-          </div>
-          <%-   end -%>
           <%- elsif method.has_call_seq? then -%>
-          <div class="method-heading">
-            <span class="method-name"><%= h method.name %></span>
-          </div>
-          <%- else -%>
-          <div class="method-heading">
-            <span class="method-name"><%= h method.name %></span>
-            <span class="method-args"><%= h method.param_seq %></span>
-            <%- if method.token_stream then -%>
-            <div class="method-controls">
-              <details class="method-source-toggle">
-                <summary>Source</summary>
-              </details>
+            <div class="method-heading">
+              <span class="method-name"><%= h method.name %></span>
             </div>
-            <%- end -%>
-          </div>
+          <%- else -%>
+            <div class="method-heading">
+              <span class="method-name"><%= h method.name %></span>
+              <span class="method-args"><%= h method.param_seq %></span>
+            </div>
           <%- end -%>
         </div>
+
+        <%- if method.token_stream -%>
+          <div class="method-controls">
+            <details class="method-source-toggle">
+              <summary>Source</summary>
+            </details>
+          </div>
+        <%- end -%>
 
         <%- unless method.skip_description? then -%>
         <div class="method-description">

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -601,6 +601,24 @@ main .method-source-code.active-menu {
   max-height: 100vh;
 }
 
+main pre.ruby::before {
+  content: "Example";
+  color: var(--secondary-color);
+  border-bottom: 1px solid var(--border-color);
+  display: block;
+  padding: 10px 0;
+  font-size: 0.9em;
+  margin-bottom: 10px;
+}
+
+main pre.ruby {
+  margin: 0;
+  padding: 0px 16px 16px 16px;
+  overflow-x: auto;
+  border-radius: 4px;
+  border-color: var(--border-color);
+}
+
 main .method-description .method-calls-super {
   color: var(--text-color);
   font-weight: bold;

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -617,7 +617,7 @@ main .method-detail {
 
 main .method-detail:target {
   margin-left: -10px;
-  border-left: 10px solid #f1edba;
+  border-left: 10px solid var(--source-code-background-color);
 }
 
 main .method-header {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -626,7 +626,7 @@ main .method-heading :link,
 main .method-heading :visited {
   color: inherit;
 }
-main .method-click-advice {
+main .method-source-toggle {
   position: absolute;
   top: 2px;
   right: 0px;
@@ -743,7 +743,7 @@ main .attribute-access-type {
     position: static;
   }
 
-  main .method-click-advice {
+  main .method-source-toggle {
     position: static;
     display: inline-block;
   }

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -615,6 +615,10 @@ main .method-detail:target {
   border-left: 10px solid #f1edba;
 }
 
+main .method-header {
+  display: inline-block;
+}
+
 main .method-heading {
   position: relative;
   font-family: var(--font-code);
@@ -622,16 +626,10 @@ main .method-heading {
   font-weight: bold;
   color: var(--text-color);
 }
-main .method-heading :link,
-main .method-heading :visited {
-  color: inherit;
-}
-main .method-source-toggle {
-  position: absolute;
-  top: 2px;
-  right: 0px;
-  padding-right: 20px;
+
+main .method-controls {
   line-height: 20px;
+  float: right;
   color: var(--secondary-color);
   cursor: pointer;
 }
@@ -739,13 +737,9 @@ main .attribute-access-type {
     white-space: nowrap;
   }
 
-  .method-controls {
-    position: static;
-  }
-
-  main .method-source-toggle {
-    position: static;
-    display: inline-block;
+  main .method-controls {
+    margin-top: 10px;
+    float: none;
   }
 }
 /* @end */

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -608,7 +608,6 @@ main .method-description .method-calls-super {
 
 main .method-detail {
   margin-bottom: 2.5em;
-  cursor: pointer;
 }
 
 main .method-detail:target {
@@ -630,16 +629,12 @@ main .method-heading :visited {
 main .method-click-advice {
   position: absolute;
   top: 2px;
-  right: 5px;
+  right: 0px;
   font-size: 12px;
-  color: #9b9877;
-  visibility: hidden;
   padding-right: 20px;
   line-height: 20px;
-  background: url(../images/zoom.png) no-repeat right top;
-}
-main .method-header:hover .method-click-advice {
-  visibility: visible;
+  color: var(--secondary-color);
+  cursor: pointer;
 }
 
 main .method-alias .method-heading {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -601,24 +601,6 @@ main .method-source-code.active-menu {
   max-height: 100vh;
 }
 
-main pre.ruby::before {
-  content: "Example";
-  color: var(--secondary-color);
-  border-bottom: 1px solid var(--border-color);
-  display: block;
-  padding: 10px 0;
-  font-size: 0.9em;
-  margin-bottom: 10px;
-}
-
-main pre.ruby {
-  margin: 0;
-  padding: 0px 16px 16px 16px;
-  overflow-x: auto;
-  border-radius: 4px;
-  border-color: var(--border-color);
-}
-
 main .method-description .method-calls-super {
   color: var(--text-color);
   font-weight: bold;

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -630,7 +630,6 @@ main .method-click-advice {
   position: absolute;
   top: 2px;
   right: 0px;
-  font-size: 12px;
   padding-right: 20px;
   line-height: 20px;
   color: var(--secondary-color);
@@ -738,6 +737,15 @@ main .attribute-access-type {
     display: block;
     overflow-x: auto;
     white-space: nowrap;
+  }
+
+  .method-controls {
+    position: static;
+  }
+
+  main .method-click-advice {
+    position: static;
+    display: inline-block;
   }
 }
 /* @end */

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -22,6 +22,7 @@
   --link-hover-color: #25a28a;  /* A slightly brighter teal-green */
   --border-color: #e0e0e0;
   --sidebar-text-color: #2c3e50;  /* Dark blue-gray for contrast */
+  --source-code-background-color: #e8f0eb;
 
   /* Font family variables */
   --font-primary: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
@@ -594,6 +595,10 @@ main .method-source-code {
   transition-delay: 0ms;
   transition-property: all;
   transition-timing-function: ease-in-out;
+}
+
+main .method-source-code pre {
+  background: var(--source-code-background-color);
 }
 
 main .method-source-code.active-menu {

--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -34,7 +34,7 @@ function showSource( e ) {
 };
 
 function hookSourceViews() {
-  document.querySelectorAll('.method-heading').forEach(function (codeObject) {
+  document.querySelectorAll('.method-click-advice').forEach(function (codeObject) {
     codeObject.addEventListener('click', showSource);
   });
 };

--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -34,7 +34,7 @@ function showSource( e ) {
 };
 
 function hookSourceViews() {
-  document.querySelectorAll('.method-click-advice').forEach(function (codeObject) {
+  document.querySelectorAll('.method-source-toggle').forEach(function (codeObject) {
     codeObject.addEventListener('click', showSource);
   });
 };


### PR DESCRIPTION
1. Source toggling control is now always displayed
    - If we think the buttons take too much space or are distracting, I'd be happy to accept ideas/PRs for styling improvements. But hiding them by default simply made this feature underutilized.
1. Source will be displayed directly under the method method
    - This matches rubyapi.org's behaviour and makes a more natural experience. When viewing a method with long description, users won't need to click the toggle, and then scroll all the way down to see the source.
1. Clicking the method name will not toggle the source anymore. I made this change so we can later make clicking method names link to the methods instead, like rubyapi.org and many other language documentations do.

## Demos

### Before

https://github.com/user-attachments/assets/ca68c0d0-147b-421f-9e04-904366856daf

### After


https://github.com/user-attachments/assets/ea6ed17f-930a-4d4e-a298-79a535c94abc



