### PR TITLE
Only let browser search through source code until it's expanded

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -585,6 +585,9 @@ main header h3 {
 /* @group Method Details */
 
 main .method-source-code {
+  /* While this is already invisible through the rule below, this will inform the browser to
+  not consider source code during text searching until it is actually expanded. */
+  visibility: hidden;
   max-height: 0;
   overflow: auto;
   transition-duration: 200ms;
@@ -594,6 +597,7 @@ main .method-source-code {
 }
 
 main .method-source-code.active-menu {
+  visibility: visible;
   max-height: 100vh;
 }
 


### PR DESCRIPTION
Something that's been bothering me is that while the source code is not visible by default, the browser still jump to it when searching. Adding the `visible` property prevents this.

Test it out yourself:
* `bundle exec rdoc`
* open `_site/RDoc.html`
* Search for `NameError`

Before, you will get a match from `load_yaml` source code, after you only get the match when that methods source code is expanded:
![image](https://github.com/user-attachments/assets/25f23a07-02d9-4903-8423-c076d4af507c)
![image](https://github.com/user-attachments/assets/d122db46-a6e2-4205-a9ec-aef5f4e7f064)
