### PR TITLE
Display class ancestors in the sidebar

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -711,6 +711,20 @@ class RDoc::ClassModule < RDoc::Context
     @superclass = superclass
   end
 
+  ##
+  # Get all super classes of this class in an array. The last element might be
+  # a string if the name is unknown.
+
+  def super_classes
+    result = []
+    parent = self
+    while parent = parent.superclass
+      result << parent
+      return result if parent.is_a?(String)
+    end
+    result
+  end
+
   def to_s # :nodoc:
     if is_alias_for then
       "#{self.class.name} #{self.full_name} -> #{is_alias_for}"

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -795,4 +795,22 @@ class RDoc::Generator::Darkfish
 
     extracted_text[0...150].gsub(/\n/, " ").squeeze(" ")
   end
+
+  def generate_ancestor_list(ancestors, klass)
+    return '' if ancestors.empty?
+
+    ancestor = ancestors.shift
+    content = +'<ul><li>'
+
+    if ancestor.is_a?(RDoc::NormalClass)
+      content << "<a href=\"#{klass.aref_to ancestor.path}\">#{ancestor.full_name}</a>"
+    else
+      content << ancestor.to_s
+    end
+
+    # Recursively call the method for the remaining ancestors
+    content << generate_ancestor_list(ancestors, klass)
+
+    content << '</li></ul>'
+  end
 end

--- a/lib/rdoc/generator/template/darkfish/_sidebar_parent.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_parent.rhtml
@@ -1,11 +1,6 @@
-<%- if klass.type == 'class' then %>
+<%- if klass.type == 'class' && (ancestors = klass.super_classes).any? -%>
 <div id="parent-class-section" class="nav-section">
-  <h3>Parent</h3>
-
-  <%- if klass.superclass and not String === klass.superclass then -%>
-  <p class="link"><a href="<%= klass.aref_to klass.superclass.path %>"><%= klass.superclass.full_name %></a>
-  <%- else -%>
-  <p class="link"><%= klass.superclass %>
-  <%- end -%>
+  <h3>Ancestors</h3>
+  <%= generate_ancestor_list(ancestors, klass) %>
 </div>
 <%- end -%>

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1279,6 +1279,12 @@ class TestRDocClassModule < XrefTestCase
     assert_equal @c3_h1, @c3_h2.superclass
   end
 
+  def test_super_classes
+    rdoc_c3_h1 = @xref_data.find_module_named('C3::H1')
+    rdoc_object = @xref_data.find_module_named('Object')
+    assert_equal [rdoc_c3_h1, rdoc_object, "BasicObject"], @c3_h2.super_classes
+  end
+
   def test_update_aliases_class
     n1 = @xref_data.add_module RDoc::NormalClass, 'N1'
     n1_k2 = n1.add_module RDoc::NormalClass, 'N2'


### PR DESCRIPTION
The purpose is to list all class ancestors in a new theme (see PR #1182).