### PR TITLE
Fix ToRdoc#accept_table

### DIFF
--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -249,8 +249,8 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   # Adds +table+ to the output
 
   def accept_table header, body, aligns
-    widths = header.zip(body) do |h, b|
-      [h.size, b.size].max
+    widths = header.zip(*body).map do |cols|
+      cols.map(&:size).max
     end
     aligns = aligns.map do |a|
       case a
@@ -262,12 +262,12 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
         :rjust
       end
     end
-    @res << header.zip(widths, aligns) do |h, w, a|
+    @res << header.zip(widths, aligns).map do |h, w, a|
       h.__send__(a, w)
     end.join("|").rstrip << "\n"
     @res << widths.map {|w| "-" * w }.join("|") << "\n"
     body.each do |row|
-      @res << row.zip(widths, aligns) do |t, w, a|
+      @res << row.zip(widths, aligns).map do |t, w, a|
         t.__send__(a, w)
       end.join("|").rstrip << "\n"
     end

--- a/test/rdoc/support/text_formatter_test_case.rb
+++ b/test/rdoc/support/text_formatter_test_case.rb
@@ -100,6 +100,23 @@ class RDoc::Markup::TextFormatterTestCase < RDoc::Markup::FormatterTestCase
       end
 
       ##
+      # Test case that calls <tt>@to.accept_table</tt>
+
+      def test_accept_table_align
+        header = ['AA', 'BB', 'CCCCC']
+        body = [
+          ['', 'bbb', 'c'],
+          ['aaaa', 'b', ''],
+          ['a', '', 'cc']
+        ]
+        aligns = [nil, :left, :right]
+        @to.start_accepting
+        @to.accept_table header, body, aligns
+
+        accept_table_align
+      end
+
+      ##
       # Test case that calls <tt>@to.attributes</tt> with an escaped
       # cross-reference.  If this test doesn't pass something may be very
       # wrong.

--- a/test/rdoc/test_rdoc_markup_to_ansi.rb
+++ b/test/rdoc/test_rdoc_markup_to_ansi.rb
@@ -348,6 +348,17 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_align
+    expected = "\e[0m" + <<-EXPECTED
+ AA |BB |CCCCC
+----|---|-----
+    |bbb|    c
+aaaa|b  |
+ a  |   |   cc
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   # functional test
   def test_convert_list_note
     note_list = <<-NOTE_LIST

--- a/test/rdoc/test_rdoc_markup_to_bs.rb
+++ b/test/rdoc/test_rdoc_markup_to_bs.rb
@@ -349,4 +349,15 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_align
+    expected = <<-EXPECTED
+ AA |BB |CCCCC
+----|---|-----
+    |bbb|    c
+aaaa|b  |
+ a  |   |   cc
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
 end

--- a/test/rdoc/test_rdoc_markup_to_markdown.rb
+++ b/test/rdoc/test_rdoc_markup_to_markdown.rb
@@ -346,6 +346,17 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_align
+    expected = <<-EXPECTED
+ AA |BB |CCCCC
+----|---|-----
+    |bbb|    c
+aaaa|b  |
+ a  |   |   cc
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   def test_convert_RDOCLINK
     result = @to.convert 'rdoc-garbage:C'
 

--- a/test/rdoc/test_rdoc_markup_to_rdoc.rb
+++ b/test/rdoc/test_rdoc_markup_to_rdoc.rb
@@ -346,6 +346,17 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_align
+    expected = <<-EXPECTED
+ AA |BB |CCCCC
+----|---|-----
+    |bbb|    c
+aaaa|b  |
+ a  |   |   cc
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   # functional test
   def test_convert_list_note
     note_list = <<-NOTE_LIST


### PR DESCRIPTION
Document of `Integer#ceil` in ruby 3.4.0dev have table. RDoc fails to show tables in text format.

Fix `ri Integer#ceil`
```
# ruby -v
ruby 3.4.0dev (2024-09-27T17:45:22Z master 027ef60500) +PRISM [x86_64-linux]
# ri Integer#ceil
/opt/ruby/lib/ruby/3.4.0+0/rdoc/markup/to_rdoc.rb:265:in 'Array#zip': wrong argument type NilClass (must respond to :each) (TypeError)

    @res << header.zip(widths, aligns) do |h, w, a|
```

Fix IRB crash
```
irb(main):001> 1.[TAB][TAB]
/opt/ruby/lib/ruby/3.4.0+0/rdoc/markup/to_rdoc.rb:265:in 'Array#zip': wrong argument type NilClass (must respond to :each) (TypeError)
```
