### PR TITLE
Use normal `font-weight` for links

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -92,7 +92,6 @@ h6:target {
   color: var(--link-color);
   text-decoration: none;
   transition: color 0.3s ease;
-  font-weight: 600;  /* Make links bolder */
 }
 
 :link:hover,


### PR DESCRIPTION
A weight of `600` is nearly the same as heading weight, which is `700`, putting too much _weight_ on links, and makes many sidebar links require wrapping. As RDoc is rendering API documentation, many identifiers are links, but aren't being used in a context where they should stand out.

Before|After
-|-
![image](https://github.com/user-attachments/assets/918b87f5-def0-4cce-ac85-8dfc67e53bf2)|![image](https://github.com/user-attachments/assets/109b6e42-350a-4ea6-b642-de316bfdda91)

The default weight works nicely, and links are already identified by color and underline on hover.