### PR TITLE
Make methods and attributes linkable

### DIFF
--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -72,8 +72,10 @@
       <%- attributes.each do |attrib| -%>
       <div id="<%= attrib.aref %>" class="method-detail">
         <div class="method-heading attribute-method-heading">
-          <span class="method-name"><%= h attrib.name %></span><span
-            class="attribute-access-type">[<%= attrib.rw %>]</span>
+          <a href="#<%= attrib.aref %>" title="Link to this attribute">
+            <span class="method-name"><%= h attrib.name %></span>
+            <span class="attribute-access-type">[<%= attrib.rw %>]</span>
+          </a>
         </div>
 
         <div class="method-description">
@@ -103,21 +105,27 @@
           <%- if (call_seq = method.call_seq) then -%>
             <%- call_seq.strip.split("\n").each_with_index do |call_seq, i| -%>
               <div class="method-heading">
-                <span class="method-callseq">
-                  <%= h(call_seq.strip.
+                <a href="#<%= method.aref %>" title="Link to this method">
+                  <span class="method-callseq">
+                    <%= h(call_seq.strip.
                         gsub( /^\w+\./m, '')).
                         gsub(/(.*)[-=]&gt;/, '\1&rarr;') %>
-                </span>
+                  </span>
+                </a>
               </div>
             <%- end -%>
           <%- elsif method.has_call_seq? then -%>
             <div class="method-heading">
-              <span class="method-name"><%= h method.name %></span>
+              <a href="#<%= method.aref %>" title="Link to this method">
+                <span class="method-name"><%= h method.name %></span>
+              </a>
             </div>
           <%- else -%>
             <div class="method-heading">
-              <span class="method-name"><%= h method.name %></span>
-              <span class="method-args"><%= h method.param_seq %></span>
+              <a href="#<%= method.aref %>" title="Link to this method">
+                <span class="method-name"><%= h method.name %></span>
+                <span class="method-args"><%= h method.param_seq %></span>
+              </a>
             </div>
           <%- end -%>
         </div>

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -631,6 +631,18 @@ main .method-heading {
   color: var(--text-color);
 }
 
+main .method-heading::after {
+  content: '¶';
+  position: absolute;
+  visibility: hidden;
+  color: var(--secondary-color);
+  font-size: 0.5em;
+}
+
+main .method-heading:hover::after {
+  visibility: visible;
+}
+
 main .method-controls {
   line-height: 20px;
   float: right;
@@ -663,7 +675,6 @@ main #attribute-method-details .method-detail:hover {
 }
 main .attribute-access-type {
   text-transform: uppercase;
-  padding: 0 1em;
 }
 /* @end */
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -84,7 +84,7 @@ h4:target,
 h5:target,
 h6:target {
   margin-left: -10px;
-  border-left: 10px solid #f1edba;
+  border-left: 10px solid var(--source-code-background-color);
 }
 
 /* 4. Links */


### PR DESCRIPTION
1. Use the same highlighting color for headers (align with the change in #1176)
2. Make methods and attributes linkable 

https://github.com/user-attachments/assets/178a5561-260e-49a9-8839-b2e566c299d9

