### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+# release.yml
+
+changelog:
+  categories:
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🛠 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This is the same as the one in `ruby/irb`. 

Ideally we should have an org-level setup for this but it's [not implemented](https://github.com/orgs/community/discussions/7926) yet.