### PR TITLE
Hack for Safari 18

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -258,6 +258,10 @@ nav ul li details > summary {
   position: relative; /* So that the open/close triangle can position itself absolutely inside */
 }
 
+nav ul li details > summary::-webkit-details-marker {
+  display: none;  /* Removes the default marker, in Safari 18. */
+}
+
 nav ul li details > summary::after {
   content: '▶';  /* Unicode right-pointing triangle */
   position: absolute;


### PR DESCRIPTION
`summary {list-style: none;}` still does not work in Safari 18.

https://github.com/ruby/rdoc/pull/1157/files#r1816107998