### PR TITLE
Use thicker fonts with high contrast to improve readability

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -25,9 +25,9 @@
   --table-td-background-color: #f5f4f6;
 
   /* Font family variables */
-  --font-primary: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
-  --font-heading: 'Helvetica Neue', Arial, sans-serif;
-  --font-code: 'Source Code Pro', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  --font-primary: 'Segoe UI', 'Verdana', 'Arial', sans-serif;
+  --font-heading: 'Helvetica', 'Arial', sans-serif;
+  --font-code: monospace;
 }
 
 /* 2. Global Styles */


### PR DESCRIPTION

Left: before/Right: after

<img width="49%" alt="Screenshot 2024-10-30 at 22 11 22" src="https://github.com/user-attachments/assets/9c2be27d-c669-49e7-a83d-95f0a979e24c">

<img width="49%" alt="Screenshot 2024-10-30 at 22 12 49" src="https://github.com/user-attachments/assets/efd3e108-1512-4e4f-9503-5365a6cad1bc">

