### PR TITLE
Extract excerpt from RDoc::Markup::Document (raw pages) correctly

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -782,7 +782,19 @@ class RDoc::Generator::Darkfish
 
   # Returns an excerpt of the content for usage in meta description tags
   def excerpt(content)
-    text = content.is_a?(RDoc::Comment) ? content.text : content
+    text = case content
+    when RDoc::Comment
+      content.text
+    when RDoc::Markup::Document
+      # This case is for page files that are not markdown nor rdoc
+      # We convert them to markdown for now as it's easier to extract the text
+      formatter = RDoc::Markup::ToMarkdown.new
+      formatter.start_accepting
+      formatter.accept_document(content)
+      formatter.end_accepting
+    else
+      content
+    end
 
     # Match from a capital letter to the first period, discarding any links, so
     # that we don't end up matching badges in the README

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative 'helper'
 
-class TestRDocGeneratorDarkfish < RDoc::TestCase
+class RDocGeneratorDarkfishTest < RDoc::TestCase
 
   def setup
     super
@@ -348,7 +348,7 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
     )
   end
 
-  def test_meta_tags_for_pages
+  def test_meta_tags_for_rdoc_files
     top_level = @store.add_file("CONTRIBUTING.rdoc", parser: RDoc::Parser::Simple)
     top_level.comment = <<~RDOC
       = Contributing
@@ -364,6 +364,52 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
       content,
       "<meta name=\"description\" content=\"CONTRIBUTING: Contributing Here are the instructions for contributing." \
       " Begin by installing Ruby.\">",
+    )
+  end
+
+  def test_meta_tags_for_markdown_files
+    top_level = @store.add_file("MyPage.md", parser: RDoc::Parser::Markdown)
+    top_level.comment = <<~MARKDOWN
+      # MyPage
+
+      This is a comment
+    MARKDOWN
+
+    @g.generate
+
+    content = File.binread("MyPage_md.html")
+    assert_include(content, '<meta name="keywords" content="ruby,documentation,MyPage">')
+    assert_include(
+      content,
+      '<meta name="description" content="MyPage: # MyPage This is a comment">',
+    )
+  end
+
+  def test_meta_tags_for_raw_pages
+    top_level = @store.add_file("MyPage", parser: RDoc::Parser::Simple)
+    top_level.comment = RDoc::Markup::Document.new(RDoc::Markup::Paragraph.new('this is a comment'))
+
+    @g.generate
+
+    content = File.binread("MyPage.html")
+    assert_include(content, '<meta name="keywords" content="ruby,documentation,MyPage">')
+    assert_include(
+      content,
+      '<meta name="description" content="MyPage: this is a comment ">',
+    )
+  end
+
+  def test_meta_tags_for_empty_document
+    top_level = @store.add_file("MyPage", parser: RDoc::Parser::Simple)
+    top_level.comment = RDoc::Markup::Document.new
+
+    @g.generate
+
+    content = File.binread("MyPage.html")
+    assert_include(content, '<meta name="keywords" content="ruby,documentation,MyPage">')
+    assert_include(
+      content,
+      '<meta name="description" content="MyPage: ">',
     )
   end
 


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20862