### PR TITLE
Split list of class and instance methods in two

### DIFF
--- a/lib/rdoc/generator/template/darkfish/_sidebar_methods.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_methods.rhtml
@@ -1,12 +1,21 @@
-<%- unless klass.method_list.empty? then %>
-<!-- Method Quickref -->
-<div id="method-list-section" class="nav-section">
-  <h3>Methods</h3>
+<% if (class_methods = klass.class_method_list.sort).any? %>
+  <div class="nav-section">
+    <h3>Class Methods</h3>
+    <ul class="link-list" role="directory">
+      <%- class_methods.each do |meth| -%>
+      <li <%- if meth.calls_super %>class="calls-super" <%- end %>><a href="#<%= meth.aref %>"><%= h meth.name -%></a></li>
+      <%- end -%>
+    </ul>
+  </div>
+<% end %>
 
-  <ul class="link-list" role="directory">
-    <%- klass.each_method do |meth| -%>
-    <li <%- if meth.calls_super %>class="calls-super" <%- end %>><a href="#<%= meth.aref %>"><%= meth.singleton ? '::' : '#' %><%= h meth.name -%></a>
-    <%- end -%>
-  </ul>
-</div>
-<%- end -%>
+<% if (instance_methods = klass.instance_methods.sort).any? %>
+  <div class="nav-section">
+    <h3>Instance Methods</h3>
+    <ul class="link-list" role="directory">
+      <%- instance_methods.each do |meth| -%>
+      <li <%- if meth.calls_super %>class="calls-super" <%- end %>><a href="#<%= meth.aref %>"><%= h meth.name -%></a></li>
+      <%- end -%>
+    </ul>
+  </div>
+<% end %>


### PR DESCRIPTION
Looking for a method is easier because eyes don't have to skip dashes or double colon.

Here is a screenshot where you can try to look for the instance method `collect` in order to compare:

![rdoc_methods_1_vs_2_lists](https://github.com/user-attachments/assets/cc77b496-0d6c-4362-96b2-dd25a432b2b2)
