### PR TITLE
Use the original `label` description list style

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -469,14 +469,15 @@ main dl {
 }
 
 main dt {
-  margin-bottom: 0.5em;
-  margin-right: 1em;
-  float: left;
   font-weight: bold;
 }
 
 main dd {
-  margin: 0 1em 1em 0.5em;
+  margin: 0 0 1em 1em;
+}
+
+main dd p:first-child {
+  margin-top: 0;
 }
 
 /* Headers within Main */


### PR DESCRIPTION
As a default for all description lists, the original "label" style is more readable.

This is slightly different from the original `label` dl though:
* slightly increase left margin for `dd` (to 1em)
* remove right margin on `dd`
* remove `dt` bottom margin and `dd` top margin, to reduce the gap between the term and its description to only the standard line-height gap

See the discussion at #1199.  Because of that discussion, this PR gives _both_ description lists the "label" style.  A different PR (#1209) brings back distinct styling for the "note" list.