### PR TITLE
Use distinct styles for note lists and label lists

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -469,14 +469,15 @@ main dl {
 }
 
 main dt {
-  margin-bottom: 0.5em;
-  margin-right: 1em;
-  float: left;
   font-weight: bold;
 }
 
 main dd {
-  margin: 0 1em 1em 0.5em;
+  margin: 0 0 1em 1em;
+}
+
+main dd p:first-child {
+  margin-top: 0;
 }
 
 /* Headers within Main */

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -469,7 +469,13 @@ main dl {
 }
 
 main dt {
+  line-height: 1.5; /* matches `main p` */
   font-weight: bold;
+}
+
+main dl.note-list dt {
+  margin-right: 1em;
+  float: left;
 }
 
 main dd {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -478,6 +478,15 @@ main dl.note-list dt {
   float: left;
 }
 
+main dl.note-list dt:has(+ dt) {
+  margin-right: 0.25em;
+}
+
+main dl.note-list dt:has(+ dt)::after {
+  content: ', ';
+  font-weight: normal;
+}
+
 main dd {
   margin: 0 0 1em 1em;
 }

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -407,7 +407,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
       "<li>"
     when :LABEL, :NOTE then
       Array(list_item.label).map do |label|
-        "<dt>#{to_html label}\n"
+        "<dt>#{to_html label}</dt>\n"
       end.join << "<dd>"
     else
       raise RDoc::Error, "Invalid list type: #{list_type.inspect}"

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -146,7 +146,7 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def accept_list_item_start_label
-    assert_equal "<dl class=\"rdoc-list label-list\"><dt>cat\n<dd>", @to.res.join
+    assert_equal "<dl class=\"rdoc-list label-list\"><dt>cat</dt>\n<dd>", @to.res.join
   end
 
   def accept_list_item_start_lalpha
@@ -154,13 +154,13 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def accept_list_item_start_note
-    assert_equal "<dl class=\"rdoc-list note-list\"><dt>cat\n<dd>",
+    assert_equal "<dl class=\"rdoc-list note-list\"><dt>cat</dt>\n<dd>",
                  @to.res.join
   end
 
   def accept_list_item_start_note_2
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt><code>teletype</code>
+<dl class="rdoc-list note-list"><dt><code>teletype</code></dt>
 <dd>
 <p>teletype description</p>
 </dd></dl>
@@ -171,7 +171,7 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
 
   def accept_list_item_start_note_multi_description
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt>label
+<dl class="rdoc-list note-list"><dt>label</dt>
 <dd>
 <p>description one</p>
 </dd><dd>
@@ -184,8 +184,8 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
 
   def accept_list_item_start_note_multi_label
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt>one
-<dt>two
+<dl class="rdoc-list note-list"><dt>one</dt>
+<dt>two</dt>
 <dd>
 <p>two headers</p>
 </dd></dl>


### PR DESCRIPTION
Together with #1208, this brings back the original "note" and "label" list styles.  It also improves on the original "note" list styling in two ways: 1) the second line and every line after it share the same indentation, and 2) commas are added between multiple `dt` elements.

* #1208
  This also removes `margin-bottom` from `dt`, which is necessary for the second indentation to match subsequent lines.
* #1226
  Necessary for adding separators between `dt`.
* Bring back the `float: left` style, for note lists only
* Set the `dt` `line-height` to match `main p`.
  Otherwise, the `dt` has a larger `line-height` than the `p` tag inside the `dd`, which causes the second line to have the same indentation as the first but different from the third.
* Add commas between note list terms.

This fixes #1199.