### PR TITLE
fix: C variables should never show up in Ancestors tree

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -415,6 +415,8 @@ The internal error was:
       parse_file filename
     end.compact
 
+    @store.resolve_c_superclasses
+
     @stats.done_adding
     @options = original_options
 

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -198,6 +198,18 @@ class RDoc::Store
   end
 
   ##
+  # Make sure any references to C variable names are resolved to the corresponding class.
+  #
+
+  def resolve_c_superclasses
+    @classes_hash.each_value do |klass|
+      if klass.superclass.is_a?(String) && (candidate = find_c_enclosure(klass.superclass))
+        klass.superclass = candidate
+      end
+    end
+  end
+
+  ##
   # Sets the parser of +absolute_name+, unless it from a source code file.
 
   def update_parser_of_file(absolute_name, parser)

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -281,6 +281,26 @@ class TestRDocStore < XrefTestCase
     assert_nil @s.find_c_enclosure('cObject')
   end
 
+  def test_resolve_c_superclasses
+    # first parse a child that references an unknown parent
+    c_file1 = @s.add_file 'ext1.c'
+    c_file1.add_class RDoc::NormalClass, 'Child', 'cExternParent'
+
+    # then parse the parent and register the C variable name as a C enclosure
+    c_file2 = @s.add_file 'ext2.c'
+    parent = c_file2.add_class RDoc::NormalClass, 'Parent', 'rb_cObject'
+
+    @s.add_c_enclosure('cExternParent', parent)
+
+    # at this point, the child's superclass is still the name of the C variable
+    assert_equal("cExternParent", @s.classes_hash['Child'].superclass)
+
+    @s.resolve_c_superclasses
+
+    # now the ancestor tree correctly references the NormalClass objects
+    assert_equal(parent, @s.classes_hash['Child'].superclass)
+  end
+
   def test_find_class_named
     assert_equal @c1, @store.find_class_named('C1')
 


### PR DESCRIPTION
If a `NormalClass`'s superclass is a C variable ("enclosure"), then update the superclass to point to the RDoc::NormalClass.

This is done in a single pass after all files have been parsed.

Fixes #1205.


Before:

![image](https://github.com/user-attachments/assets/952aaf7b-c6eb-4618-a6e5-7f93a3658604)

After:

![image](https://github.com/user-attachments/assets/753b77a7-cada-465e-99e1-dbaa6e245d2a)
