### PR TITLE
Sort `MethodAttr` so that names starting with symbols are before names starting with alpha ASCII

### DIFF
--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -114,8 +114,8 @@ class RDoc::MethodAttr < RDoc::CodeObject
     return unless other.respond_to?(:singleton) &&
                   other.respond_to?(:name)
 
-    [     @singleton ? 0 : 1,       name] <=>
-    [other.singleton ? 0 : 1, other.name]
+    [@singleton      ? 0 : 1, name_codepoint_range,       name] <=>
+    [other.singleton ? 0 : 1, other.name_codepoint_range, other.name]
   end
 
   def == other # :nodoc:
@@ -415,4 +415,16 @@ class RDoc::MethodAttr < RDoc::CodeObject
     end
   end
 
+  def name_codepoint_range # :nodoc:
+    case name.codepoints[0]
+    when 0..64 # anything below "A"
+      1
+    when 91..96 # the symbols between "Z" and "a"
+      2
+    when 123..126 # 7-bit symbols above "z": "{", "|", "}", "~"
+      3
+    else # everythig else can be sorted as normal
+      4
+    end
+  end
 end

--- a/test/rdoc/test_rdoc_method_attr.rb
+++ b/test/rdoc/test_rdoc_method_attr.rb
@@ -148,8 +148,34 @@ class TestRDocMethodAttr < XrefTestCase
     assert_equal expected, @c1_m.search_record
   end
 
-  def test_spaceship
+  def test_spaceship_returns_nil_on_inappropriate_types
     assert_nil @c1_m.<=>(RDoc::CodeObject.new)
+  end
+
+  def test_spaceship_orders_symbols_first
+    # in the desired sort order
+    m_plus       = RDoc::AnyMethod.new nil, '+'
+    m_eqeq       = RDoc::AnyMethod.new nil, '=='
+    m_bracket    = RDoc::AnyMethod.new nil, '[]'
+    m_caret      = RDoc::AnyMethod.new nil, '^'
+    m_bar        = RDoc::AnyMethod.new nil, '|'
+    m_tilde      = RDoc::AnyMethod.new nil, '~'
+    m_Alpha      = RDoc::AnyMethod.new nil, 'Alpha'
+    m_Zero       = RDoc::AnyMethod.new nil, 'Zero'
+    m_alpha      = RDoc::AnyMethod.new nil, 'alpha'
+    m_zero       = RDoc::AnyMethod.new nil, 'zero'
+    m_konnichiwa = RDoc::AnyMethod.new nil, 'こんにちは'
+
+    assert_equal(-1, m_plus <=> m_eqeq)
+    assert_equal(-1, m_eqeq <=> m_bracket)
+    assert_equal(-1, m_bracket <=> m_caret)
+    assert_equal(-1, m_caret <=> m_bar)
+    assert_equal(-1, m_bar <=> m_tilde)
+    assert_equal(-1, m_tilde <=> m_Alpha)
+    assert_equal(-1, m_Alpha <=> m_Zero)
+    assert_equal(-1, m_Zero <=> m_alpha)
+    assert_equal(-1, m_alpha <=> m_zero)
+    assert_equal(-1, m_zero <=> m_konnichiwa)
   end
 
   def test_equals2


### PR DESCRIPTION
There are three distinct ranges of symbols in ASCII:

- the range below "A", 0..64 in decimal
- the range between "Z" and "a", 91..96 in decimal
- the range above "z", 123..127 in decimal

With this change, any method starting with a character in these "symbol ranges" will be sorted before a method starting with an alpha ASCII character. The remaining methods, all starting with alpha or 8-bit characters, will be sorted against each other exactly as before.

Specifically this addresses the issue from #1204 which is that `#[]` and `#^` were previously sorted _after_ the alpha methods. These methods will now be sorted before alpha methods.

Fixes #1204