### PR TITLE
Add closing tags for description list terms

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -407,7 +407,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
       "<li>"
     when :LABEL, :NOTE then
       Array(list_item.label).map do |label|
-        "<dt>#{to_html label}\n"
+        "<dt>#{to_html label}</dt>\n"
       end.join << "<dd>"
     else
       raise RDoc::Error, "Invalid list type: #{list_type.inspect}"

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -146,7 +146,7 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def accept_list_item_start_label
-    assert_equal "<dl class=\"rdoc-list label-list\"><dt>cat\n<dd>", @to.res.join
+    assert_equal "<dl class=\"rdoc-list label-list\"><dt>cat</dt>\n<dd>", @to.res.join
   end
 
   def accept_list_item_start_lalpha
@@ -154,13 +154,13 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
   end
 
   def accept_list_item_start_note
-    assert_equal "<dl class=\"rdoc-list note-list\"><dt>cat\n<dd>",
+    assert_equal "<dl class=\"rdoc-list note-list\"><dt>cat</dt>\n<dd>",
                  @to.res.join
   end
 
   def accept_list_item_start_note_2
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt><code>teletype</code>
+<dl class="rdoc-list note-list"><dt><code>teletype</code></dt>
 <dd>
 <p>teletype description</p>
 </dd></dl>
@@ -171,7 +171,7 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
 
   def accept_list_item_start_note_multi_description
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt>label
+<dl class="rdoc-list note-list"><dt>label</dt>
 <dd>
 <p>description one</p>
 </dd><dd>
@@ -184,8 +184,8 @@ class TestRDocMarkupToHtml < RDoc::Markup::FormatterTestCase
 
   def accept_list_item_start_note_multi_label
     expected = <<-EXPECTED
-<dl class="rdoc-list note-list"><dt>one
-<dt>two
+<dl class="rdoc-list note-list"><dt>one</dt>
+<dt>two</dt>
 <dd>
 <p>two headers</p>
 </dd></dl>


### PR DESCRIPTION
Without the closing tags, the `dt` elements contain whitespace after the text.  This normally isn't a big deal, but does mess some things up, e.g: using `::after` with `content: ", "` in stylesheets.