### PR TITLE
Stop running CI against JRuby and some CI config cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on: [push, pull_request]
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4 # v3.3.0
+    # libyaml-dev is needed for psych, see https://github.com/ruby/setup-ruby/issues/409
+    - if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt install libyaml-dev
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@master
+      with:
+        ruby-version: 3.3
+        bundler-cache: true
+    - name: Run rubocop
+      run: bundle exec rubocop
+    - name: Sanity check for the format_generated_files task
+      run: bundle exec rake generate format_generated_files
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # 'bundle install' and cache
-    # Avoid issues on these platforms
-    - if: ${{ matrix.ruby == '2.6' }}
-      run: gem update --system
     - name: Run test
       run: bundle exec rake
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       # 2.7 breaks `test_parse_statements_nodoc_identifier_alias_method`
       min_version: 3.0
+      engine: cruby-truffleruby
 
   test:
     needs: ruby-versions
@@ -24,10 +25,6 @@ jobs:
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head
-          - os: windows-latest
-            ruby: jruby
-          - os: windows-latest
-            ruby: jruby-head
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4 # v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,17 +49,3 @@ jobs:
       run: bundle exec rake rdoc
     - if: ${{ matrix.ruby == 'head' && startsWith(matrix.os, 'ubuntu') }}
       run: bundle exec rake install
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-      - name: Run rubocop
-        run: bundle exec rubocop
-        # Just to make sure the format_generated_files task is working
-      - name: Sanity check for the format_generated_files task
-        run: bundle exec rake generate format_generated_files

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,3 @@ group :development do
   gem 'gettext'
   gem 'prism', '>= 0.30.0'
 end
-
-# Workaround for https://github.com/mkristian/jar-dependencies/issues/86
-gem "jar-dependencies", "~> 0.4.0", platform: :jruby


### PR DESCRIPTION
Due to https://github.com/mkristian/jar-dependencies/issues/86, the JRuby CI hasn't been running for a while.

```
bundler: failed to load command: rake (/Users/runner/work/rdoc/rdoc/vendor/bundle/jruby/3.1.0/bin/rake)
Gem::LoadError: You have already activated jar-dependencies 0.5.0, but your Gemfile requires jar-dependencies 0.4.1. Since jar-dependencies is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports jar-dependencies as a default gem.
  check_for_activated_spec! at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/runtime.rb:30[8](https://github.com/ruby/rdoc/actions/runs/12235162661/job/34125882061#step:6:9)
                      setup at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/runtime.rb:25
                       each at org/jruby/RubyArray.java:2009
                       each at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/spec_set.rb:155
                        map at org/jruby/RubyEnumerable.java:818
                      setup at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/runtime.rb:24
                      setup at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler.rb:161
                     <main> at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/setup.rb:20
                 with_level at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/ui/shell.rb:136
                    silence at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/ui/shell.rb:88
                     <main> at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/setup.rb:20
                    require at org/jruby/RubyKernel.java:1187
           require_relative at org/jruby/RubyKernel.java:1216
                kernel_load at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/cli/exec.rb:56
                        run at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/cli/exec.rb:23
                       exec at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/cli.rb:486
                        run at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/command.rb:27
             invoke_command at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/invocation.rb:127
                   dispatch at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/vendor/thor/lib/thor.rb:3[9](https://github.com/ruby/rdoc/actions/runs/12235162661/job/34125882061#step:6:10)2
                   dispatch at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/cli.rb:31
                      start at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/base.rb:485
                      start at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/cli.rb:25
                     <main> at /Users/runner/.rubies/jruby-head/lib/ruby/gems/shared/gems/bundler-2.3.26/exe/bundle:48
       with_friendly_errors at /Users/runner/.rubies/jruby-head/lib/ruby/stdlib/bundler/friendly_errors.rb:[12](https://github.com/ruby/rdoc/actions/runs/12235162661/job/34125882061#step:6:13)0
                     <main> at /Users/runner/.rubies/jruby-head/lib/ruby/gems/shared/gems/bundler-2.3.26/exe/bundle:36
                       load at org/jruby/RubyKernel.java:1223
                     <main> at /Users/runner/.rubies/jruby-head/bin/bundle:25
```

@headius feel free to add JRuby back once the `jar-dependencies` issue has been resolved.