### PR TITLE
[WIP] Centered styling rdoc

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -240,7 +240,7 @@ nav a:hover {
   top: 1rem;
   right: 1rem;
   cursor: pointer;
-  color: var(--highlight-color);
+  color: var(--text-color);
 }
 
 /* Mobile and tablet styles */
@@ -249,6 +249,7 @@ nav a:hover {
     overflow-x: hidden;
     width: 100%;
     position: relative;
+    height: 100dvh;
   }
 
   body {
@@ -259,7 +260,7 @@ nav a:hover {
     position: fixed;
     top: 0;
     left: -100%;
-    height: 100vh;
+    height: 100dvh;
     width: 100%;
     min-width: 100%;
     transition: left 0.3s ease;
@@ -269,10 +270,12 @@ nav a:hover {
     padding: 0;
     border: none;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
   }
 
   #navigation .nav-content {
-    padding: 4rem 1.5rem 6rem;
+    padding: 4rem 1.5rem;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     flex: 1;
@@ -282,6 +285,7 @@ nav a:hover {
     flex-direction: column;
     max-width: 800px;
     margin: 0 auto;
+    padding-bottom: env(safe-area-inset-bottom, 120px);
   }
 
   #navigation #project-navigation {
@@ -353,6 +357,7 @@ nav a:hover {
     z-index: 1001;
     right: 1rem;
     top: 1rem;
+    color: var(--text-color);
   }
 }
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -153,10 +153,9 @@ nav {
   font-size: 16px;
   border-right: 1px solid var(--border-color);
   position: relative;
-  width: 300px;
-  min-width: 300px;
+  width: 360px;
+  min-width: 360px;
   background: var(--background-color);
-  overflow: visible;
   display: flex;
   flex-direction: column;
   color: var(--text-color);
@@ -234,63 +233,126 @@ nav a:hover {
 
 /* Navigation toggle button */
 #navigation-toggle {
-  display: none; /* Hide by default on desktop */
-  z-index: 1000;
+  display: none;
+  z-index: 1001;
   font-size: 2em;
   position: fixed;
   top: 1rem;
-  right: 1rem; /* Align to top right */
+  right: 1rem;
   cursor: pointer;
   color: var(--highlight-color);
 }
 
-/* Mobile styles */
-@media (max-width: 1023px) {
-  body {
-    flex-direction: column;
+/* Mobile and tablet styles */
+@media (max-width: 1199px) {
+  html, body {
+    overflow-x: hidden;
+    width: 100%;
     position: relative;
   }
 
-  nav {
+  body {
+    flex-direction: column;
+  }
+
+  #navigation {
     position: fixed;
     top: 0;
-    left: -300px;
+    left: -100%;
     height: 100vh;
-    width: 300px;
+    width: 100%;
+    min-width: 100%;
     transition: left 0.3s ease;
     z-index: 1000;
     background: var(--background-color);
-    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-    padding-top: 4rem;
+    box-shadow: none;
+    padding: 0;
+    border: none;
     overflow-y: auto;
   }
 
-  nav[aria-expanded="true"] {
+  #navigation .nav-content {
+    padding: 4rem 1.5rem 6rem;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    flex: 1;
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  #navigation #project-navigation {
+    margin-bottom: 1em;
+  }
+
+  #navigation .nav-section {
+    margin: 1em 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  #navigation h2, 
+  #navigation h3 {
+    border-bottom: 1px solid var(--border-color);
+    padding: 0.5em 0;
+    margin: 0 0 0.5em;
+    color: var(--highlight-color);
+  }
+
+  #search-section {
+    padding: 1em 0;
+    border-bottom: 1px solid var(--border-color);
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  #search-field {
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
+    padding: 0.5em 1em 0.5em 2.5em;
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    font-size: 14px;
+    outline: none;
+  }
+
+  #navigation[aria-expanded="true"] {
     left: 0;
   }
 
   main {
-    position: relative;
     width: 100%;
-    margin-top: 4rem;
+    margin: 4rem auto 0;
     transition: transform 0.3s ease;
     padding: 0 1rem;
+    position: relative;
+    box-sizing: border-box;
+    max-width: 100%;
   }
 
   main[aria-hidden="true"] {
-    transform: translateX(300px);
+    transform: translateX(100%);
     pointer-events: none;
     position: fixed;
-    width: 100%;
+    overflow: hidden;
+    width: 100vw;
+    visibility: hidden;
   }
 
-  /* Ensure the toggle stays on top */
   #navigation-toggle {
     display: block;
     background: var(--background-color);
     padding: 0.5rem;
     border-radius: 4px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    position: fixed;
+    z-index: 1001;
+    right: 1rem;
+    top: 1rem;
   }
 }
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -232,19 +232,72 @@ nav a:hover {
   text-decoration: underline;
 }
 
+/* Navigation toggle button */
 #navigation-toggle {
+  display: none; /* Hide by default on desktop */
   z-index: 1000;
   font-size: 2em;
-  display: block;
   position: fixed;
-  top: 10px;
-  left: 20px;
+  top: 1rem;
+  right: 1rem; /* Align to top right */
   cursor: pointer;
+  color: var(--highlight-color);
 }
 
+/* Mobile styles */
+@media (max-width: 1023px) {
+  body {
+    flex-direction: column;
+    position: relative;
+  }
+
+  nav {
+    position: fixed;
+    top: 0;
+    left: -300px;
+    height: 100vh;
+    width: 300px;
+    transition: left 0.3s ease;
+    z-index: 1000;
+    background: var(--background-color);
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+    padding-top: 4rem;
+    overflow-y: auto;
+  }
+
+  nav[aria-expanded="true"] {
+    left: 0;
+  }
+
+  main {
+    position: relative;
+    width: 100%;
+    margin-top: 4rem;
+    transition: transform 0.3s ease;
+    padding: 0 1rem;
+  }
+
+  main[aria-hidden="true"] {
+    transform: translateX(300px);
+    pointer-events: none;
+    position: fixed;
+    width: 100%;
+  }
+
+  /* Ensure the toggle stays on top */
+  #navigation-toggle {
+    display: block;
+    background: var(--background-color);
+    padding: 0.5rem;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+}
+
+/* Remove old toggle positioning */
 #navigation-toggle[aria-expanded="true"] {
-  top: 10px;
-  left: 250px;
+  top: 1rem;
+  right: 1rem; /* Keep in top right even when expanded */
 }
 
 nav ul li details {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -37,12 +37,12 @@ body {
   font-weight: 400;
   color: var(--text-color);
   line-height: 1.6;
-
-  /* Layout */
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
   margin: 0;
+  display: flex;
+  flex-direction: row;
+  min-height: 100vh;
+  overflow-y: auto;
+  justify-content: center;
 }
 
 /* 3. Typography */
@@ -152,17 +152,16 @@ nav {
   font-family: var(--font-heading);
   font-size: 16px;
   border-right: 1px solid var(--border-color);
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: var(--sidebar-width);
-  background: var(--background-color); /* It needs an explicit background for toggling narrow screens */
-  overflow-y: auto;
-  z-index: 10;
+  position: relative;
+  width: 300px;
+  min-width: 300px;
+  background: var(--background-color);
+  overflow: visible;
   display: flex;
   flex-direction: column;
   color: var(--text-color);
+  padding-top: 3em;
+  margin-right: 0;
 }
 
 nav[hidden] {
@@ -170,7 +169,7 @@ nav[hidden] {
 }
 
 nav footer {
-  padding: 1em;
+  padding: 1em 1.5em;
   border-top: 1px solid var(--border-color);
 }
 
@@ -180,7 +179,7 @@ nav footer a {
 
 nav .nav-section {
   margin-top: 1em;
-  padding: 0 1em;
+  padding: 0 1.5em;
 }
 
 nav h2, nav h3 {
@@ -279,7 +278,7 @@ nav ul li details[open] > summary::after {
 main {
   flex: 1;
   display: block;
-  margin: 3em auto;
+  margin: 3em 0;
   padding: 0 2em;
   max-width: 800px;
   font-size: 16px;
@@ -290,7 +289,7 @@ main {
 
 @media (min-width: 1024px) {
   main {
-    margin-left: var(--sidebar-width);
+    margin: 3em 0;
   }
 }
 
@@ -319,7 +318,7 @@ main h6 {
 
 /* Search */
 #search-section {
-  padding: 1em;
+  padding: 1em 1.5em;
   background-color: var(--background-color);
   border-bottom: 1px solid var(--border-color);
 }
@@ -645,34 +644,14 @@ main .attribute-access-type {
 }
 
 /* Responsive Adjustments */
-@media (max-width: 480px) {
+@media (max-width: 1023px) {
   nav {
-    width: 100%;
+    width: 300px;
+    min-width: 300px;
   }
-
+  
   main {
-    margin: 1em auto;
+    margin: 3em 0;
     padding: 0 1em;
-    max-width: 100%;
-  }
-
-  #navigation-toggle {
-    right: 10px;
-    left: auto;
-  }
-
-  #navigation-toggle[aria-expanded="true"] {
-    left: auto;
-  }
-
-  table {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  main .method-controls {
-    margin-top: 10px;
-    float: none;
   }
 }

--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -91,19 +91,36 @@ function hookFocus() {
 }
 
 function hookSidebar() {
-  var navigation = document.querySelector('#navigation');
-  var navigationToggle = document.querySelector('#navigation-toggle');
+  const toggle = document.getElementById('navigation-toggle');
+  const nav = document.querySelector('nav');
+  const main = document.querySelector('main');
 
-  navigationToggle.addEventListener('click', function() {
-    navigation.hidden = !navigation.hidden;
-    navigationToggle.ariaExpanded = navigationToggle.ariaExpanded !== 'true';
+  if (!toggle || !nav || !main) return;
+
+  // Set initial ARIA states
+  toggle.setAttribute('aria-expanded', 'false');
+  nav.setAttribute('aria-expanded', 'false');
+
+  toggle.addEventListener('click', function() {
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    
+    // Toggle the states
+    toggle.setAttribute('aria-expanded', !isExpanded);
+    nav.setAttribute('aria-expanded', !isExpanded);
+    main.setAttribute('aria-hidden', !isExpanded);
   });
 
-  var isSmallViewport = window.matchMedia("(max-width: 1024px)").matches;
-  if (isSmallViewport) {
-    navigation.hidden = true;
-    navigationToggle.ariaExpanded = false;
-  }
+  // Close nav when clicking outside on mobile
+  document.addEventListener('click', function(event) {
+    if (window.innerWidth > 1023) return; // Only on mobile
+    
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (!isExpanded) return;
+
+    if (!nav.contains(event.target) && !toggle.contains(event.target)) {
+      toggle.click();
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/lib/rdoc/generator/template/darkfish/page.rhtml
+++ b/lib/rdoc/generator/template/darkfish/page.rhtml
@@ -2,15 +2,17 @@
 <%= render '_sidebar_toggle.rhtml' %>
 
 <nav id="navigation" role="navigation">
-  <div id="project-navigation">
-    <%= render '_sidebar_navigation.rhtml' %>
-    <%= render '_sidebar_search.rhtml' %>
+  <div class="nav-content">
+    <div id="project-navigation">
+      <%= render '_sidebar_navigation.rhtml' %>
+      <%= render '_sidebar_search.rhtml' %>
+    </div>
+
+    <%= render '_sidebar_table_of_contents.rhtml' %>
+    <%= render '_sidebar_pages.rhtml' %>
+
+    <%= render '_footer.rhtml' %>
   </div>
-
-  <%= render '_sidebar_table_of_contents.rhtml' %>
-  <%= render '_sidebar_pages.rhtml' %>
-
-  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main" aria-label="Page <%=h file.full_name%>">


### PR DESCRIPTION
Makes the desktop view less [framey](https://en.wikipedia.org/wiki/Frame_(World_Wide_Web))
<img width="1422" alt="Screenshot 2024-12-12 at 5 05 36 PM" src="https://github.com/user-attachments/assets/9ba0efb4-3803-4f1e-846d-cb4924fa48fe" />

Also if left nav is longer you can still scroll down.
<img width="1409" alt="Screenshot 2024-12-12 at 5 05 50 PM" src="https://github.com/user-attachments/assets/a5984fcc-29c0-4c89-8167-24938cb09152" />

Main caveats with this design is there's no easy way to get back to the top of the nav without scrolling to the top of the document. But I think it's a better more modern design on desktop.

Mobile view uses hamburger menu to toggle between nav and main content.
<img width="412" alt="Screenshot 2024-12-12 at 5 09 08 PM" src="https://github.com/user-attachments/assets/c4296e5a-45cb-467f-870d-c1513bd6aa28" />

Nav
<img width="421" alt="Screenshot 2024-12-12 at 5 09 15 PM" src="https://github.com/user-attachments/assets/1691ab99-ea60-4cc7-a925-2db8ea219d57" />
