### PR TITLE
Fix iPad Pro navigation not shown

### DIFF
--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -99,7 +99,7 @@ function hookSidebar() {
     navigationToggle.ariaExpanded = navigationToggle.ariaExpanded !== 'true';
   });
 
-  var isSmallViewport = window.matchMedia("(max-width: 1024px)").matches;
+  var isSmallViewport = window.matchMedia("(max-width: 1023px)").matches;
   if (isSmallViewport) {
     navigation.hidden = true;
     navigationToggle.ariaExpanded = false;


### PR DESCRIPTION
Found this issue when I was debugging the navigation toggle. I noticed it first in the chrome dev tools, but it was also reproducible on an iPad Pro.

Symptom:
- On iPad Pro, the navigation section is hidden but there's enough space to show it. Making the user have to click the hamburger button to show it but it's not necessary to hide the navigation section.
- On desktop, the navigation section is shown.
- On mobile, the navigation section is hidden until the hamburger button is clicked.

Fix:
- The javascript code was matching 1024px instead of 1023px. The media sections of the css was altering the layout on 1024px. So ipad got the full desktop layout but the navigation section was hidden.

Before:
<img width="890" alt="Screenshot 2024-12-13 at 1 19 39 PM" src="https://github.com/user-attachments/assets/8d05617f-b900-415a-8da8-08d7f3fad488" />


After:
<img width="886" alt="Screenshot 2024-12-13 at 1 20 37 PM" src="https://github.com/user-attachments/assets/b43476a8-ff4b-40e2-a670-a7172680842b" />
