### PR TITLE
Hide hamburger on desktop

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -296,6 +296,10 @@ main {
   .table-of-contents main {
     margin-left: 20em;
   }
+
+  #navigation-toggle {
+    display: none !important;
+  }
 }
 
 main h1[class] {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -292,6 +292,10 @@ main {
   main {
     margin-left: var(--sidebar-width);
   }
+
+  .table-of-contents main {
+    margin-left: 20em;
+  }
 }
 
 main h1[class] {
@@ -309,12 +313,6 @@ main h5,
 main h6 {
   font-family: var(--font-heading);
   color: var(--highlight-color);
-}
-
-@media (min-width: 1024px) {
-  .table-of-contents main {
-    margin-left: 20em;
-  }
 }
 
 /* Search */
@@ -513,18 +511,6 @@ main header h3 {
 /* Utility Classes */
 .hide { display: none !important; }
 .initially-hidden { display: none; }
-
-/* Media Queries */
-@media (min-width: 1024px) {
-  /* Styles for larger screens */
-  .table-of-contents main {
-    margin-left: 20em;
-  }
-}
-
-@media print {
-  /* Print-specific styles */
-}
 
 /* Table of Contents */
 .table-of-contents ul {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -298,7 +298,7 @@ main {
   }
 
   #navigation-toggle {
-    display: none !important;
+    display: none;
   }
 }
 


### PR DESCRIPTION
The hamburger menu 👇 doesn't need to show on desktop where there's enough room to always show the sidebar.
<img width="89" alt="Screenshot 2024-12-13 at 1 40 17 PM" src="https://github.com/user-attachments/assets/f88ebda8-92b0-4d5e-bd63-4c30c760fbc9" />

**Here's what it looks like on desktop without:**
<img width="353" alt="Screenshot 2024-12-13 at 1 38 05 PM" src="https://github.com/user-attachments/assets/21b4a422-537b-49b6-8c7a-8e6195ce5719" />

Dependant on [this PR](https://github.com/ruby/rdoc/pull/1236) otherwise iPad Pros won't show the navigation.