### PR TITLE
Auto-hide navigation on link click

### DIFF
--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -103,6 +103,12 @@ function hookSidebar() {
   if (isSmallViewport) {
     navigation.hidden = true;
     navigationToggle.ariaExpanded = false;
+    document.addEventListener('click', (e) => {
+      if (e.target.closest('#navigation a')) {
+        navigation.hidden = true;
+        navigationToggle.ariaExpanded = false;
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Hide navigation sidebar when clicking anchor links on mobile devices. Previously, anchor links would change the page but the navigation sidebar would block the view.