### PR TITLE
Enable cross reference in code

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -182,4 +182,43 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
     end
   end
 
+  def convert_flow(flow)
+    res = []
+
+    i = 0
+    while i < flow.size
+      item = flow[i]
+      i += 1
+      case item
+      when RDoc::Markup::AttrChanger then
+        # Make "+Class#method+" a cross reference
+        if tt_tag?(item.turn_on) and
+          String === (str = flow[i]) and
+          RDoc::Markup::AttrChanger === flow[i+1] and
+          tt_tag?(flow[i+1].turn_off, true) and
+          (@options.hyperlink_all ? ALL_CROSSREF_REGEXP : CROSSREF_REGEXP).match?(str) and
+          (text = cross_reference str) != str
+        then
+          text = yield text, res if defined?(yield)
+          res << text
+          i += 2
+          next
+        end
+        off_tags res, item
+        on_tags res, item
+      when String then
+        text = convert_string(item)
+        text = yield text, res if defined?(yield)
+        res << text
+      when RDoc::Markup::RegexpHandling then
+        text = convert_regexp_handling(item)
+        text = yield text, res if defined?(yield)
+        res << text
+      else
+        raise "Unknown flow element: #{item.inspect}"
+      end
+    end
+
+    res.join('')
+  end
 end

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -16,6 +16,18 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
     result = @to.convert 'C1'
 
     assert_equal para("<a href=\"C1.html\"><code>C1</code></a>"), result
+
+    result = @to.convert '+C1+'
+    assert_equal para("<a href=\"C1.html\"><code>C1</code></a>"), result
+
+    result = @to.convert 'FOO'
+    assert_equal para("FOO"), result
+
+    result = @to.convert '+FOO+'
+    assert_equal para("<code>FOO</code>"), result
+
+    result = @to.convert '<tt># :stopdoc:</tt>:'
+    assert_equal para("<code># :stopdoc:</code>:"), result
   end
 
   def test_convert_CROSSREF_method


### PR DESCRIPTION
Some people like to mark up method names in MarkDown style block quotes, like this: ruby/ruby#12333.
Currently, no links are created in the code in the RDoc, but such words most likely refer to methods.
This PR makes a word a code cross-reference if the whole word can be resolved as a reference.