### PR TITLE
Add attribute :force to RDoc::RubygemsHook just like RDoc::RubyGemsHook

### DIFF
--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -271,7 +271,7 @@ end
 module RDoc
   class RubygemsHook
 
-    attr_accessor :generate_rdoc, :generate_ri
+    attr_accessor :generate_rdoc, :generate_ri, :force
 
     def self.default_gem?
       !File.exist?(File.join(__dir__, "..", "rubygems_plugin.rb"))
@@ -281,6 +281,7 @@ module RDoc
       @spec = spec
       @generate_rdoc = generate_rdoc
       @generate_ri   = generate_ri
+      @force = false
     end
 
     def generate
@@ -288,7 +289,9 @@ module RDoc
       return unless self.class.default_gem?
 
       # Generate document for compatibility if this is a default gem.
-      RubyGemsHook.new(@spec, @generate_rdoc, @generate_ri).generate
+      hook = RubyGemsHook.new(@spec, @generate_rdoc, @generate_ri)
+      hook.force = @force
+      hook.generate
     end
 
     def remove

--- a/test/rdoc/test_rdoc_rubygems_hook.rb
+++ b/test/rdoc/test_rdoc_rubygems_hook.rb
@@ -200,6 +200,25 @@ class TestRDocRubyGemsHook < Test::Unit::TestCase
     assert_path_exist File.join(@a.doc_dir('ri'),   'cache.ri')
   end
 
+  def test_generate_rubygems_compatible
+    original_default_gem_method = RDoc::RubygemsHook.method(:default_gem?)
+    RDoc::RubygemsHook.singleton_class.remove_method(:default_gem?)
+    RDoc::RubygemsHook.define_singleton_method(:default_gem?) { true }
+    FileUtils.mkdir_p @a.doc_dir 'ri'
+    FileUtils.mkdir_p @a.doc_dir 'rdoc'
+    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
+
+    # rubygems/lib/rubygems/commands/rdoc_command.rb calls this
+    hook = RDoc::RubygemsHook.new @a, true, true
+    hook.force = true
+    hook.generate
+
+    assert_path_exist File.join(@a.doc_dir('rdoc'), 'index.html')
+  ensure
+    RDoc::RubygemsHook.singleton_class.remove_method(:default_gem?)
+    RDoc::RubygemsHook.define_singleton_method(:default_gem?, &original_default_gem_method)
+  end
+
   def test_generate_no_overwrite
     FileUtils.mkdir_p @a.doc_dir 'ri'
     FileUtils.mkdir_p @a.doc_dir 'rdoc'


### PR DESCRIPTION
Rubygems creates an instance of RDoc::RubygemsHook, sets `doc.force = overwrite`, then calls `doc.generate` the document. RDoc::RubygemsHook needs attribute `:force` just like RDoc::RubyGemsHook.

Fixes #1243