### PR TITLE
Handle ghost methods followed by undocumented methods

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1806,6 +1806,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
       case tk[:kind]
       when :on_nl, :on_ignored_nl then
         skip_tkspace
+        non_comment_seen = parse_comment container, tk, comment unless
+          comment.empty?
 
         keep_comment = true
         container.current_line_visibility = nil
@@ -1828,10 +1830,6 @@ class RDoc::Parser::Ruby < RDoc::Parser
         end
 
         if non_comment_seen then
-          # Look for RDoc in a comment about to be thrown away
-          non_comment_seen = parse_comment container, tk, comment unless
-            comment.empty?
-
           comment = ''
           comment = RDoc::Encoding.change_encoding comment, @encoding if @encoding
         end

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -920,6 +920,32 @@ end
     assert_equal 'Comment followed by a linebreak', regular2.comment.to_s
   end
 
+  def test_parse_ghost_method_followed_by_undocumented_method
+    util_parser <<-'CLASS'
+class Foo
+  ##
+  # :method: ghost
+  # This is a ghost method
+
+  def baz() end
+end
+    CLASS
+
+    tk = @parser.get_tk
+
+    @parser.parse_class @top_level, RDoc::Parser::Ruby::NORMAL, tk, @comment
+
+    foo = @top_level.classes.first
+    assert_equal 'Foo', foo.full_name
+
+    ghost = foo.method_list.first
+    assert_equal 'Foo#ghost', ghost.full_name
+    assert_equal 'This is a ghost method', ghost.comment.to_s
+
+    baz = foo.method_list[1]
+    assert_equal 'Foo#baz', baz.full_name
+  end
+
   def test_parse_class_nodoc
     comment = RDoc::Comment.new "##\n# my class\n", @top_level
 


### PR DESCRIPTION
Docs for ghost methods would get thrown away if the following method
does not have a comment. By parsing comments on linebreaks we avoid this
problem.

Builds on: #1258