### PR TITLE
[DOC] Stop autolinking the word "RDoc"

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -7,3 +7,5 @@ op_dir: _site # for GitHub Pages and should match the config of RDoc task in Rak
 title: rdoc Documentation
 main_page: README.rdoc
 warn_missing_rdoc_ref: true
+autolink_excluded_words:
+- RDoc


### PR DESCRIPTION
The project name "RDoc" should not be linked to the module `RDoc`.