### PR TITLE
Fix prism_ruby superclass resolve order

### DIFF
--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -642,14 +642,16 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
 
     owner, name = find_or_create_constant_owner_name(module_name)
     if is_class
-      mod = owner.classes_hash[name] || owner.add_class(RDoc::NormalClass, name, superclass_name || '::Object')
-
       # RDoc::NormalClass resolves superclass name despite of the lack of module nesting information.
       # We need to fix it when RDoc::NormalClass resolved to a wrong constant name
       if superclass_name
         superclass_full_path = resolve_constant_path(superclass_name)
         superclass = @store.find_class_or_module(superclass_full_path) if superclass_full_path
         superclass_full_path ||= superclass_name
+      end
+      # add_class should be done after resolving superclass
+      mod = owner.classes_hash[name] || owner.add_class(RDoc::NormalClass, name, superclass_name || '::Object')
+      if superclass_name
         if superclass
           mod.superclass = superclass
         elsif mod.superclass.is_a?(String) && mod.superclass != superclass_full_path


### PR DESCRIPTION
Fixes #1249 

Running `make html` in ruby/ruby fails with `'RDoc::ClassModule#superclass': stack level too deep (SystemStackError)`.
Parsing the `OpenSSL::Cipher::Cipher` in the code below succeeds, but with recursive superclass.
```ruby
class OpenSSL
  class Cipher
    # Defines class OpenSSL::Cipher::Cipher with superclass=OpenSSL::Cipher
    class Cipher < Cipher; end
  end
end
```

In class definition, superclass part is evaluated before constant definition.
PrismRuby should do the same: resolve superclass first, then add class with the given classname.