### PR TITLE
Add missing `RDoc::RubygemsHook` API for `gem server`

### DIFF
--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -273,6 +273,10 @@ module RDoc
 
     attr_accessor :generate_rdoc, :generate_ri, :force
 
+    class << self
+      attr_accessor :rdoc_version
+    end
+
     def self.default_gem?
       !File.exist?(File.join(__dir__, "..", "rubygems_plugin.rb"))
     end
@@ -309,6 +313,10 @@ module RDoc
 
       # Generate document for compatibility if this is a default gem.
       RubyGemsHook.generate(installer, specs)
+    end
+
+    def self.load_rdoc
+      @rdoc_version = RubyGemsHook.load_rdoc
     end
   end
 end

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -273,10 +273,6 @@ module RDoc
 
     attr_accessor :generate_rdoc, :generate_ri, :force
 
-    class << self
-      attr_accessor :rdoc_version
-    end
-
     def self.default_gem?
       !File.exist?(File.join(__dir__, "..", "rubygems_plugin.rb"))
     end
@@ -316,7 +312,11 @@ module RDoc
     end
 
     def self.load_rdoc
-      @rdoc_version = RubyGemsHook.load_rdoc
+      RubyGemsHook.load_rdoc
+    end
+
+    def self.rdoc_version
+      RubyGemsHook.rdoc_version
     end
   end
 end

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -318,5 +318,13 @@ module RDoc
     def self.rdoc_version
       RubyGemsHook.rdoc_version
     end
+
+    def rdoc_installed?
+      RubyGemsHook.new(@spec).rdoc_installed?
+    end
+
+    def ri_installed?
+      RubyGemsHook.new(@spec).ri_installed?
+    end
   end
 end


### PR DESCRIPTION
This PR fixes #1269.

## Expected Behavior

`gem server` command is successful.

```console
❯ gem server
Server started at http://[::]:8808
Server started at http://0.0.0.0:8808
```

## Actual Behavior

`gem server` command doesn't work because `Gem::Rdoc.load_rdoc` raise `NoMethodError`.

```console
❯ gem server
ERROR:  While executing gem ... (NoMethodError)
    undefined method 'load_rdoc' for class RDoc::RubygemsHook

    Gem::RDoc.load_rdoc
             ^^^^^^^^^^
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:437:in 'Gem::Server#initialize'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:426:in 'Class#new'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:426:in 'Gem::Server.run'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rubygems-server-0.3.0/lib/rubygems/commands/server_command.rb:83:in 'Gem::Commands::ServerCommand#execute'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/command.rb:326:in 'Gem::Command#invoke_with_build_args'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/command_manager.rb:253:in 'Gem::CommandManager#invoke_command'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/command_manager.rb:194:in 'Gem::CommandManager#process_args'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/command_manager.rb:152:in 'Gem::CommandManager#run'
        /Users/mterada/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/gem_runner.rb:57:in 'Gem::GemRunner#run'
        /Users/mterada/.rbenv/versions/3.4.1/bin/gem:12:in '<main>'
```

## Versions

```console
❯ rdoc -v
6.10.0
```
