### PR TITLE
[DOC] Remove unnecessary rdoc-ref missing example

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -996,8 +996,7 @@ require 'rdoc'
 #   and entire <tt>rdoc-ref:</tt> square-bracketed clause is removed
 #   from the resulting text.
 #
-#   - <tt>Nosuch[rdoc-ref:RDoc::Nosuch]</tt> generates
-#     Nosuch[rdoc-ref:RDoc::Nosuch].
+#   - <tt>Nosuch[rdoc-ref:RDoc::Nosuch]</tt> generates Nosuch.
 #
 #
 # [<tt>rdoc-label</tt> Scheme]


### PR DESCRIPTION
We don't actually need to link to the missing item to show the non-linked result.