### PR TITLE
Finalize RDoc::Options before calling RDoc::RDoc#parse_files

### DIFF
--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -181,9 +181,9 @@ class RDoc::RubyGemsHook
       options = ::RDoc::Options.new
       options.default_title = "#{@spec.full_name} Documentation"
       options.parse args
+      options.quiet = !Gem.configuration.really_verbose
+      options.finish
     end
-
-    options.quiet = !Gem.configuration.really_verbose
 
     @rdoc = new_rdoc
     @rdoc.options = options


### PR DESCRIPTION
Commit 6cf6e1647b97, which went to v6.5.0, changed `RDoc::Options#parse` to not call `#finish` in it. While the commit adjusted other call sites, it missed `lib/rdoc/rubygems_hook.rb`.

`RDoc::Options#finish` prepares the include paths for `:include:` directives. This has to be done before starting to parse sources.

I think this should fix https://github.com/ruby/net-http/issues/193 + https://github.com/ruby/net-http/pull/194.