### PR TITLE
Enable `warn_missing_rdoc_ref` by default

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -410,7 +410,7 @@ class RDoc::Options
     @update_output_dir = true
     @verbosity = 1
     @visibility = :protected
-    @warn_missing_rdoc_ref = false
+    @warn_missing_rdoc_ref = true
     @webcvs = nil
     @write_options = false
     @encoding = Encoding::UTF_8

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -82,7 +82,7 @@ class TestRDocOptions < RDoc::TestCase
       'template_stylesheets'  => [],
       'title'                 => nil,
       'visibility'            => :protected,
-      'warn_missing_rdoc_ref' => false,
+      'warn_missing_rdoc_ref' => true,
       'webcvs'                => nil,
       'skip_tests'            => true,
       'apply_default_exclude' => true,


### PR DESCRIPTION
This feature has been tested in RDoc and IRB, as well as my local Ruby project for a while. It's been finding and now preventing dead rdoc-ref links effectively. So I think it's a great feature to be enabled by default.