### PR TITLE
Add a `build:local_ruby` task to simplify local testing flow

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -52,8 +52,7 @@ jobs:
       - name: Build RDoc locally
         run: |
           bundle install
-          bundle exec rake build
-          mv pkg/rdoc-*.gem ../ruby/gems
+          bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Generate Documentation with RDoc
         run: make html

--- a/Rakefile
+++ b/Rakefile
@@ -103,8 +103,9 @@ desc "Build #{Bundler::GemHelper.gemspec.full_name} and move it to local ruby/ru
 namespace :build do
   task local_ruby: :build do
     target = File.join("..", "ruby", "gems")
+
     unless File.directory?(target)
-      abort("Expected ruby to be cloned at the same level as #{Bundler::GemHelper.gemspec.full_name} to use this task")
+      abort("Expected Ruby to be cloned under the same parent directory as RDoc to use this task")
     end
 
     mv("#{path}.gem", target)

--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,18 @@ task :clean do
   end
 end
 
+desc "Build #{Bundler::GemHelper.gemspec.full_name} and move it to local ruby/ruby project's bundled gems folder"
+namespace :build do
+  task local_ruby: :build do
+    target = File.join("..", "ruby", "gems")
+    unless File.directory?(target)
+      abort("Expected ruby to be cloned at the same level as #{Bundler::GemHelper.gemspec.full_name} to use this task")
+    end
+
+    mv("#{path}.gem", target)
+  end
+end
+
 begin
   require 'rubocop/rake_task'
 rescue LoadError


### PR DESCRIPTION
A common way to test RDoc changes is to build `ruby/ruby`'s documentation with the latest RDoc changes. When RDoc was a default gem, we can sync it to `ruby/ruby` with its `tool/sync_default_gems.rb` script.

Now that RDoc is a bundled gem, we need to use a different method to sync it to `ruby/ruby`. And so far building it and moving it to `ruby/ruby`'s bundled gems folder is the easiest way to do it.