### PR TITLE
Reduce document difference between RDoc::Parser::Ruby and RDoc::Parser::PrismRuby

### DIFF
--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -679,6 +679,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
         superclass_full_path = resolve_constant_path(superclass_name)
         superclass = @store.find_class_or_module(superclass_full_path) if superclass_full_path
         superclass_full_path ||= superclass_name
+        superclass_full_path = superclass_full_path.sub(/^::/, '')
       end
       # add_class should be done after resolving superclass
       mod = owner.classes_hash[name] || owner.add_class(RDoc::NormalClass, name, superclass_name || superclass_expr || '::Object')

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -689,7 +689,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       if superclass_name
         if superclass
           mod.superclass = superclass
-        elsif mod.superclass.is_a?(String) && mod.superclass != superclass_full_path
+        elsif (mod.superclass.is_a?(String) || mod.superclass.name == 'Object') && mod.superclass != superclass_full_path
           mod.superclass = superclass_full_path
         end
       end

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -527,16 +527,6 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
     handle_modifier_directive(meth, end_line)
     return unless should_document?(meth)
 
-    if meth.name == 'initialize' && !singleton
-      if meth.dont_rename_initialize
-        meth.visibility = :protected
-      else
-        meth.name = 'new'
-        meth.singleton = true
-        meth.visibility = :public
-      end
-    end
-
     internal_add_method(
       receiver,
       meth,
@@ -548,6 +538,18 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       block_params: block_params,
       tokens: tokens
     )
+
+    # Rename after add_method to register duplicated 'new' and 'initialize'
+    # defined in c and ruby just like the old parser did.
+    if meth.name == 'initialize' && !singleton
+      if meth.dont_rename_initialize
+        meth.visibility = :protected
+      else
+        meth.name = 'new'
+        meth.singleton = true
+        meth.visibility = :public
+      end
+    end
   end
 
   private def internal_add_method(container, meth, line_no:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:) # :nodoc:

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -510,7 +510,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
 
   # Adds a method defined by `def` syntax
 
-  def add_method(name, receiver_name:, receiver_fallback_type:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:, start_line:, end_line:)
+  def add_method(name, receiver_name:, receiver_fallback_type:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:, start_line:, args_end_line:, end_line:)
     return if @in_proc_block
 
     receiver = receiver_name ? find_or_create_module_path(receiver_name, receiver_fallback_type) : @container
@@ -524,6 +524,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       meth.comment = comment
     end
     handle_modifier_directive(meth, start_line)
+    handle_modifier_directive(meth, args_end_line)
     handle_modifier_directive(meth, end_line)
     return unless should_document?(meth)
 
@@ -854,6 +855,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
 
     def visit_def_node(node)
       start_line = node.location.start_line
+      args_end_line = node.parameters&.location&.end_line || start_line
       end_line = node.location.end_line
       @scanner.process_comments_until(start_line - 1)
 
@@ -904,6 +906,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
         calls_super: calls_super,
         tokens: tokens,
         start_line: start_line,
+        args_end_line: args_end_line,
         end_line: end_line
       )
     ensure

--- a/test/rdoc/test_rdoc_parser_prism_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_prism_ruby.rb
@@ -663,25 +663,22 @@ module RDocParserPrismTestCases
           add_my_method :bar
         end
 
-        tap do
-          # comment baz1
+        metaprogramming do
+          # class that defines this method is unknown
           def baz1; end
         end
 
-        self.tap do
-          # comment baz2
-          def baz2; end
-        end
+        my_decorator def self.baz2; end
 
-        my_decorator def self.baz3; end
-
-        self.my_decorator def baz4; end
+        self.my_decorator def baz3; end
       end
     RUBY
     mod = @store.find_module_named 'A'
     methods = mod.method_list
-    assert_equal ['A::foo', 'A#bar', 'A#baz1', 'A#baz2', 'A::baz3', 'A#baz4'], methods.map(&:full_name)
-    assert_equal ['comment foo', 'comment bar', 'comment baz1', 'comment baz2'], methods.take(4).map { |m| m.comment.text.strip }
+    unless accept_legacy_bug?
+      assert_equal ['A::foo', 'A#bar', 'A::baz2', 'A#baz3'], methods.map(&:full_name)
+    end
+    assert_equal ['comment foo', 'comment bar'], methods.take(2).map { |m| m.comment.text.strip }
   end
 
   def test_method_yields_directive

--- a/test/rdoc/test_rdoc_parser_prism_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_prism_ruby.rb
@@ -1091,7 +1091,7 @@ module RDocParserPrismTestCases
   end
 
   def test_undocumentable_change_visibility
-    pend if accept_legacy_bug?
+    omit if accept_legacy_bug?
     util_parser <<~RUBY
       class A
         def m1; end
@@ -1126,7 +1126,7 @@ module RDocParserPrismTestCases
   end
 
   def test_method_visibility_change_in_subclass
-    pend 'not implemented' if accept_legacy_bug?
+    omit 'not implemented' if accept_legacy_bug?
     util_parser <<~RUBY
       class A
         def m1; end
@@ -1237,7 +1237,7 @@ module RDocParserPrismTestCases
   end
 
   def test_invalid_alias_method
-    pend if accept_legacy_bug?
+    omit if accept_legacy_bug?
     util_parser <<~RUBY
       class Foo
         def foo; end
@@ -1639,7 +1639,7 @@ module RDocParserPrismTestCases
   end
 
   def test_constant_with_singleton_class
-    pend if accept_legacy_bug?
+    omit if accept_legacy_bug?
     util_parser <<~RUBY
       class Foo
         class Bar; end
@@ -1728,7 +1728,7 @@ module RDocParserPrismTestCases
   end
 
   def test_include_extend_to_singleton_class
-    pend 'not implemented' if accept_legacy_bug?
+    omit 'not implemented' if accept_legacy_bug?
     util_parser <<~RUBY
       class Foo
         class << self
@@ -1777,7 +1777,7 @@ module RDocParserPrismTestCases
   end
 
   def test_various_argument_include
-    pend 'not implemented' if accept_legacy_bug?
+    omit 'not implemented' if accept_legacy_bug?
     util_parser <<~RUBY
       module A; end
       module B; end

--- a/test/rdoc/test_rdoc_parser_prism_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_prism_ruby.rb
@@ -1927,6 +1927,35 @@ module RDocParserPrismTestCases
     assert_equal ['a', 'f'], mod.method_list.map(&:name)
   end
 
+  def test_include_extend_suppressed_within_block
+    util_parser <<~RUBY
+      module M; end
+      module N; end
+      module O: end
+      class A
+        metaprogramming do
+          include M
+          extend N
+          class B
+            include M
+            extend N
+          end
+          include M
+          extend N
+        end
+        include O
+        extend O
+      end
+    RUBY
+    a, b = @store.all_classes
+    unless accept_legacy_bug?
+      assert_equal ['O'], a.includes.map(&:name)
+      assert_equal ['O'], a.extends.map(&:name)
+    end
+    assert_equal ['M'], b.includes.map(&:name)
+    assert_equal ['N'], b.extends.map(&:name)
+  end
+
   def test_multibyte_method_name
     content = <<~RUBY
       class Foo

--- a/test/rdoc/test_rdoc_parser_prism_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_prism_ruby.rb
@@ -1391,9 +1391,12 @@ module RDocParserPrismTestCases
         def doc3; end
         def nodoc3
         end # :nodoc:
+        def nodoc4(arg1,
+                   arg2) # :nodoc:
+        end
         def doc4; end
         # :stopdoc:
-        def nodoc4; end
+        def nodoc5; end
       end
     RUBY
     klass = @store.find_class_named 'Foo'

--- a/test/rdoc/xref_data.rb
+++ b/test/rdoc/xref_data.rb
@@ -110,6 +110,7 @@ end
 
 class C8
   class << self
+    # This is C8.singleton_class::S1. C8::S1 does not exist.
     class S1
     end
   end


### PR DESCRIPTION
Fix these bugs/incompatibilities which was making makes many differences between two parsers
```ruby
module DidYouMean
  # NameErrorCheckers = Object.new is now evaluated outside of this singleton class.
  class << (NameErrorCheckers = Object.new)
    # DidYouMean::NameErrorCheckers::NameErrorCheckers is not documented anymore
  end
end

# Nodoc comment on the end of parameter line is now working
def self.new2(user, password, host, port, path,
              typecode = nil, arg_check = true) # :nodoc:
end

module Enumerable
  # Fix syntax tree traverse order. Fix bug that this comment is ignored.
  def to_set(klass = Set, *args, &block)
  end unless condition
end

# Documents both ruby and c definition of new and initialize. (accepts duplicated entry only for method "new")
# files: Fiddle/Function.html, Fiddle/Handle.html, Fiddle/Pinned.html and more

# This include is not listed in the documentation anymore
cxx = Module.new do
  include MakeMakefile
end

# Superclass: `Object` → `"DelegateClass(File)"`
class Tempfile < DelegateClass(File)
end

module Psych
  # Superclass: `::Hash` → `Hash`
  class Omap < ::Hash
  end
end

String.include(
  Module.new {
    # This is not a toplevel method anymore
    def byteindex(needle, offset = 0)
    end
  }
)

class Dir
  module Tmpname
    # Check for :nodoc: and skip creating module RANDOM
    class << RANDOM # :nodoc:
    end
  end
end

DefaultResolver = self.new
# Don't create module DefaultResolver if it is already defined as a constant
def DefaultResolver.replace_resolvers new_resolvers
  @resolvers = new_resolvers
end
```

# Diff

Diff of generating html files in ruby/ruby between RDoc::Parser::Ruby and RDoc::Parser::PrismRuby

## Some link of constant names in document text are removed/added
CGI/Util.html
Exception.html
Gem/DefaultUserInteraction.html
Gem/Security.html
MakeMakefile.html
NEWS/NEWS-3_2_0_md.html
Net/HTTPHeader.html
OpenSSL/Buffering.html
OpenSSL/PKey/DSA.html
OpenSSL/PKey/EC.html
OpenSSL/PKey/RSA.html
Ripper/Filter.html
UnicodeNormalize.html

## Trailing garbage text removed from meta tag
Fiddle/DLError.html
Prism/ConstantPathNode.html
Prism/ParenthesesNode.html

## Call-seq improved or changed(space added/removed)
Delegator.html
Fiddle/Error.html
FileUtils.html
Gem/Commands/QueryCommand.html
MonitorMixin/ConditionVariable.html
Net/HTTPHeader.html
YAMLTree.html
SyntaxSuggest/CleanDocument.html
YAML/DBM.html

## Wrong include/extend removed
CGI.html
ERB/Util.html
Gem/BasicSpecification.html
Gem/Commands/SetupCommand.html
Gem/Platform.html
Gem/Util.html
MakeMakefile.html
OpenURI/Meta.html

## Missing constant added
DidYouMean.html
Gem/Validator.html

## Missing document comment added
DidYouMean.html

## Missing method added
Digest/SHA2.html
ERB/Util.html

## Method source improved
Gem/Commands/SetupCommand.html

## Method visibility improved
Gem/Commands/SetupCommand.html
IPSocket.html
Ractor.html

## Wrong method removed
Resolv/SZ.html
SyntaxSuggest.html

## Wrong metaprogramming comment treated as method comment
Gem/Specification.html
Object.html
```ruby
##
# metaprogramming method comment
require 'path_treated_as_metaprogramming_method_name'
```


## Wrong comment removed
Net/HTTP.html
Net.html

## RDoc bug was suppressed by another bug, but not supperssed anymore
Net/HTTPFatalError.html

## Method added
Pathname.html
Comment `# -> path # :nodoc:` is not considered to be a :nodoc: comment in PrismRuby.

## index.html
Link to Gem::Request and UnicodeNormalize is added (unknown)
Ripper::Lexer is removed (it has `#:nodoc: internal use only comment` comment)
EXCEPTION_TYPE added (RDoc::Parser::Ruby does not handle `EXCEPTION_TYPE = HTTPError                  #`)
