### PR TITLE
Remove unnecessary coupling in comments' call_seq extraction

### DIFF
--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -110,7 +110,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # See also #param_seq
 
   def call_seq= call_seq
-    return if call_seq.empty?
+    return if call_seq.nil? || call_seq.empty?
 
     @call_seq = call_seq
   end

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -92,7 +92,7 @@ class RDoc::Comment
   #   #   ARGF.to_a(limit)      -> array
   #   #   ARGF.to_a(sep, limit) -> array
 
-  def extract_call_seq method
+  def extract_call_seq
     # we must handle situations like the above followed by an unindented first
     # comment.  The difficulty is to make sure not to match lines starting
     # with ARGF at the same indent, but that are after the first description
@@ -116,10 +116,7 @@ class RDoc::Comment
       @text.slice! all_start...all_stop
 
       seq.gsub!(/^\s*/, '')
-      method.call_seq = seq
     end
-
-    method
   end
 
   ##

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -810,7 +810,7 @@ class RDoc::Parser::C < RDoc::Parser
 
   def find_modifiers comment, meth_obj
     comment.normalize
-    comment.extract_call_seq meth_obj
+    meth_obj.call_seq = comment.extract_call_seq
 
     look_for_directives_in meth_obj, comment
   end

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -303,7 +303,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       meth.singleton = @singleton || singleton_method
       handle_consecutive_comment_directive(meth, comment)
       comment.normalize
-      comment.extract_call_seq(meth)
+      meth.call_seq = comment.extract_call_seq
       meth.comment = comment
       if node
         tokens = visible_tokens_from_location(node.location)
@@ -520,7 +520,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       handle_consecutive_comment_directive(meth, comment)
 
       comment.normalize
-      comment.extract_call_seq(meth)
+      meth.call_seq = comment.extract_call_seq
       meth.comment = comment
     end
     handle_modifier_directive(meth, start_line)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1153,7 +1153,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       end
 
     comment.normalize
-    comment.extract_call_seq meth
+    meth.call_seq = comment.extract_call_seq
 
     return unless meth.name
 
@@ -1417,7 +1417,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
       look_for_directives_in meth, comment
       comment.normalize
-      comment.extract_call_seq meth
+      meth.call_seq = comment.extract_call_seq
 
       container.add_method meth
 
@@ -1485,7 +1485,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     parse_method_params_and_body container, single, meth, added_container
 
     comment.normalize
-    comment.extract_call_seq meth
+    meth.call_seq = comment.extract_call_seq
 
     meth.comment = comment
 

--- a/test/rdoc/test_rdoc_comment.rb
+++ b/test/rdoc/test_rdoc_comment.rb
@@ -3,7 +3,7 @@
 
 require_relative 'helper'
 
-class TestRDocComment < RDoc::TestCase
+class RDocCommentTest < RDoc::TestCase
 
   def setup
     super
@@ -42,8 +42,6 @@ class TestRDocComment < RDoc::TestCase
   end
 
   def test_extract_call_seq
-    m = RDoc::AnyMethod.new nil, 'm'
-
     comment = RDoc::Comment.new <<-COMMENT, @top_level
 call-seq:
   bla => true or false
@@ -51,28 +49,20 @@ call-seq:
 moar comment
     COMMENT
 
-    comment.extract_call_seq m
-
-    assert_equal "bla => true or false\n", m.call_seq
+    assert_equal "bla => true or false\n", comment.extract_call_seq
   end
 
   def test_extract_call_seq_blank
-    m = RDoc::AnyMethod.new nil, 'm'
-
     comment = RDoc::Comment.new <<-COMMENT, @top_level
 call-seq:
   bla => true or false
 
     COMMENT
 
-    comment.extract_call_seq m
-
-    assert_equal "bla => true or false\n", m.call_seq
+    assert_equal "bla => true or false\n", comment.extract_call_seq
   end
 
   def test_extract_call_seq_commented
-    m = RDoc::AnyMethod.new nil, 'm'
-
     comment = RDoc::Comment.new <<-COMMENT, @top_level
 # call-seq:
 #   bla => true or false
@@ -80,36 +70,26 @@ call-seq:
 # moar comment
     COMMENT
 
-    comment.extract_call_seq m
-
-    assert_nil m.call_seq
+    assert_nil comment.extract_call_seq
   end
 
   def test_extract_call_seq_no_blank
-    m = RDoc::AnyMethod.new nil, 'm'
-
     comment = RDoc::Comment.new <<-COMMENT, @top_level
 call-seq:
   bla => true or false
     COMMENT
 
-    comment.extract_call_seq m
-
-    assert_equal "bla => true or false\n", m.call_seq
+    assert_equal "bla => true or false\n", comment.extract_call_seq
   end
 
   def test_extract_call_seq_undent
-    m = RDoc::AnyMethod.new nil, 'm'
-
     comment = RDoc::Comment.new <<-COMMENT, @top_level
 call-seq:
   bla => true or false
 moar comment
     COMMENT
 
-    comment.extract_call_seq m
-
-    assert_equal "bla => true or false\nmoar comment\n", m.call_seq
+    assert_equal "bla => true or false\nmoar comment\n", comment.extract_call_seq
   end
 
   def test_extract_call_seq_c
@@ -128,10 +108,6 @@ Otherwise, returns a +Date+ for the commercial week year, commercial week,
 and commercial week day given. Ignores the 4th argument.
     COMMENT
 
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
-
-    comment.extract_call_seq method_obj
-
     expected = <<-CALL_SEQ.chomp
 commercial() -> Date <br />
 commercial(cwyear, cweek=41, cwday=5, sg=nil) -> Date [ruby 1.8] <br />
@@ -139,7 +115,7 @@ commercial(cwyear, cweek=1, cwday=1, sg=nil) -> Date [ruby 1.9]
 
     CALL_SEQ
 
-    assert_equal expected, method_obj.call_seq
+    assert_equal expected, comment.extract_call_seq
   end
 
   def test_extract_call_seq_c_no_blank
@@ -150,10 +126,6 @@ call-seq:
   commercial(cwyear, cweek=1, cwday=1, sg=nil) -> Date [ruby 1.9]
     COMMENT
 
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
-
-    comment.extract_call_seq method_obj
-
     expected = <<-CALL_SEQ.chomp
 commercial() -> Date <br />
 commercial(cwyear, cweek=41, cwday=5, sg=nil) -> Date [ruby 1.8] <br />
@@ -161,7 +133,7 @@ commercial(cwyear, cweek=1, cwday=1, sg=nil) -> Date [ruby 1.9]
 
     CALL_SEQ
 
-    assert_equal expected, method_obj.call_seq
+    assert_equal expected, comment.extract_call_seq
   end
 
   def test_extract_call_seq_c_separator
@@ -183,10 +155,6 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
 
     COMMENT
 
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
-
-    comment.extract_call_seq method_obj
-
     expected = <<-CALL_SEQ
 ARGF.readlines(sep=$/)     -> array
 ARGF.readlines(limit)      -> array
@@ -196,7 +164,7 @@ ARGF.to_a(limit)      -> array
 ARGF.to_a(sep, limit) -> array
     CALL_SEQ
 
-    assert_equal expected, method_obj.call_seq
+    assert_equal expected, comment.extract_call_seq
 
     expected = <<-'COMMENT'
 
@@ -211,11 +179,12 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
     assert_equal expected, comment.text
   end
 
+  # This test relies on AnyMethod#call_seq's behaviour as well
   def test_extract_call_linear_performance
     pre = ->(n) {[n, RDoc::Comment.new("\n"*n + 'call-seq:' + 'a'*n)]}
     method_obj = RDoc::AnyMethod.new nil, 'blah'
     assert_linear_performance((2..5).map {|i| 10**i}, pre: pre) do |n, comment|
-      comment.extract_call_seq method_obj
+      method_obj.call_seq = comment.extract_call_seq
       assert_equal n, method_obj.call_seq.size
     end
   end


### PR DESCRIPTION
There is no need to pass the method object to `RDoc::Comment#extract_call_seq` just to assign the result to the method object's `call_seq` attribute. This unnecessarily complicates the code and makes it harder to understand/refactor, which is evident in the method's tests.

This commit removes the indirection and simplifies the implementation & tests.