### PR TITLE
Explicitly require helper in test_case

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,8 +38,6 @@ end
 Rake::TestTask.new(:normal_test) do |t|
   t.verbose = true
   t.deps = :generate
-  t.libs << "test/lib"
-  t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"].exclude("test/rdoc/test_rdoc_rubygems_hook.rb")
 end
 

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -13,6 +13,7 @@ require 'tempfile'
 require 'tmpdir'
 require 'stringio'
 
+require_relative '../../lib/helper'
 require_relative '../../../lib/rdoc'
 
 ##


### PR DESCRIPTION
Currently, the helper is required through the Rake test task, which is very implicit and means when running some tests directly some methods are not available.

For example, running `bundle exec ruby -Itest PATH_TO_RDOC/test/rdoc/test_rdoc_comment.rb` will trigger `NoMethodError: undefined method 'assert_linear_performance' for an instance of RDocCommentTest` because `test/lib/helper.rb` is not required.

This commit makes the test case always require the helper and remove the related options from the Rake test task.