### PR TITLE
Relax paragraph pattern

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -700,6 +700,8 @@ class RDoc::Generator::Darkfish
     template
   end
 
+  ParagraphExcerptRegexp = /[A-Z][^\.:\/]+\./
+
   # Returns an excerpt of the comment for usage in meta description tags
   def excerpt(comment)
     text = case comment
@@ -711,11 +713,11 @@ class RDoc::Generator::Darkfish
 
     # Match from a capital letter to the first period, discarding any links, so
     # that we don't end up matching badges in the README
-    first_paragraph_match = text.match(/[A-Z][^\.:\/]+\./)
+    first_paragraph_match = text.match(ParagraphExcerptRegexp)
     return text[0...150].gsub(/\n/, " ").squeeze(" ") unless first_paragraph_match
 
     extracted_text = first_paragraph_match[0]
-    second_paragraph = first_paragraph_match.post_match.match(/[A-Z][^\.:\/]+\./)
+    second_paragraph = first_paragraph_match.post_match.match(ParagraphExcerptRegexp)
     extracted_text << " " << second_paragraph[0] if second_paragraph
 
     extracted_text[0...150].gsub(/\n/, " ").squeeze(" ")

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -722,7 +722,7 @@ class RDoc::Generator::Darkfish
       first_paragraph_match = text.match(pattern)
     rescue Encoding::CompatibilityError
       # The doc is non-ASCII text and encoded in other than Unicode base encodings.
-      raise unless pattern.eaual?(ParagraphExcerptRegexpUnicode)
+      raise if pattern == ParagraphExcerptRegexpOther
       pattern = ParagraphExcerptRegexpOther
       retry
     end

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -714,13 +714,13 @@ class RDoc::Generator::Darkfish
     # Match from a capital letter to the first period, discarding any links, so
     # that we don't end up matching badges in the README
     first_paragraph_match = text.match(ParagraphExcerptRegexp)
-    return text[0...150].gsub(/\n/, " ").squeeze(" ") unless first_paragraph_match
+    return text[0...150].tr_s("\n", " ").squeeze(" ") unless first_paragraph_match
 
     extracted_text = first_paragraph_match[0]
     second_paragraph = first_paragraph_match.post_match.match(ParagraphExcerptRegexp)
     extracted_text << " " << second_paragraph[0] if second_paragraph
 
-    extracted_text[0...150].gsub(/\n/, " ").squeeze(" ")
+    extracted_text[0...150].tr_s("\n", " ").squeeze(" ")
   end
 
   def generate_ancestor_list(ancestors, klass)

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -454,8 +454,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
     top_level.comment = <<~MARKDOWN
       # Distributed Ruby: dRuby
 
-      dRuby is a distributed object system for Ruby.  It allows an object in one
-      Ruby process to invoke methods on an object in another Ruby process.
+      dRuby is a distributed object system for Ruby.  It allows an object.
     MARKDOWN
 
     @g.generate
@@ -466,7 +465,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
       "<meta name=\"description\" content=\"" \
       "README: dRuby " \
       "dRuby is a distributed object system for Ruby. " \
-      "It allows an object in one Ruby process to invoke methods on an object"
+      "It allows an object."
     )
   end
 

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -449,6 +449,27 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
     )
   end
 
+  def test_meta_tags_for_markdwon_files_paragraph
+    top_level = @store.add_file("README.md", parser: RDoc::Parser::Simple)
+    top_level.comment = <<~MARKDOWN
+      # Distributed Ruby: dRuby
+
+      dRuby is a distributed object system for Ruby.  It allows an object in one
+      Ruby process to invoke methods on an object in another Ruby process.
+    MARKDOWN
+
+    @g.generate
+
+    content = File.binread("README_md.html")
+    assert_include(
+      content,
+      "<meta name=\"description\" content=\"" \
+      "README: dRuby " \
+      "dRuby is a distributed object system for Ruby. " \
+      "It allows an object in one Ruby process to invoke methods on an object"
+    )
+  end
+
   def test_meta_tags_for_markdown_files
     top_level = @store.add_file("MyPage.md", parser: RDoc::Parser::Markdown)
     top_level.comment = <<~MARKDOWN


### PR DESCRIPTION
Not all paragraphs in documentations start with a capital letter, as usual English text.

Fix #1298
