### PR TITLE
Remove unused `class_dir` and `file_dir` attributes from generators

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -634,7 +634,7 @@ class RDoc::ClassModule < RDoc::Context
   # Path to this class or module for use with HTML generator output.
 
   def path
-    http_url @store.rdoc.generator.class_dir
+    http_url(nil)
   end
 
   ##

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -634,7 +634,7 @@ class RDoc::ClassModule < RDoc::Context
   # Path to this class or module for use with HTML generator output.
 
   def path
-    http_url(nil)
+    http_url
   end
 
   ##

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -973,10 +973,10 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # URL for this with a +prefix+
 
-  def http_url(prefix)
+  def http_url
     path = name_for_path
     path = path.gsub(/<<\s*(\w*)/, 'from-\1') if path =~ /<</
-    path = [prefix] + path.split('::')
+    path = path.split('::')
 
     File.join(*path.compact) + '.html'
   end

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -173,10 +173,8 @@ class RDoc::TopLevel < RDoc::Context
   ##
   # URL for this with a +prefix+
 
-  def http_url(prefix)
-    path = [prefix, @relative_name.tr('.', '_')]
-
-    File.join(*path.compact) + '.html'
+  def http_url
+    @relative_name.tr('.', '_') + '.html'
   end
 
   def inspect # :nodoc:
@@ -246,7 +244,7 @@ class RDoc::TopLevel < RDoc::Context
   # Path to this file for use with HTML generator output.
 
   def path
-    http_url(nil)
+    http_url
   end
 
   def pretty_print q # :nodoc:

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -246,7 +246,7 @@ class RDoc::TopLevel < RDoc::Context
   # Path to this file for use with HTML generator output.
 
   def path
-    http_url @store.rdoc.generator.file_dir
+    http_url(nil)
   end
 
   def pretty_print q # :nodoc:

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -185,14 +185,6 @@ class RDoc::Generator::Darkfish
   end
 
   ##
-  # Directory where generated class HTML files live relative to the output
-  # dir.
-
-  def file_dir
-    nil
-  end
-
-  ##
   # Create the directories the generated docs will live in if they don't
   # already exist.
 

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -188,14 +188,6 @@ class RDoc::Generator::Darkfish
   # Directory where generated class HTML files live relative to the output
   # dir.
 
-  def class_dir
-    nil
-  end
-
-  ##
-  # Directory where generated class HTML files live relative to the output
-  # dir.
-
   def file_dir
     nil
   end

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -87,7 +87,7 @@ class RDoc::Generator::JsonIndex
 
   ##
   # Creates a new generator.  +parent_generator+ is used to determine the
-  # class_dir and file_dir of links in the output index.
+  # file_dir of links in the output index.
   #
   # +options+ are the same options passed to the parent generator.
 
@@ -263,13 +263,6 @@ class RDoc::Generator::JsonIndex
       record.shift
       @index[:info]            << record
     end
-  end
-
-  ##
-  # The directory classes are written to
-
-  def class_dir
-    @parent_generator.class_dir
   end
 
   ##

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -86,9 +86,7 @@ class RDoc::Generator::JsonIndex
   attr_reader :index # :nodoc:
 
   ##
-  # Creates a new generator.  +parent_generator+ is used to determine the
-  # file_dir of links in the output index.
-  #
+  # Creates a new generator.
   # +options+ are the same options passed to the parent generator.
 
   def initialize parent_generator, options
@@ -263,13 +261,6 @@ class RDoc::Generator::JsonIndex
       record.shift
       @index[:info]            << record
     end
-  end
-
-  ##
-  # The directory files are written to
-
-  def file_dir
-    @parent_generator.file_dir
   end
 
   def reset files, classes # :nodoc:

--- a/lib/rdoc/generator/pot.rb
+++ b/lib/rdoc/generator/pot.rb
@@ -81,11 +81,6 @@ class RDoc::Generator::POT
     end
   end
 
-  # :nodoc:
-  def class_dir
-    nil
-  end
-
   private
   def extract_messages
     extractor = MessageExtractor.new(@store)

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -53,9 +53,7 @@ class RDoc::TestCase < Test::Unit::TestCase
     @rdoc.store = @store
     @rdoc.options = RDoc::Options.new
 
-    g = Object.new
-    def g.file_dir() end
-    @rdoc.generator = g
+    @rdoc.generator = Object.new
 
     RDoc::Markup::PreProcess.reset
   end

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -54,7 +54,6 @@ class RDoc::TestCase < Test::Unit::TestCase
     @rdoc.options = RDoc::Options.new
 
     g = Object.new
-    def g.class_dir() end
     def g.file_dir() end
     @rdoc.generator = g
 

--- a/test/rdoc/test_rdoc_generator_json_index.rb
+++ b/test/rdoc/test_rdoc_generator_json_index.rb
@@ -80,10 +80,6 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     assert_equal expected, index
   end
 
-  def test_file_dir
-    assert_equal @darkfish.file_dir, @g.file_dir
-  end
-
   def test_generate
     @g.generate
 

--- a/test/rdoc/test_rdoc_generator_json_index.rb
+++ b/test/rdoc/test_rdoc_generator_json_index.rb
@@ -80,10 +80,6 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     assert_equal expected, index
   end
 
-  def test_class_dir
-    assert_equal @darkfish.class_dir, @g.class_dir
-  end
-
   def test_file_dir
     assert_equal @darkfish.file_dir, @g.file_dir
   end

--- a/test/rdoc/test_rdoc_top_level.rb
+++ b/test/rdoc/test_rdoc_top_level.rb
@@ -156,10 +156,10 @@ class TestRDocTopLevel < XrefTestCase
   end
 
   def test_http_url
-    assert_equal 'prefix/path/top_level_rb.html', @top_level.http_url('prefix')
+    assert_equal 'path/top_level_rb.html', @top_level.http_url
 
     other_level = @store.add_file 'path.other/level.rb'
-    assert_equal 'prefix/path_other/level_rb.html', other_level.http_url('prefix')
+    assert_equal 'path_other/level_rb.html', other_level.http_url
   end
 
   def test_last_modified

--- a/test/rdoc/xref_test_case.rb
+++ b/test/rdoc/xref_test_case.rb
@@ -30,7 +30,6 @@ class XrefTestCase < RDoc::TestCase
     @top_levels.push @example_md
 
     generator = Object.new
-    def generator.file_dir() nil end
     @rdoc.options = @options
     @rdoc.generator = generator
 

--- a/test/rdoc/xref_test_case.rb
+++ b/test/rdoc/xref_test_case.rb
@@ -30,7 +30,6 @@ class XrefTestCase < RDoc::TestCase
     @top_levels.push @example_md
 
     generator = Object.new
-    def generator.class_dir() nil end
     def generator.file_dir() nil end
     @rdoc.options = @options
     @rdoc.generator = generator


### PR DESCRIPTION
These generator methods are either not defined, or return a fixed `nil` value. Therefore, we can remove them and simplify some downstream logics accordingly.