### PR TITLE
Reenable JRuby for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       # 2.7 breaks `test_parse_statements_nodoc_identifier_alias_method`
       min_version: 3.0
       versions: '["mswin"]'
-      engine: cruby-truffleruby
 
   test:
     needs: ruby-versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head
+          - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
+            ruby: jruby-head
           - os: macos-latest
             ruby: mswin
           - os: ubuntu-latest


### PR DESCRIPTION
JRuby's recent issues with jar-dependencies caused installs to fail, but those issues have been resolved as of JRuby 9.4.12.0 (and by extension, jruby-head).

Reverts part of #1228.

Previous PR #1229 seemed to get messed up so I'm re-pushing here.