### PR TITLE
Tests for markdown code using multiple backquotes

### DIFF
--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -136,9 +136,27 @@ a block quote
 
   def test_parse_code
     doc = parse "Code: `text`"
-
     expected = doc(para("Code: <code>text</code>"))
+    assert_equal expected, doc
 
+    doc = parse "Code: ` text `"
+    expected = doc(para("Code: <code>text</code>"))
+    assert_equal expected, doc
+
+    doc = parse "Code: ``text`s``"
+    expected = doc(para("Code: <code>text`s</code>"))
+    assert_equal expected, doc
+
+    doc = parse "Code: `` text`s ``"
+    expected = doc(para("Code: <code>text`s</code>"))
+    assert_equal expected, doc
+
+    doc = parse "Code: ```text`s```"
+    expected = doc(para("Code: <code>text`s</code>"))
+    assert_equal expected, doc
+
+    doc = parse "Code: ``` text`s ```"
+    expected = doc(para("Code: <code>text`s</code>"))
     assert_equal expected, doc
   end
 


### PR DESCRIPTION
More exhaustive than "MarkdownTest_1.0.3/Code Spans.text" file.