### PR TITLE
Remove an unused constant

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -74,12 +74,6 @@ class RDoc::Generator::Darkfish
   ]
 
   ##
-  # Path to this file's parent directory. Used to find templates and other
-  # resources.
-
-  GENERATOR_DIR = File.join 'rdoc', 'generator'
-
-  ##
   # Release Version
 
   VERSION = '3'


### PR DESCRIPTION
From the comment, it seems that this was probably intended to `__dir__`.