### PR TITLE
Avoid accessing `RDoc` objects through `Store`

### DIFF
--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -300,11 +300,7 @@ class RDoc::CodeObject
   # This is used by Text#snippet
 
   def options
-    if @store and @store.rdoc then
-      @store.options
-    else
-      RDoc::Options.new
-    end
+    @store&.options || RDoc::Options.new
   end
 
   ##

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -301,7 +301,7 @@ class RDoc::CodeObject
 
   def options
     if @store and @store.rdoc then
-      @store.rdoc.options
+      @store.options
     else
       RDoc::Options.new
     end

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -482,7 +482,7 @@ class RDoc::Context < RDoc::CodeObject
         known.comment = method.comment if known.comment.empty?
         previously = ", previously in #{known.file}" unless
           method.file == known.file
-        @store.rdoc.options.warn \
+        @store.options.warn \
           "Duplicate method #{known.full_name} in #{method.file}#{previously}"
       end
     else

--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -34,7 +34,7 @@ module RDoc::Generator::Markup
   def formatter
     return @formatter if defined? @formatter
 
-    options = @store.rdoc.options
+    options = @store.options
     this = RDoc::Context === self ? self : @parent
 
     @formatter = RDoc::Markup::ToHtmlCrossref.new options, this.path, this
@@ -147,7 +147,7 @@ class RDoc::TopLevel
   # command line option to set.
 
   def cvs_url
-    url = @store.rdoc.options.webcvs
+    url = @store.options.webcvs
 
     if /%s/ =~ url then
       url % @relative_name

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -94,11 +94,7 @@ class RDoc::Store
 
   attr_accessor :path
 
-  ##
-  # The RDoc::RDoc driver for this parse tree.  This allows classes consulting
-  # the documentation tree to access user-set options, for example.
-
-  attr_accessor :rdoc
+  attr_writer :rdoc
 
   ##
   # Type of ri datastore this was loaded from.  See RDoc::RI::Driver,

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -982,7 +982,7 @@ class RDoc::Store
   end
 
   def options
-    @rdoc.options
+    @rdoc&.options
   end
 
   private

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -981,6 +981,10 @@ class RDoc::Store
     @unique_modules
   end
 
+  def options
+    @rdoc.options
+  end
+
   private
   def marshal_load(file)
     File.open(file, 'rb') {|io| Marshal.load(io, MarshalFilter)}

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -99,8 +99,8 @@ module RDoc::Text
   # Requires the including class to implement #formatter
 
   def markup text
-    if @store.rdoc.options
-      locale = @store.rdoc.options.locale
+    if @store.options
+      locale = @store.options.locale
     else
       locale = nil
     end

--- a/test/rdoc/test_rdoc_code_object.rb
+++ b/test/rdoc/test_rdoc_code_object.rb
@@ -122,7 +122,7 @@ class TestRDocCodeObject < XrefTestCase
 
     refute @co.document_children
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -137,7 +137,7 @@ class TestRDocCodeObject < XrefTestCase
     @co.document_self = false
     refute @co.document_self
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -190,7 +190,7 @@ class TestRDocCodeObject < XrefTestCase
 
     @co.done_documenting = true
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -236,7 +236,7 @@ class TestRDocCodeObject < XrefTestCase
     refute @co.document_children
     assert @co.ignored?
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -381,7 +381,7 @@ class TestRDocCodeObject < XrefTestCase
 
     refute @co.document_self
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -397,7 +397,7 @@ class TestRDocCodeObject < XrefTestCase
     refute @co.document_self
     refute @co.document_children
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 
@@ -417,7 +417,7 @@ class TestRDocCodeObject < XrefTestCase
     refute @co.document_children
     assert @co.suppressed?
 
-    @store.rdoc.options.visibility = :nodoc
+    @store.options.visibility = :nodoc
 
     @co.store = @store
 

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -219,7 +219,7 @@ class TestRDocContext < XrefTestCase
   end
 
   def test_add_method_duplicate
-    @store.rdoc.options.verbosity = 2
+    @store.options.verbosity = 2
 
     meth1 = RDoc::AnyMethod.new nil, 'name'
     meth1.record_location @store.add_file 'first.rb'

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -31,7 +31,6 @@ class TestRDocRDoc < RDoc::TestCase
       end
 
       assert File.directory? 'ri'
-      assert_equal rdoc, rdoc.store.rdoc
     end
 
     store = rdoc.store
@@ -58,7 +57,6 @@ class TestRDocRDoc < RDoc::TestCase
       end
 
       refute File.directory? 'doc'
-      assert_equal rdoc, rdoc.store.rdoc
     end
     assert_includes out, '100%'
 

--- a/test/rdoc/test_rdoc_servlet.rb
+++ b/test/rdoc/test_rdoc_servlet.rb
@@ -294,9 +294,6 @@ class TestRDocServlet < RDoc::TestCase
 
     assert_equal 'MAIN_PAGE.rdoc', @s.options.main_page
     assert_equal 'Title',          @s.options.title
-
-    assert_kind_of RDoc::RDoc, store.rdoc
-    assert_same generator, store.rdoc.generator
   end
 
   def test_if_modified_since


### PR DESCRIPTION
There's an unhealthy coupling between `RDoc` and `Store`, where they hold reference of each other and access things both ways.

IMO, `RDoc` instances holding `Store` objects makes sense as `Store` is a component of it. But `Store` shouldn't need to reference back to its `RDoc` instance.

This PR is the first step of removing this coupling by dropping `Store#rdoc` usages.