### PR TITLE
Make `Options` a required constructor argument of `Store`

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -214,7 +214,6 @@ option)
 
   def store= store
     @store = store
-    @store.rdoc = self
   end
 
   ##
@@ -450,8 +449,6 @@ The internal error was:
   # current directory, so make sure you're somewhere writable before invoking.
 
   def document options
-    self.store = RDoc::Store.new
-
     if RDoc::Options === options then
       @options = options
     else
@@ -459,6 +456,8 @@ The internal error was:
       @options.parse options
     end
     @options.finish
+
+    self.store = RDoc::Store.new(@options)
 
     if @options.pipe then
       handle_pipe

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -69,7 +69,7 @@ class RDoc::RDoc
   ##
   # The current documentation store
 
-  attr_reader :store
+  attr_accessor :store
 
   ##
   # Add +klass+ that can generate output after parsing
@@ -206,14 +206,6 @@ option)
     end
 
     last
-  end
-
-  ##
-  # Sets the current documentation tree to +store+ and sets the store's rdoc
-  # driver to this instance.
-
-  def store= store
-    @store = store
   end
 
   ##
@@ -457,7 +449,7 @@ The internal error was:
     end
     @options.finish
 
-    self.store = RDoc::Store.new(@options)
+    @store = RDoc::Store.new(@options)
 
     if @options.pipe then
       handle_pipe

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -460,12 +460,6 @@ The internal error was:
       @last_modified = setup_output_dir @options.op_dir, @options.force_update
     end
 
-    @store.encoding = @options.encoding
-    @store.dry_run  = @options.dry_run
-    @store.main     = @options.main_page
-    @store.title    = @options.title
-    @store.path     = @options.op_dir
-
     @start_time = Time.now
 
     @store.load_cache

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -420,7 +420,7 @@ or the PAGER environment variable.
                          *options[:extra_doc_dirs]) do |path, type|
       @doc_dirs << path
 
-      store = RDoc::RI::Store.new path, type
+      store = RDoc::RI::Store.new(path: path, type: type)
       store.load_cache
       @stores << store
     end

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -420,7 +420,7 @@ or the PAGER environment variable.
                          *options[:extra_doc_dirs]) do |path, type|
       @doc_dirs << path
 
-      store = RDoc::RI::Store.new(path: path, type: type)
+      store = RDoc::RI::Store.new(RDoc::Options.new, path: path, type: type)
       store.load_cache
       @stores << store
     end

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -188,7 +188,7 @@ class RDoc::RubyGemsHook
     @rdoc = new_rdoc
     @rdoc.options = options
 
-    store = RDoc::Store.new
+    store = RDoc::Store.new(options)
     store.encoding = options.encoding
     store.dry_run  = options.dry_run
     store.main     = options.main_page

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -188,13 +188,7 @@ class RDoc::RubyGemsHook
     @rdoc = new_rdoc
     @rdoc.options = options
 
-    store = RDoc::Store.new(options)
-    store.encoding = options.encoding
-    store.dry_run  = options.dry_run
-    store.main     = options.main_page
-    store.title    = options.title
-
-    @rdoc.store = store
+    @rdoc.store = RDoc::Store.new(options)
 
     say "Parsing documentation for #{@spec.full_name}"
 

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -291,7 +291,7 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
   def installed_docs
     extra_counter = 0
     ri_paths.map do |path, type|
-      store = RDoc::Store.new path, type
+      store = RDoc::Store.new(path: path, type: type)
       exists = File.exist? store.cache_path
 
       case type
@@ -420,15 +420,15 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
   def store_for source_name
     case source_name
     when 'home' then
-      RDoc::Store.new RDoc::RI::Paths.home_dir, :home
+      RDoc::Store.new(path: RDoc::RI::Paths.home_dir, type: :home)
     when 'ruby' then
-      RDoc::Store.new RDoc::RI::Paths.system_dir, :system
+      RDoc::Store.new(path: RDoc::RI::Paths.system_dir, type: :system)
     when 'site' then
-      RDoc::Store.new RDoc::RI::Paths.site_dir, :site
+      RDoc::Store.new(path: RDoc::RI::Paths.site_dir, type: :site)
     when /\Aextra-(\d+)\z/ then
       index = $1.to_i - 1
       ri_dir = installed_docs[index][4]
-      RDoc::Store.new ri_dir, :extra
+      RDoc::Store.new(path: ri_dir, type: :extra)
     else
       ri_dir, type = ri_paths.find do |dir, dir_type|
         next unless dir_type == :gem
@@ -439,7 +439,7 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
       raise WEBrick::HTTPStatus::NotFound,
             "Could not find gem \"#{ERB::Util.html_escape(source_name)}\". Are you sure you installed it?" unless ri_dir
 
-      store = RDoc::Store.new ri_dir, type
+      store = RDoc::Store.new(path: ri_dir, type: type)
 
       return store if File.exist? store.cache_path
 

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -133,7 +133,7 @@ class RDoc::Servlet < WEBrick::HTTPServlet::AbstractServlet
       show_documentation req, res
     end
   rescue WEBrick::HTTPStatus::NotFound => e
-    generator = generator_for RDoc::Store.new
+    generator = generator_for RDoc::Store.new(@options)
 
     not_found generator, req, res, e.message
   rescue WEBrick::HTTPStatus::Status
@@ -291,7 +291,7 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
   def installed_docs
     extra_counter = 0
     ri_paths.map do |path, type|
-      store = RDoc::Store.new(path: path, type: type)
+      store = RDoc::Store.new(@options, path: path, type: type)
       exists = File.exist? store.cache_path
 
       case type
@@ -420,15 +420,15 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
   def store_for source_name
     case source_name
     when 'home' then
-      RDoc::Store.new(path: RDoc::RI::Paths.home_dir, type: :home)
+      RDoc::Store.new(@options, path: RDoc::RI::Paths.home_dir, type: :home)
     when 'ruby' then
-      RDoc::Store.new(path: RDoc::RI::Paths.system_dir, type: :system)
+      RDoc::Store.new(@options, path: RDoc::RI::Paths.system_dir, type: :system)
     when 'site' then
-      RDoc::Store.new(path: RDoc::RI::Paths.site_dir, type: :site)
+      RDoc::Store.new(@options, path: RDoc::RI::Paths.site_dir, type: :site)
     when /\Aextra-(\d+)\z/ then
       index = $1.to_i - 1
       ri_dir = installed_docs[index][4]
-      RDoc::Store.new(path: ri_dir, type: :extra)
+      RDoc::Store.new(@options, path: ri_dir, type: :extra)
     else
       ri_dir, type = ri_paths.find do |dir, dir_type|
         next unless dir_type == :gem
@@ -439,7 +439,7 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
       raise WEBrick::HTTPStatus::NotFound,
             "Could not find gem \"#{ERB::Util.html_escape(source_name)}\". Are you sure you installed it?" unless ri_dir
 
-      store = RDoc::Store.new(path: ri_dir, type: type)
+      store = RDoc::Store.new(@options, path: ri_dir, type: type)
 
       return store if File.exist? store.cache_path
 

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -121,11 +121,11 @@ class RDoc::Store
   # Creates a new Store of +type+ that will load or save to +path+
 
   def initialize(options, path: nil, type: nil)
-    @dry_run  = false
-    @encoding = nil
-    @path     = path
-    @type     = type
     @options  = options
+    @dry_run  = options.dry_run
+    @encoding = options.encoding
+    @path     = path || options.op_dir
+    @type     = type
 
     @cache = {
       :ancestors                   => {},
@@ -135,10 +135,10 @@ class RDoc::Store
       :c_singleton_class_variables => {},
       :encoding                    => @encoding,
       :instance_methods            => {},
-      :main                        => nil,
+      :main                        => options.main_page,
       :modules                     => [],
       :pages                       => [],
-      :title                       => nil,
+      :title                       => options.title,
     }
 
     @classes_hash = {}

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -120,7 +120,7 @@ class RDoc::Store
   ##
   # Creates a new Store of +type+ that will load or save to +path+
 
-  def initialize path = nil, type = nil
+  def initialize path: nil, type: nil
     @dry_run  = false
     @encoding = nil
     @path     = path

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -94,7 +94,7 @@ class RDoc::Store
 
   attr_accessor :path
 
-  attr_writer :rdoc
+  attr_reader :options
 
   ##
   # Type of ri datastore this was loaded from.  See RDoc::RI::Driver,
@@ -120,12 +120,12 @@ class RDoc::Store
   ##
   # Creates a new Store of +type+ that will load or save to +path+
 
-  def initialize path: nil, type: nil
+  def initialize(options, path: nil, type: nil)
     @dry_run  = false
     @encoding = nil
     @path     = path
-    @rdoc     = nil
     @type     = type
+    @options  = options
 
     @cache = {
       :ancestors                   => {},
@@ -975,10 +975,6 @@ class RDoc::Store
 
   def unique_modules
     @unique_modules
-  end
-
-  def options
-    @rdoc&.options
   end
 
   private

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -47,11 +47,12 @@ class RDoc::TestCase < Test::Unit::TestCase
 
     @pwd = Dir.pwd
 
-    @store = RDoc::Store.new
+    @options = RDoc::Options.new
+    @store = RDoc::Store.new(@options)
 
     @rdoc = RDoc::RDoc.new
     @rdoc.store = @store
-    @rdoc.options = RDoc::Options.new
+    @rdoc.options = @options
 
     @rdoc.generator = Object.new
 

--- a/test/rdoc/test_rdoc_any_method.rb
+++ b/test/rdoc/test_rdoc_any_method.rb
@@ -180,7 +180,7 @@ each_line(foo)
 <span class="ruby-constant">B</span>
     EXPECTED
 
-    @options.line_numbers = true
+    @c2_a.options.line_numbers = true
     assert_equal <<-EXPECTED.chomp, @c2_a.markup_code
   <span class="ruby-comment"># File xref_data.rb</span>
 <span class="line-num">1</span> <span class="ruby-constant">A</span>

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -791,7 +791,7 @@ class TestRDocClassModule < XrefTestCase
     const = cm1.add_constant RDoc::Constant.new('C3', nil, 'one')
     const.record_location tl1
 
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
     tl = store.add_file 'one.rb'
     cm2 = tl.add_class RDoc::ClassModule, 'Klass'
     cm2.instance_variable_set :@comment, @RM::Document.new
@@ -826,7 +826,7 @@ class TestRDocClassModule < XrefTestCase
     const = cm1.add_constant RDoc::Constant.new('C3', nil, 'one')
     const.record_location tl1
 
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
     tl = store.add_file 'one.rb'
     cm2 = tl.add_class RDoc::ClassModule, 'Klass'
     cm2.instance_variable_set :@comment, @RM::Document.new
@@ -859,7 +859,7 @@ class TestRDocClassModule < XrefTestCase
     ext.record_location tl1
 
     tl2 = @store.add_file 'two.rb'
-    tl2.store = RDoc::Store.new
+    tl2.store = RDoc::Store.new(RDoc::Options.new)
 
     cm2 = tl2.add_class RDoc::ClassModule, 'Klass'
     cm2.instance_variable_set :@comment, @RM::Document.new
@@ -895,7 +895,7 @@ class TestRDocClassModule < XrefTestCase
     incl.record_location tl1
 
     tl2 = @store.add_file 'two.rb'
-    tl2.store = RDoc::Store.new
+    tl2.store = RDoc::Store.new(RDoc::Options.new)
 
     cm2 = tl2.add_class RDoc::ClassModule, 'Klass'
     cm2.instance_variable_set :@comment, @RM::Document.new
@@ -931,7 +931,7 @@ class TestRDocClassModule < XrefTestCase
     incl.record_location tl1
 
     tl2 = @store.add_file 'one.rb'
-    tl2.store = RDoc::Store.new
+    tl2.store = RDoc::Store.new(RDoc::Options.new)
 
     cm2 = tl2.add_class RDoc::ClassModule, 'Klass'
     cm2.instance_variable_set :@comment, @RM::Document.new
@@ -1034,7 +1034,7 @@ class TestRDocClassModule < XrefTestCase
            cm1.add_section 'section 2', comment('comment 2 a', tl1_1)
            cm1.add_section 'section 4', comment('comment 4 a', tl1_1)
 
-    store2 = RDoc::Store.new
+    store2 = RDoc::Store.new(RDoc::Options.new)
     tl2_1 = store2.add_file 'one.rb'
     tl2_2 = store2.add_file 'two.rb'
 
@@ -1086,7 +1086,7 @@ class TestRDocClassModule < XrefTestCase
     cm1.add_section 'section', comment('comment 1 a', tl1_1)
     cm1.add_section 'section', comment('comment 3',   tl1_3)
 
-    store2 = RDoc::Store.new
+    store2 = RDoc::Store.new(RDoc::Options.new)
     tl2_1 = store2.add_file 'one.rb'
     tl2_2 = store2.add_file 'two.rb'
     tl2_3 = store2.add_file 'three.rb'
@@ -1382,7 +1382,7 @@ class TestRDocClassModule < XrefTestCase
   end
 
   def test_update_aliases_reparent_root
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
 
     top_level = store.add_file 'file.rb'
 

--- a/test/rdoc/test_rdoc_code_object.rb
+++ b/test/rdoc/test_rdoc_code_object.rb
@@ -275,14 +275,6 @@ class TestRDocCodeObject < XrefTestCase
     assert_equal 'not_rdoc', @co.metadata['markup']
   end
 
-  def test_options
-    assert_kind_of RDoc::Options, @co.options
-
-    @co.store = @store
-
-    assert_same @options, @co.options
-  end
-
   def test_parent_file_name
     assert_equal '(unknown)', @co.parent_file_name
     assert_equal 'xref_data.rb', @c1.parent_file_name

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -290,7 +290,7 @@ class TestRDocContext < XrefTestCase
   end
 
   def test_add_module_alias_top_level
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
 
     top_level = store.add_file 'file.rb'
 

--- a/test/rdoc/test_rdoc_generator_ri.rb
+++ b/test/rdoc/test_rdoc_generator_ri.rb
@@ -52,7 +52,7 @@ class TestRDocGeneratorRI < RDoc::TestCase
     assert_file File.join(@tmpdir, 'Object', 'method-i.ri')
     assert_file File.join(@tmpdir, 'Object', 'method%21-i.ri')
 
-    store = RDoc::RI::Store.new @tmpdir
+    store = RDoc::RI::Store.new(path: @tmpdir)
     store.load_cache
 
     encoding = Encoding::UTF_8

--- a/test/rdoc/test_rdoc_generator_ri.rb
+++ b/test/rdoc/test_rdoc_generator_ri.rb
@@ -52,7 +52,7 @@ class TestRDocGeneratorRI < RDoc::TestCase
     assert_file File.join(@tmpdir, 'Object', 'method-i.ri')
     assert_file File.join(@tmpdir, 'Object', 'method%21-i.ri')
 
-    store = RDoc::RI::Store.new(path: @tmpdir)
+    store = RDoc::RI::Store.new(@options, path: @tmpdir)
     store.load_cache
 
     encoding = Encoding::UTF_8

--- a/test/rdoc/test_rdoc_method_attr.rb
+++ b/test/rdoc/test_rdoc_method_attr.rb
@@ -185,8 +185,7 @@ class TestRDocMethodAttr < XrefTestCase
 
   def test_pretty_print
     temp_dir do |tmpdir|
-      s = RDoc::RI::Store.new(path: tmpdir)
-      s.rdoc = @rdoc
+      s = RDoc::RI::Store.new(RDoc::Options.new, path: tmpdir)
 
       top_level = s.add_file 'file.rb'
       meth_bang = RDoc::AnyMethod.new nil, 'method!'

--- a/test/rdoc/test_rdoc_method_attr.rb
+++ b/test/rdoc/test_rdoc_method_attr.rb
@@ -185,7 +185,7 @@ class TestRDocMethodAttr < XrefTestCase
 
   def test_pretty_print
     temp_dir do |tmpdir|
-      s = RDoc::RI::Store.new tmpdir
+      s = RDoc::RI::Store.new(path: tmpdir)
       s.rdoc = @rdoc
 
       top_level = s.add_file 'file.rb'

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -7,7 +7,8 @@ class TestRDocRDoc < RDoc::TestCase
     super
 
     @rdoc = RDoc::RDoc.new
-    @rdoc.options = RDoc::Options.new
+    @options = RDoc::Options.new
+    @rdoc.options = @options
 
     @stats = RDoc::Stats.new @store, 0, 0
     @rdoc.instance_variable_set :@stats, @stats
@@ -244,7 +245,7 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     temp_dir do |dir|
       @rdoc.options.root = Pathname(Dir.pwd)
@@ -261,7 +262,7 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file_binary
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     root = File.dirname __FILE__
 
@@ -278,7 +279,7 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file_include_root
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     test_path = File.expand_path('..', __FILE__)
     top_level = nil
@@ -300,7 +301,7 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file_page_dir
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     temp_dir do |dir|
       FileUtils.mkdir 'pages'
@@ -321,7 +322,7 @@ class TestRDocRDoc < RDoc::TestCase
   def test_parse_file_relative
     pwd = Dir.pwd
 
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     temp_dir do |dir|
       @rdoc.options.root = Pathname(dir)
@@ -343,7 +344,7 @@ class TestRDocRDoc < RDoc::TestCase
 
   def test_parse_file_encoding
     @rdoc.options.encoding = Encoding::ISO_8859_1
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     tf = Tempfile.open 'test.txt' do |io|
       io.write 'hi'
@@ -361,7 +362,7 @@ class TestRDocRDoc < RDoc::TestCase
     omit 'chmod not supported' if Gem.win_platform?
     omit "assumes that euid is not root" if Process.euid == 0
 
-    @rdoc.store = RDoc::Store.new
+    @rdoc.store = RDoc::Store.new(@options)
 
     tf = Tempfile.open 'test.txt' do |io|
       io.write 'hi'

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -460,7 +460,7 @@ class RDocRIDriverTest < RDoc::TestCase
     #
     # Y is not chosen randomly, it has to be after Object in the alphabet
     # to reproduce https://github.com/ruby/rdoc/issues/814.
-    store = RDoc::RI::Store.new @home_ri
+    store = RDoc::RI::Store.new(path: @home_ri)
     store.cache[:ancestors] = { "Z" => ["Object", "Y"], "Y" => ["X"] }
     store.cache[:modules] = %W[X Y Z]
     @driver.stores = [store]
@@ -538,7 +538,7 @@ class RDocRIDriverTest < RDoc::TestCase
   end
 
   def test_complete
-    store = RDoc::RI::Store.new @home_ri
+    store = RDoc::RI::Store.new(path: @home_ri)
     store.cache[:ancestors] = {
       'Foo'      => %w[Object],
       'Foo::Bar' => %w[Object],
@@ -963,7 +963,7 @@ Foo::Bar#bother
   end
 
   def test_expand_class_2
-    @store1 = RDoc::RI::Store.new @home_ri, :home
+    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 
@@ -981,7 +981,7 @@ Foo::Bar#bother
   end
 
   def test_expand_class_3
-    @store1 = RDoc::RI::Store.new @home_ri, :home
+    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 
@@ -1007,7 +1007,7 @@ Foo::Bar#bother
 
     assert_equal 'Z', e.name
 
-    @driver.stores << RDoc::Store.new(nil, :system)
+    @driver.stores << RDoc::Store.new(path: nil, type: :system)
 
     assert_equal 'ruby:README', @driver.expand_name('ruby:README')
     assert_equal 'ruby:',       @driver.expand_name('ruby:')
@@ -1084,8 +1084,8 @@ Foo::Bar#bother
   end
 
   def test_find_store
-    @driver.stores << RDoc::Store.new(nil,              :system)
-    @driver.stores << RDoc::Store.new('doc/gem-1.0/ri', :gem)
+    @driver.stores << RDoc::Store.new(path: nil, type: :system)
+    @driver.stores << RDoc::Store.new(path: 'doc/gem-1.0/ri', type: :gem)
 
     assert_equal 'ruby',    @driver.find_store('ruby')
     assert_equal 'gem-1.0', @driver.find_store('gem-1.0')
@@ -1466,7 +1466,7 @@ Foo::Bar#bother
   end
 
   def util_ancestors_store
-    store1 = RDoc::RI::Store.new @home_ri
+    store1 = RDoc::RI::Store.new(path: @home_ri)
     store1.cache[:ancestors] = {
       'Foo'      => %w[Object],
       'Foo::Bar' => %w[Foo],
@@ -1483,7 +1483,7 @@ Foo::Bar#bother
       Foo::Bar
     ]
 
-    store2 = RDoc::RI::Store.new @home_ri
+    store2 = RDoc::RI::Store.new(path: @home_ri)
     store2.cache[:ancestors] = {
       'Foo'    => %w[Mixin Object],
       'Mixin'  => %w[],
@@ -1514,7 +1514,7 @@ Foo::Bar#bother
     util_store
 
     @home_ri2 = "#{@home_ri}2"
-    @store2 = RDoc::RI::Store.new @home_ri2
+    @store2 = RDoc::RI::Store.new(path: @home_ri2)
 
     @top_level = @store2.add_file 'file.rb'
 
@@ -1539,7 +1539,7 @@ Foo::Bar#bother
   end
 
   def util_store
-    @store1 = RDoc::RI::Store.new @home_ri, :home
+    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -23,6 +23,7 @@ class RDocRIDriverTest < RDoc::TestCase
     @options[:home]       = @rdoc_home
     @options[:use_stdout] = true
     @options[:formatter]  = @RM::ToRdoc
+    @rdoc_options = RDoc::Options.new
 
     @driver = RDoc::RI::Driver.new @options
   end
@@ -460,7 +461,7 @@ class RDocRIDriverTest < RDoc::TestCase
     #
     # Y is not chosen randomly, it has to be after Object in the alphabet
     # to reproduce https://github.com/ruby/rdoc/issues/814.
-    store = RDoc::RI::Store.new(path: @home_ri)
+    store = RDoc::RI::Store.new(@rdoc_options, path: @home_ri)
     store.cache[:ancestors] = { "Z" => ["Object", "Y"], "Y" => ["X"] }
     store.cache[:modules] = %W[X Y Z]
     @driver.stores = [store]
@@ -538,7 +539,7 @@ class RDocRIDriverTest < RDoc::TestCase
   end
 
   def test_complete
-    store = RDoc::RI::Store.new(path: @home_ri)
+    store = RDoc::RI::Store.new(@rdoc_options, path: @home_ri)
     store.cache[:ancestors] = {
       'Foo'      => %w[Object],
       'Foo::Bar' => %w[Object],
@@ -963,7 +964,7 @@ Foo::Bar#bother
   end
 
   def test_expand_class_2
-    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
+    @store1 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 
@@ -981,7 +982,7 @@ Foo::Bar#bother
   end
 
   def test_expand_class_3
-    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
+    @store1 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 
@@ -1007,7 +1008,7 @@ Foo::Bar#bother
 
     assert_equal 'Z', e.name
 
-    @driver.stores << RDoc::Store.new(path: nil, type: :system)
+    @driver.stores << RDoc::Store.new(@rdoc_options, path: nil, type: :system)
 
     assert_equal 'ruby:README', @driver.expand_name('ruby:README')
     assert_equal 'ruby:',       @driver.expand_name('ruby:')
@@ -1084,8 +1085,8 @@ Foo::Bar#bother
   end
 
   def test_find_store
-    @driver.stores << RDoc::Store.new(path: nil, type: :system)
-    @driver.stores << RDoc::Store.new(path: 'doc/gem-1.0/ri', type: :gem)
+    @driver.stores << RDoc::Store.new(@rdoc_options, path: nil, type: :system)
+    @driver.stores << RDoc::Store.new(@rdoc_options, path: 'doc/gem-1.0/ri', type: :gem)
 
     assert_equal 'ruby',    @driver.find_store('ruby')
     assert_equal 'gem-1.0', @driver.find_store('gem-1.0')
@@ -1466,7 +1467,7 @@ Foo::Bar#bother
   end
 
   def util_ancestors_store
-    store1 = RDoc::RI::Store.new(path: @home_ri)
+    store1 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri)
     store1.cache[:ancestors] = {
       'Foo'      => %w[Object],
       'Foo::Bar' => %w[Foo],
@@ -1483,7 +1484,7 @@ Foo::Bar#bother
       Foo::Bar
     ]
 
-    store2 = RDoc::RI::Store.new(path: @home_ri)
+    store2 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri)
     store2.cache[:ancestors] = {
       'Foo'    => %w[Mixin Object],
       'Mixin'  => %w[],
@@ -1514,7 +1515,7 @@ Foo::Bar#bother
     util_store
 
     @home_ri2 = "#{@home_ri}2"
-    @store2 = RDoc::RI::Store.new(path: @home_ri2)
+    @store2 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri2)
 
     @top_level = @store2.add_file 'file.rb'
 
@@ -1539,7 +1540,7 @@ Foo::Bar#bother
   end
 
   def util_store
-    @store1 = RDoc::RI::Store.new(path: @home_ri, type: :home)
+    @store1 = RDoc::RI::Store.new(@rdoc_options, path: @home_ri, type: :home)
 
     @top_level = @store1.add_file 'file.rb'
 

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -1008,7 +1008,7 @@ Foo::Bar#bother
 
     assert_equal 'Z', e.name
 
-    @driver.stores << RDoc::Store.new(@rdoc_options, path: nil, type: :system)
+    @driver.stores << RDoc::Store.new(@rdoc_options, type: :system)
 
     assert_equal 'ruby:README', @driver.expand_name('ruby:README')
     assert_equal 'ruby:',       @driver.expand_name('ruby:')
@@ -1085,7 +1085,7 @@ Foo::Bar#bother
   end
 
   def test_find_store
-    @driver.stores << RDoc::Store.new(@rdoc_options, path: nil, type: :system)
+    @driver.stores << RDoc::Store.new(@rdoc_options, type: :system)
     @driver.stores << RDoc::Store.new(@rdoc_options, path: 'doc/gem-1.0/ri', type: :gem)
 
     assert_equal 'ruby',    @driver.find_store('ruby')

--- a/test/rdoc/test_rdoc_rubygems_hook.rb
+++ b/test/rdoc/test_rdoc_rubygems_hook.rb
@@ -94,7 +94,7 @@ class TestRDocRubyGemsHook < Test::Unit::TestCase
     options.files = []
 
     rdoc = @hook.new_rdoc
-    rdoc.store = RDoc::Store.new
+    rdoc.store = RDoc::Store.new(options)
     @hook.instance_variable_set :@rdoc, rdoc
     @hook.instance_variable_set :@file_info, []
 

--- a/test/rdoc/test_rdoc_servlet.rb
+++ b/test/rdoc/test_rdoc_servlet.rb
@@ -45,6 +45,7 @@ class TestRDocServlet < RDoc::TestCase
     @system_dir  = File.join @tempdir, 'base', 'system'
     @home_dir    = File.join @tempdir, 'home'
     @gem_doc_dir = File.join @tempdir, 'doc'
+    @options     = RDoc::Options.new
 
     @orig_base = RDoc::RI::Paths::BASE
     RDoc::RI::Paths::BASE.replace @base
@@ -199,7 +200,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_documentation_page_class
-    store = RDoc::Store.new
+    store = RDoc::Store.new(@options)
 
     generator = @s.generator_for store
 
@@ -214,7 +215,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_documentation_page_not_found
-    store = RDoc::Store.new
+    store = RDoc::Store.new(@options)
 
     generator = @s.generator_for store
 
@@ -226,7 +227,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_documentation_page_page
-    store = RDoc::Store.new
+    store = RDoc::Store.new(@options)
 
     generator = @s.generator_for store
 
@@ -239,7 +240,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_documentation_page_page_with_nesting
-    store = RDoc::Store.new
+    store = RDoc::Store.new(@options)
 
     generator = @s.generator_for store
 
@@ -259,7 +260,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_documentation_source_cached
-    cached_store = RDoc::Store.new
+    cached_store = RDoc::Store.new(@options)
 
     @stores['ruby'] = cached_store
 
@@ -282,7 +283,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_generator_for
-    store = RDoc::Store.new
+    store = RDoc::Store.new(@options)
     store.main  = 'MAIN_PAGE.rdoc'
     store.title = 'Title'
 
@@ -349,7 +350,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_not_found
-    generator = @s.generator_for RDoc::Store.new
+    generator = @s.generator_for RDoc::Store.new(@options)
 
     @req.path = '/ruby/Missing.html'
 
@@ -361,7 +362,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def test_not_found_message
-    generator = @s.generator_for RDoc::Store.new
+    generator = @s.generator_for RDoc::Store.new(@options)
 
     @req.path = '/ruby/Missing.html'
 
@@ -532,7 +533,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def touch_system_cache_path
-    store = RDoc::Store.new(path: @system_dir)
+    store = RDoc::Store.new(@options, path: @system_dir)
     store.title = 'Standard Library Documentation'
 
     FileUtils.mkdir_p File.dirname store.cache_path
@@ -541,7 +542,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def touch_extra_cache_path
-    store = RDoc::Store.new(path: @extra_dirs.first)
+    store = RDoc::Store.new(@options, path: @extra_dirs.first)
     store.title = 'My Extra Documentation'
 
     FileUtils.mkdir_p File.dirname store.cache_path

--- a/test/rdoc/test_rdoc_servlet.rb
+++ b/test/rdoc/test_rdoc_servlet.rb
@@ -532,7 +532,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def touch_system_cache_path
-    store = RDoc::Store.new @system_dir
+    store = RDoc::Store.new(path: @system_dir)
     store.title = 'Standard Library Documentation'
 
     FileUtils.mkdir_p File.dirname store.cache_path
@@ -541,7 +541,7 @@ class TestRDocServlet < RDoc::TestCase
   end
 
   def touch_extra_cache_path
-    store = RDoc::Store.new @extra_dirs.first
+    store = RDoc::Store.new(path: @extra_dirs.first)
     store.title = 'My Extra Documentation'
 
     FileUtils.mkdir_p File.dirname store.cache_path

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -9,8 +9,7 @@ class TestRDocStore < XrefTestCase
     super
 
     @tmpdir = File.join Dir.tmpdir, "test_rdoc_ri_store_#{$$}"
-    @s = RDoc::RI::Store.new(path: @tmpdir)
-    @s.rdoc = @rdoc
+    @s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
 
     @top_level = @s.add_file 'file.rb'
 
@@ -397,7 +396,7 @@ class TestRDocStore < XrefTestCase
 
     @s.save
 
-    s = RDoc::Store.new(path: @tmpdir)
+    s = RDoc::Store.new(RDoc::Options.new, path: @tmpdir)
 
     s.load_all
 
@@ -838,13 +837,13 @@ class TestRDocStore < XrefTestCase
     meth.record_location @top_level
 
     # load original, save newly updated class
-    @s = RDoc::RI::Store.new(path: @tmpdir)
+    @s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
     @s.load_cache
     @s.save_class klass
     @s.save_cache
 
     # load from disk again
-    @s = RDoc::RI::Store.new(path: @tmpdir)
+    @s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
     @s.load_cache
 
     @s.load_class 'Object'
@@ -882,7 +881,7 @@ class TestRDocStore < XrefTestCase
     assert_file @s.method_file(@klass.full_name, @meth.full_name)
     assert_file @s.method_file(@klass.full_name, @meth_bang.full_name)
 
-    s = RDoc::Store.new(path: @s.path)
+    s = RDoc::Store.new(RDoc::Options.new, path: @s.path)
     s.load_cache
 
     loaded = s.load_class 'Object'
@@ -891,7 +890,7 @@ class TestRDocStore < XrefTestCase
 
     s.save_class loaded
 
-    s = RDoc::Store.new(path: @s.path)
+    s = RDoc::Store.new(RDoc::Options.new, path: @s.path)
     s.load_cache
 
     reloaded = s.load_class 'Object'
@@ -911,10 +910,10 @@ class TestRDocStore < XrefTestCase
     klass = RDoc::NormalClass.new 'Object'
     klass.add_comment 'new comment', @top_level
 
-    s = RDoc::RI::Store.new(path: @tmpdir)
+    s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
     s.save_class klass
 
-    s = RDoc::RI::Store.new(path: @tmpdir)
+    s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
 
     inner = @RM::Document.new @RM::Paragraph.new 'new comment'
     inner.file = @top_level
@@ -926,7 +925,7 @@ class TestRDocStore < XrefTestCase
 
   # This is a functional test
   def test_save_class_merge_constant
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
     tl = store.add_file 'file.rb'
 
     klass = tl.add_class RDoc::NormalClass, 'C'
@@ -938,16 +937,16 @@ class TestRDocStore < XrefTestCase
     @s.save_class klass
 
     # separate parse run, independent store
-    store = RDoc::Store.new
+    store = RDoc::Store.new(RDoc::Options.new)
     tl = store.add_file 'file.rb'
     klass2 = tl.add_class RDoc::NormalClass, 'C'
     klass2.record_location tl
 
-    s = RDoc::RI::Store.new(path: @tmpdir)
+    s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
     s.save_class klass2
 
     # separate `ri` run, independent store
-    s = RDoc::RI::Store.new(path: @tmpdir)
+    s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
 
     result = s.load_class 'C'
 

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -90,7 +90,7 @@ class TestRDocStore < XrefTestCase
       :class_methods               => cmethods,
       :c_class_variables           => {},
       :c_singleton_class_variables => {},
-      :encoding                    => nil,
+      :encoding                    => Encoding::UTF_8,
       :instance_methods            => imethods,
       :modules                     => modules,
       :pages                       => pages,
@@ -447,6 +447,10 @@ class TestRDocStore < XrefTestCase
       Marshal.dump cache, io
     end
 
+    # Store prioritize @encoding over the cached value
+    # See we need to unset @encoding to test the cached value
+    @s.encoding = nil
+
     @s.load_cache
 
     assert_equal cache, @s.cache
@@ -497,7 +501,7 @@ class TestRDocStore < XrefTestCase
       :class_methods               => {},
       :c_class_variables           => {},
       :c_singleton_class_variables => {},
-      :encoding                    => nil,
+      :encoding                    => Encoding::UTF_8,
       :instance_methods            => {},
       :main                        => nil,
       :modules                     => [],
@@ -529,6 +533,10 @@ class TestRDocStore < XrefTestCase
     File.open File.join(@tmpdir, 'cache.ri'), 'wb' do |io|
       Marshal.dump cache, io
     end
+
+    # Store prioritize @encoding over the cached value
+    # See we need to unset @encoding to test the cached value
+    @s.encoding = nil
 
     @s.load_cache
 
@@ -685,7 +693,7 @@ class TestRDocStore < XrefTestCase
       },
       :main => nil,
       :modules => %w[Mod Object Object::SubClass],
-      :encoding => nil,
+      :encoding => Encoding::UTF_8,
       :pages => %w[README.txt],
       :title => nil,
     }

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -9,7 +9,7 @@ class TestRDocStore < XrefTestCase
     super
 
     @tmpdir = File.join Dir.tmpdir, "test_rdoc_ri_store_#{$$}"
-    @s = RDoc::RI::Store.new @tmpdir
+    @s = RDoc::RI::Store.new(path: @tmpdir)
     @s.rdoc = @rdoc
 
     @top_level = @s.add_file 'file.rb'
@@ -397,7 +397,7 @@ class TestRDocStore < XrefTestCase
 
     @s.save
 
-    s = RDoc::Store.new @tmpdir
+    s = RDoc::Store.new(path: @tmpdir)
 
     s.load_all
 
@@ -838,13 +838,13 @@ class TestRDocStore < XrefTestCase
     meth.record_location @top_level
 
     # load original, save newly updated class
-    @s = RDoc::RI::Store.new @tmpdir
+    @s = RDoc::RI::Store.new(path: @tmpdir)
     @s.load_cache
     @s.save_class klass
     @s.save_cache
 
     # load from disk again
-    @s = RDoc::RI::Store.new @tmpdir
+    @s = RDoc::RI::Store.new(path: @tmpdir)
     @s.load_cache
 
     @s.load_class 'Object'
@@ -882,7 +882,7 @@ class TestRDocStore < XrefTestCase
     assert_file @s.method_file(@klass.full_name, @meth.full_name)
     assert_file @s.method_file(@klass.full_name, @meth_bang.full_name)
 
-    s = RDoc::Store.new @s.path
+    s = RDoc::Store.new(path: @s.path)
     s.load_cache
 
     loaded = s.load_class 'Object'
@@ -891,7 +891,7 @@ class TestRDocStore < XrefTestCase
 
     s.save_class loaded
 
-    s = RDoc::Store.new @s.path
+    s = RDoc::Store.new(path: @s.path)
     s.load_cache
 
     reloaded = s.load_class 'Object'
@@ -911,10 +911,10 @@ class TestRDocStore < XrefTestCase
     klass = RDoc::NormalClass.new 'Object'
     klass.add_comment 'new comment', @top_level
 
-    s = RDoc::RI::Store.new @tmpdir
+    s = RDoc::RI::Store.new(path: @tmpdir)
     s.save_class klass
 
-    s = RDoc::RI::Store.new @tmpdir
+    s = RDoc::RI::Store.new(path: @tmpdir)
 
     inner = @RM::Document.new @RM::Paragraph.new 'new comment'
     inner.file = @top_level
@@ -943,11 +943,11 @@ class TestRDocStore < XrefTestCase
     klass2 = tl.add_class RDoc::NormalClass, 'C'
     klass2.record_location tl
 
-    s = RDoc::RI::Store.new @tmpdir
+    s = RDoc::RI::Store.new(path: @tmpdir)
     s.save_class klass2
 
     # separate `ri` run, independent store
-    s = RDoc::RI::Store.new @tmpdir
+    s = RDoc::RI::Store.new(path: @tmpdir)
 
     result = s.load_class 'C'
 


### PR DESCRIPTION
Since `Store` relies on accessing `Options` for various tasks, it should simply hold a reference to the `Options` object itself, instead of accessing it through an `RDoc` instance and forming an unnecessary coupling.

This PR requires `Store` to be initialized with an `Options` instance.