### PR TITLE
Remove dead or unnecessary methods/attributes

### DIFF
--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -218,20 +218,6 @@ class RDoc::CodeObject
   end
 
   ##
-  # Yields each parent of this CodeObject.  See also
-  # RDoc::ClassModule#each_ancestor
-
-  def each_parent
-    code_object = self
-
-    while code_object = code_object.parent do
-      yield code_object
-    end
-
-    self
-  end
-
-  ##
   # File name where this CodeObject was found.
   #
   # See also RDoc::Context#in_files

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -91,13 +91,6 @@ class RDoc::CodeObject
   attr_reader :store
 
   ##
-  # We are the model of the code, but we know that at some point we will be
-  # worked on by viewers. By implementing the Viewable protocol, viewers can
-  # associated themselves with these objects.
-
-  attr_accessor :viewer
-
-  ##
   # When mixed-in to a class, this points to the Context in which it was originally defined.
 
   attr_accessor :mixin_from

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -314,13 +314,6 @@ class RDoc::CodeObject
   end
 
   ##
-  # File name of our parent
-
-  def parent_file_name
-    @parent ? @parent.base_name : '(unknown)'
-  end
-
-  ##
   # Name of our parent
 
   def parent_name

--- a/lib/rdoc/code_object/alias.rb
+++ b/lib/rdoc/code_object/alias.rb
@@ -60,13 +60,6 @@ class RDoc::Alias < RDoc::CodeObject
   end
 
   ##
-  # Full old name including namespace
-
-  def full_old_name
-    @full_name || "#{parent.name}#{pretty_old_name}"
-  end
-
-  ##
   # HTML id-friendly version of +#new_name+.
 
   def html_name

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -56,7 +56,6 @@ class RDoc::ClassModule < RDoc::Context
 
     klass.parent = mod.parent
     klass.section = mod.section
-    klass.viewer = mod.viewer
 
     klass.attributes.concat mod.attributes
     klass.method_list.concat mod.method_list

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -34,8 +34,6 @@ class RDoc::ClassModule < RDoc::Context
 
   attr_accessor :comment_location
 
-  attr_accessor :diagram # :nodoc:
-
   ##
   # Class or module this constant is an alias for
 
@@ -109,7 +107,6 @@ class RDoc::ClassModule < RDoc::Context
 
   def initialize(name, superclass = nil)
     @constant_aliases = []
-    @diagram          = nil
     @is_alias_for     = nil
     @name             = name
     @superclass       = superclass

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -848,13 +848,6 @@ class RDoc::Context < RDoc::CodeObject
   end
 
   ##
-  # Finds a file with +name+ in this context
-
-  def find_file_named name
-    @store.find_file_named name
-  end
-
-  ##
   # Finds an instance method with +name+ in this context
 
   def find_instance_method_named(name)
@@ -871,7 +864,7 @@ class RDoc::Context < RDoc::CodeObject
     find_attribute_named(symbol) or
     find_external_alias_named(symbol) or
     find_module_named(symbol) or
-    find_file_named(symbol)
+    @store.find_file_named(symbol)
   end
 
   ##

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -714,38 +714,10 @@ class RDoc::Context < RDoc::CodeObject
   end
 
   ##
-  # Iterator for attributes
-
-  def each_attribute # :yields: attribute
-    @attributes.each { |a| yield a }
-  end
-
-  ##
   # Iterator for classes and modules
 
   def each_classmodule(&block) # :yields: module
     classes_and_modules.sort.each(&block)
-  end
-
-  ##
-  # Iterator for constants
-
-  def each_constant # :yields: constant
-    @constants.each {|c| yield c}
-  end
-
-  ##
-  # Iterator for included modules
-
-  def each_include # :yields: include
-    @includes.each do |i| yield i end
-  end
-
-  ##
-  # Iterator for extension modules
-
-  def each_extend # :yields: extend
-    @extends.each do |e| yield e end
   end
 
   ##

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -688,13 +688,6 @@ class RDoc::Context < RDoc::CodeObject
     section
   end
 
-  ##
-  # Is part of this thing was defined in +file+?
-
-  def defined_in?(file)
-    @in_files.include?(file)
-  end
-
   def display(method_attr) # :nodoc:
     if method_attr.is_a? RDoc::Attr
       "#{method_attr.definition} #{method_attr.pretty_name}"

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -314,19 +314,6 @@ class RDoc::MethodAttr < RDoc::CodeObject
   end
 
   ##
-  # Name for output to HTML.  For class methods the full name with a "." is
-  # used like +SomeClass.method_name+.  For instance methods the class name is
-  # used if +context+ does not match the parent.
-  #
-  # This is to help prevent people from using :: to call class methods.
-
-  def output_name context
-    return "#{name_prefix}#{@name}" if context == parent
-
-    "#{parent_name}#{@singleton ? '.' : '#'}#{@name}"
-  end
-
-  ##
   # Method/attribute name with class/instance indicator
 
   def pretty_name

--- a/lib/rdoc/code_object/require.rb
+++ b/lib/rdoc/code_object/require.rb
@@ -24,7 +24,7 @@ class RDoc::Require < RDoc::CodeObject
       self.class,
       object_id,
       @name,
-      parent_file_name,
+      @parent ? @parent.base_name : '(unknown)'
     ]
   end
 

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -28,8 +28,6 @@ class RDoc::TopLevel < RDoc::Context
 
   attr_reader :classes_or_modules
 
-  attr_accessor :diagram # :nodoc:
-
   ##
   # The parser class that processed this file
 
@@ -46,7 +44,6 @@ class RDoc::TopLevel < RDoc::Context
     @absolute_name = absolute_name
     @relative_name = relative_name
     @file_stat     = File.stat(absolute_name) rescue nil # HACK for testing
-    @diagram       = nil
     @parser        = nil
 
     @classes_or_modules = []

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -7,11 +7,6 @@ class RDoc::TopLevel < RDoc::Context
   MARSHAL_VERSION = 0 # :nodoc:
 
   ##
-  # This TopLevel's File::Stat struct
-
-  attr_accessor :file_stat
-
-  ##
   # Relative name of this file
 
   attr_accessor :relative_name
@@ -43,7 +38,6 @@ class RDoc::TopLevel < RDoc::Context
     @name = nil
     @absolute_name = absolute_name
     @relative_name = relative_name
-    @file_stat     = File.stat(absolute_name) rescue nil # HACK for testing
     @parser        = nil
 
     @classes_or_modules = []
@@ -184,13 +178,6 @@ class RDoc::TopLevel < RDoc::Context
   end
 
   ##
-  # Time this file was last modified, if known
-
-  def last_modified
-    @file_stat ? file_stat.mtime : nil
-  end
-
-  ##
   # Dumps this TopLevel for use by ri.  See also #marshal_load
 
   def marshal_dump
@@ -210,8 +197,6 @@ class RDoc::TopLevel < RDoc::Context
 
     @parser  = array[2]
     @comment = RDoc::Comment.from_document array[3]
-
-    @file_stat          = nil
   end
 
   ##

--- a/lib/rdoc/generator/pot/message_extractor.rb
+++ b/lib/rdoc/generator/pot/message_extractor.rb
@@ -35,11 +35,11 @@ class RDoc::Generator::POT::MessageExtractor
       end
     end
 
-    klass.each_constant do |constant|
+    klass.constants.each do |constant|
       extract_text(constant.comment, constant.full_name)
     end
 
-    klass.each_attribute do |attribute|
+    klass.attributes.each do |attribute|
       extract_text(attribute.comment, attribute.full_name)
     end
 

--- a/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
@@ -3,7 +3,7 @@
   <h3>Extended With Modules</h3>
 
   <ul class="link-list">
-    <%- klass.each_extend do |ext| -%>
+    <%- klass.extends.each do |ext| -%>
   <%- unless String === ext.module then -%>
     <li><a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a>
   <%- else -%>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
@@ -3,7 +3,7 @@
   <h3>Included Modules</h3>
 
   <ul class="link-list">
-  <%- klass.each_include do |inc| -%>
+  <%- klass.includes.each do |inc| -%>
   <%- unless String === inc.module then -%>
     <li><a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a>
   <%- else -%>

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -261,7 +261,7 @@ class RDoc::Stats
 
     report = []
 
-    cm.each_attribute do |attr|
+    cm.attributes.each do |attr|
       next if attr.documented?
       line = attr.line ? ":#{attr.line}" : nil
       report << "  #{attr.definition} :#{attr.name} # in file #{attr.file.full_name}#{line}\n"
@@ -331,7 +331,7 @@ class RDoc::Stats
 
     report = []
 
-    cm.each_constant do |constant|
+    cm.constants.each do |constant|
       # TODO constant aliases are listed in the summary but not reported
       # figure out what to do here
       next if constant.documented? || constant.is_alias_for

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -762,7 +762,7 @@ class RDoc::Store
         save_method klass, method
       end
 
-      klass.each_attribute do |attribute|
+      klass.attributes.each do |attribute|
         save_method klass, attribute
       end
     end

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1474,7 +1474,7 @@ class TestRDocClassModule < XrefTestCase
     @c1.add_extend a
     @c1.add_extend b
     @c1.add_extend c
-    @c1.each_extend do |extend| extend.module end # cache extended modules
+    @c1.extends.each do |extend| extend.module end # cache extended modules
 
     @m1_m2.document_self = nil
     assert @m1_m2.remove_from_documentation?
@@ -1495,7 +1495,7 @@ class TestRDocClassModule < XrefTestCase
 
     @c1.add_extend a
     @c1.add_extend b
-    @c1.each_extend do |extend| extend.module end # cache extended modules
+    @c1.extends.each do |extend| extend.module end # cache extended modules
 
     @c1.update_extends
 
@@ -1510,7 +1510,7 @@ class TestRDocClassModule < XrefTestCase
     @c1.add_extend a
     @c1.add_extend b
     @c1.add_extend c
-    @c1.each_extend do |extend| extend.module end # cache extended modules
+    @c1.extends.each do |extend| extend.module end # cache extended modules
 
     @m1_m2.document_self = nil
     assert @m1_m2.remove_from_documentation?

--- a/test/rdoc/test_rdoc_code_object.rb
+++ b/test/rdoc/test_rdoc_code_object.rb
@@ -201,16 +201,6 @@ class TestRDocCodeObject < XrefTestCase
     refute @co.done_documenting
   end
 
-  def test_each_parent
-    parents = []
-
-    @parent_m.each_parent do |code_object|
-      parents << code_object
-    end
-
-    assert_equal [@parent, @xref_data], parents
-  end
-
   def test_file_name
     assert_nil @co.file_name
 

--- a/test/rdoc/test_rdoc_code_object.rb
+++ b/test/rdoc/test_rdoc_code_object.rb
@@ -265,11 +265,6 @@ class TestRDocCodeObject < XrefTestCase
     assert_equal 'not_rdoc', @co.metadata['markup']
   end
 
-  def test_parent_file_name
-    assert_equal '(unknown)', @co.parent_file_name
-    assert_equal 'xref_data.rb', @c1.parent_file_name
-  end
-
   def test_parent_name
     assert_equal '(unknown)', @co.parent_name
     assert_equal 'xref_data.rb', @c1.parent_name

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -437,12 +437,6 @@ class TestRDocContext < XrefTestCase
     assert_equal default_section, @context.current_section
   end
 
-  def test_defined_in_eh
-    assert @c1.defined_in?(@c1.top_level)
-
-    refute @c1.defined_in?(@store.add_file('name.rb'))
-  end
-
   def test_equals2
     assert_equal @c3,    @c3
     refute_equal @c2,    @c3

--- a/test/rdoc/test_rdoc_context.rb
+++ b/test/rdoc/test_rdoc_context.rb
@@ -538,11 +538,6 @@ class TestRDocContext < XrefTestCase
     assert_equal @c2, @c2_c3.find_enclosing_module_named('C2')
   end
 
-  def test_find_file_named
-    assert_nil               @c1.find_file_named('nonexistent.rb')
-    assert_equal @xref_data, @c1.find_file_named(@file_name)
-  end
-
   def test_find_instance_method_named
     assert_nil @c1.find_instance_method_named('none')
 

--- a/test/rdoc/test_rdoc_method_attr.rb
+++ b/test/rdoc/test_rdoc_method_attr.rb
@@ -124,14 +124,6 @@ class TestRDocMethodAttr < XrefTestCase
     assert_equal @c2_b, @c2_a.is_alias_for
   end
 
-  def test_output_name
-    assert_equal '#m',  @c1_m.output_name(@c1)
-    assert_equal '::m', @c1__m.output_name(@c1)
-
-    assert_equal 'C1#m', @c1_m.output_name(@c2)
-    assert_equal 'C1.m', @c1__m.output_name(@c2)
-  end
-
   def test_search_record
     @c1_m.comment = 'This is a comment.'
 

--- a/test/rdoc/test_rdoc_parser_ruby.rb
+++ b/test/rdoc/test_rdoc_parser_ruby.rb
@@ -1277,7 +1277,6 @@ EOF
     assert_equal @top_level, foo.file
     assert_equal 1,          foo.line
 
-    assert_nil               foo.viewer
     assert_equal true,       foo.document_children
     assert_equal true,       foo.document_self
     assert_equal false,      foo.done_documenting
@@ -1344,7 +1343,6 @@ EOF
     assert_nil                foo.block_params
     assert_nil                foo.call_seq
     assert_nil                foo.is_alias_for
-    assert_nil                foo.viewer
     assert_equal true,        foo.document_children
     assert_equal true,        foo.document_self
     assert_equal '',          foo.params
@@ -1677,7 +1675,6 @@ end
     assert_equal klass,   foo.parent
     assert_equal false,   foo.singleton
     assert_equal 'add_my_method :foo', foo.text
-    assert_nil            foo.viewer
     assert_equal :public, foo.visibility
     assert_equal klass.current_section, foo.section
 
@@ -1878,7 +1875,6 @@ end
     assert_nil              foo.block_params
     assert_nil              foo.call_seq
     assert_nil              foo.is_alias_for
-    assert_nil              foo.viewer
     assert_equal true,      foo.document_children
     assert_equal true,      foo.document_self
     assert_equal '()',      foo.params

--- a/test/rdoc/test_rdoc_top_level.rb
+++ b/test/rdoc/test_rdoc_top_level.rb
@@ -162,14 +162,6 @@ class TestRDocTopLevel < XrefTestCase
     assert_equal 'path_other/level_rb.html', other_level.http_url
   end
 
-  def test_last_modified
-    assert_nil @top_level.last_modified
-    stat = Object.new
-    def stat.mtime() 0 end
-    @top_level.file_stat = stat
-    assert_equal 0, @top_level.last_modified
-  end
-
   def test_marshal_dump
     page = @store.add_file 'README.txt'
     page.parser = RDoc::Parser::Simple


### PR DESCRIPTION
2 types of targets in this PR:
- Completely unused methods (outside of tests, ofc)
- Single-used or unnecessary methods. Like:

```rb
  def each_constant # :yields: constant
    @constants.each {|c| yield c}
  end
```