### PR TITLE
docs(README): fix the example that doesn't work

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,11 +53,8 @@ To generate documentation programmatically:
   gem 'rdoc'
   require 'rdoc/rdoc'
 
-  options = RDoc::Options.new
-  # see RDoc::Options
-
   rdoc = RDoc::RDoc.new
-  rdoc.document options
+  rdoc.document([]) # This generates documentation for all files in the current directory
   # see RDoc::RDoc
 
 You can specify the target files for document generation with +.document+ file in the project root directory.


### PR DESCRIPTION
```ruby
RDoc::RDoc.new.document(RDoc::Options.new)
```

fails with the following error:

```
/Users/okuramasafumi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rdoc-6.12.0/lib/rdoc/options.rb:522:in 'RDoc::Options#check_files': undefined method 'delete_if' for nil (NoMethodError)
```

I think this should be fixed, but for now modifying an example might be enough.