### PR TITLE
Workaround `build` task issue in Ruby core CI

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -50,8 +50,13 @@ jobs:
         with:
           path: ruby/rdoc
       - name: Build RDoc locally
+        # The `build` task provided by `require 'bundler/gem_tasks'` seems to have a bug
+        # as described in https://github.com/rubygems/rubygems/issues/8477
+        # The manual `gem build` and `gem install` are used to work around this issue.
         run: |
           bundle install
+          gem build rdoc.gemspec
+          gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Generate Documentation with RDoc

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           bundle install
           gem build rdoc.gemspec
+          # This gem isn't used for generating Ruby documentation.
+          # This is just for fixing `pkg/rdoc-X.Y.Z.gem` path.
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc


### PR DESCRIPTION
The issue is described in https://github.com/rubygems/rubygems/issues/8477

The issue fails the workflow whenever RDoc's version is bumped as there will then be a mismatch between the target file name and the version that's actually built.

For example:

```
rdoc 6.13.0 built to pkg/rdoc-6.12.0.gem.
```

This commit works around the issue by manually building the gem and installing it locally so the latest installed version will match the version contained in the gemspec file.