### PR TITLE
fix(options): `RDoc::Options` needs to call `parse` for its setup

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -442,7 +442,7 @@ The internal error was:
 
   def document options
     if RDoc::Options === options then
-      @options = options
+      @options = options.parse [] # Some logic only lives in `parse` method such as default generator
     else
       @options = RDoc::Options.load_options
       @options.parse options

--- a/test/rdoc/test_rdoc_rdoc.rb
+++ b/test/rdoc/test_rdoc_rdoc.rb
@@ -14,6 +14,17 @@ class TestRDocRDoc < RDoc::TestCase
     @rdoc.instance_variable_set :@stats, @stats
   end
 
+  def test_document_with_bare_options
+    rdoc = RDoc::RDoc.new
+    options = RDoc::Options.new
+    temp_dir do
+      rdoc.document options
+    end
+    store = rdoc.store
+    assert_equal nil, store.main
+    assert_equal nil, store.title
+  end
+
   def test_document # functional test
     options = RDoc::Options.new
     options.files = [File.expand_path('../xref_data.rb', __FILE__)]


### PR DESCRIPTION
This change workarounds the issue that `RDoc::Options.new` does not work itself without calling `parse` since some important setup logic lives in it.
I believe we can improve this a lot by moving default option setup in `initialize`, for example, but it takes time.
This usage of `RDoc::Options.new` is documented in README, and I believe this workaround solves it quickly and well enough.