### PR TITLE
Allow customizing path prefix through options

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -630,7 +630,9 @@ class RDoc::ClassModule < RDoc::Context
   # Path to this class or module for use with HTML generator output.
 
   def path
-    http_url
+    prefix = options.class_module_path_prefix
+    return http_url unless prefix
+    File.join(prefix, http_url)
   end
 
   ##

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -226,7 +226,9 @@ class RDoc::TopLevel < RDoc::Context
   # Path to this file for use with HTML generator output.
 
   def path
-    http_url
+    prefix = options.file_path_prefix
+    return http_url unless prefix
+    File.join(prefix, http_url)
   end
 
   def pretty_print q # :nodoc:

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -363,6 +363,16 @@ class RDoc::Options
   # Words to be ignored in autolink cross-references
   attr_accessor :autolink_excluded_words
 
+  ##
+  # The prefix to use for class and module page paths
+
+  attr_accessor :class_module_path_prefix
+
+  ##
+  # The prefix to use for file page paths
+
+  attr_accessor :file_path_prefix
+
   def initialize loaded_options = nil # :nodoc:
     init_ivars
     override loaded_options if loaded_options
@@ -417,6 +427,8 @@ class RDoc::Options
     @charset = @encoding.name
     @skip_tests = true
     @apply_default_exclude = true
+    @class_module_path_prefix = nil
+    @file_path_prefix = nil
   end
 
   def init_with map # :nodoc:

--- a/test/rdoc/test_rdoc_class_module.rb
+++ b/test/rdoc/test_rdoc_class_module.rb
@@ -1548,6 +1548,13 @@ class RDocClassModuleTest < XrefTestCase
     assert_equal ["A", "A::B", "A::B::C"], cm3.fully_qualified_nesting_namespaces
   end
 
+  def test_path
+    assert_equal 'C1.html', @c1.path
+
+    @options.class_module_path_prefix = 'class'
+    assert_equal 'class/C1.html', @c1.path
+  end
+
   class RDocClassModuleMixinsTest < XrefTestCase
     def setup
       super

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -87,6 +87,8 @@ class TestRDocOptions < RDoc::TestCase
       'skip_tests'            => true,
       'apply_default_exclude' => true,
       'autolink_excluded_words' => [],
+      'class_module_path_prefix' => nil,
+      'file_path_prefix' => nil,
     }
 
     assert_equal expected, coder

--- a/test/rdoc/test_rdoc_top_level.rb
+++ b/test/rdoc/test_rdoc_top_level.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative 'xref_test_case'
 
-class TestRDocTopLevel < XrefTestCase
+class RDocTopLevelTest < XrefTestCase
 
   def setup
     super
@@ -160,6 +160,13 @@ class TestRDocTopLevel < XrefTestCase
 
     other_level = @store.add_file 'path.other/level.rb'
     assert_equal 'path_other/level_rb.html', other_level.http_url
+  end
+
+  def test_path
+    assert_equal 'path/top_level_rb.html', @top_level.path
+
+    @options.file_path_prefix = 'file'
+    assert_equal 'file/path/top_level_rb.html', @top_level.path
   end
 
   def test_marshal_dump


### PR DESCRIPTION
In https://github.com/ruby/rdoc/pull/1304, I removed the ability to set path prefix through patching Darkfish generator. But it turns out that it's used in `sdoc`.

See https://github.com/ruby/rdoc/pull/1304#issuecomment-2749251458

But the original implementation was brittle and confusing. So instead of just restoring it, I think allowing the customization through options is a better approach.