### PR TITLE
Bump version to v6.13.1

### DIFF
--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -5,6 +5,6 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '6.13.0'
+  VERSION = '6.13.1'
 
 end


### PR DESCRIPTION
Diff: https://github.com/ruby/rdoc/compare/v6.13.0...master

I consider #1330 a fix too because the new options are introduced as an better alternative for a accidental breaking change.