### PR TITLE
Fix RDoc::Options example in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,8 @@ To generate documentation programmatically:
   require 'rdoc/rdoc'
 
   options = RDoc::Options.new
+  options.files = ['a.rb', 'b.rb']
+  options.setup_generator 'darkfish'
   # see RDoc::Options
 
   rdoc = RDoc::RDoc.new


### PR DESCRIPTION
Add minimal option setup(options.files and options.generator) to make the example code work.

https://github.com/ruby/rdoc/pull/1325#discussion_r2009419651
