### PR TITLE
Enable `Style/MethodDefParentheses` rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,14 @@ AllCops:
   TargetRubyVersion: 3.0
   DisabledByDefault: true
   SuggestExtensions: false
+  Exclude:
+    # Exclude files that are auto generated
+    - "lib/rdoc/rd/block_parser.rb"
+    - "lib/rdoc/rd/inline_parser.rb"
+    - "lib/rdoc/markdown.rb"
+    - "lib/rdoc/markdown/literals.rb"
+    # Exclude dependency files when installing them under vendor
+    - "vendor/**/*"
 
 Layout/TrailingWhitespace:
   Enabled: true
@@ -19,4 +27,7 @@ Layout/SpaceAfterComma:
   Enabled: true
 
 Lint/UnreachableCode:
+  Enabled: true
+
+Style/MethodDefParentheses:
   Enabled: true

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -236,7 +236,7 @@ class RDoc::CodeObject
   #
   # Set to +nil+ to clear RDoc's cached value
 
-  def full_name= full_name
+  def full_name=(full_name)
     @full_name = full_name
   end
 
@@ -316,7 +316,7 @@ class RDoc::CodeObject
   ##
   # Records the RDoc::TopLevel (file) where this code object was defined
 
-  def record_location top_level
+  def record_location(top_level)
     @ignored    = false
     @suppressed = false
     @file       = top_level
@@ -358,7 +358,7 @@ class RDoc::CodeObject
   ##
   # Sets the +store+ that contains this CodeObject
 
-  def store= store
+  def store=(store)
     @store = store
 
     return unless @track_visibility

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -52,7 +52,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   ##
   # Adds +an_alias+ as an alias for this method in +context+.
 
-  def add_alias an_alias, context = nil
+  def add_alias(an_alias, context = nil)
     method = self.class.new an_alias.text, an_alias.new_name, singleton: singleton
 
     method.record_location an_alias.file
@@ -104,7 +104,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   #
   # See also #param_seq
 
-  def call_seq= call_seq
+  def call_seq=(call_seq)
     return if call_seq.nil? || call_seq.empty?
 
     @call_seq = call_seq
@@ -176,7 +176,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # * #full_name
   # * #parent_name
 
-  def marshal_load array
+  def marshal_load(array)
     initialize_visibility
 
     @dont_rename_initialize = nil
@@ -309,7 +309,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   ##
   # Sets the store for this method and its referenced code objects.
 
-  def store= store
+  def store=(store)
     super
 
     @file = @store.add_file @file.full_name if @file

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -32,7 +32,7 @@ class RDoc::Attr < RDoc::MethodAttr
   ##
   # Attributes are equal when their names, singleton and rw are identical
 
-  def == other
+  def ==(other)
     self.class == other.class and
       self.name == other.name and
       self.rw == other.rw and
@@ -118,7 +118,7 @@ class RDoc::Attr < RDoc::MethodAttr
   # * #full_name
   # * #parent_name
 
-  def marshal_load array
+  def marshal_load(array)
     initialize_visibility
 
     @aliases      = []
@@ -145,7 +145,7 @@ class RDoc::Attr < RDoc::MethodAttr
     @parent_name ||= @full_name.split('#', 2).first
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[#{self.class.name} #{full_name} #{rw} #{visibility}", "]" do
       unless comment.empty? then
         q.breakable

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -45,7 +45,7 @@ class RDoc::ClassModule < RDoc::Context
   #--
   # TODO move to RDoc::NormalClass (I think)
 
-  def self.from_module class_type, mod
+  def self.from_module(class_type, mod)
     klass = class_type.new mod.name
 
     mod.comment_location.each do |comment, location|
@@ -120,7 +120,7 @@ class RDoc::ClassModule < RDoc::Context
   # method is preferred over #comment= since it allows ri data to be updated
   # across multiple runs.
 
-  def add_comment comment, location
+  def add_comment(comment, location)
     return unless document_self
 
     original = comment
@@ -141,7 +141,7 @@ class RDoc::ClassModule < RDoc::Context
     self.comment = original
   end
 
-  def add_things my_things, other_things # :nodoc:
+  def add_things(my_things, other_things) # :nodoc:
     other_things.each do |group, things|
       my_things[group].each { |thing| yield false, thing } if
         my_things.include? group
@@ -198,7 +198,7 @@ class RDoc::ClassModule < RDoc::Context
   # Appends +comment+ to the current comment, but separated by a rule.  Works
   # more like <tt>+=</tt>.
 
-  def comment= comment # :nodoc:
+  def comment=(comment) # :nodoc:
     comment = case comment
               when RDoc::Comment then
                 comment.normalize
@@ -216,7 +216,7 @@ class RDoc::ClassModule < RDoc::Context
   #
   # See RDoc::Store#complete
 
-  def complete min_visibility
+  def complete(min_visibility)
     update_aliases
     remove_nodoc_children
     embed_mixins
@@ -259,7 +259,7 @@ class RDoc::ClassModule < RDoc::Context
   ##
   # Looks for a symbol in the #ancestors. See Context#find_local_symbol.
 
-  def find_ancestor_local_symbol symbol
+  def find_ancestor_local_symbol(symbol)
     each_ancestor do |m|
       res = m.find_local_symbol(symbol)
       return res if res
@@ -271,7 +271,7 @@ class RDoc::ClassModule < RDoc::Context
   ##
   # Finds a class or module with +name+ in this namespace or its descendants
 
-  def find_class_named name
+  def find_class_named(name)
     return self if full_name == name
     return self if @name == name
 
@@ -360,7 +360,7 @@ class RDoc::ClassModule < RDoc::Context
     ]
   end
 
-  def marshal_load array # :nodoc:
+  def marshal_load(array) # :nodoc:
     initialize_visibility
     initialize_methods_etc
     @current_section   = nil
@@ -450,7 +450,7 @@ class RDoc::ClassModule < RDoc::Context
   #
   # The data in +class_module+ is preferred over the receiver.
 
-  def merge class_module
+  def merge(class_module)
     @parent      = class_module.parent
     @parent_name = class_module.parent_name
 
@@ -535,7 +535,7 @@ class RDoc::ClassModule < RDoc::Context
   #     end
   #   end
 
-  def merge_collections mine, other, other_files, &block # :nodoc:
+  def merge_collections(mine, other, other_files, &block) # :nodoc:
     my_things    = mine. group_by { |thing| thing.file }
     other_things = other.group_by { |thing| thing.file }
 
@@ -547,7 +547,7 @@ class RDoc::ClassModule < RDoc::Context
   # Merges the comments in this ClassModule with the comments in the other
   # ClassModule +cm+.
 
-  def merge_sections cm # :nodoc:
+  def merge_sections(cm) # :nodoc:
     my_sections    =    sections.group_by { |section| section.title }
     other_sections = cm.sections.group_by { |section| section.title }
 
@@ -595,7 +595,7 @@ class RDoc::ClassModule < RDoc::Context
   #
   # Used for modules and classes that are constant aliases.
 
-  def name= new_name
+  def name=(new_name)
     @name = new_name
   end
 
@@ -603,7 +603,7 @@ class RDoc::ClassModule < RDoc::Context
   # Parses +comment_location+ into an RDoc::Markup::Document composed of
   # multiple RDoc::Markup::Documents with their file set.
 
-  def parse comment_location
+  def parse(comment_location)
     case comment_location
     when String then
       super
@@ -675,7 +675,7 @@ class RDoc::ClassModule < RDoc::Context
     end
   end
 
-  def remove_things my_things, other_files # :nodoc:
+  def remove_things(my_things, other_files) # :nodoc:
     my_things.delete_if do |file, things|
       next false unless other_files.include? file
 
@@ -705,7 +705,7 @@ class RDoc::ClassModule < RDoc::Context
   ##
   # Sets the store for this class or module and its contained code objects.
 
-  def store= store
+  def store=(store)
     super
 
     @attributes .each do |attr|  attr.store  = store end

--- a/lib/rdoc/code_object/constant.rb
+++ b/lib/rdoc/code_object/constant.rb
@@ -44,7 +44,7 @@ class RDoc::Constant < RDoc::CodeObject
   ##
   # Constants are ordered by name
 
-  def <=> other
+  def <=>(other)
     return unless self.class === other
 
     [parent_name, name] <=> [other.parent_name, other.name]
@@ -53,7 +53,7 @@ class RDoc::Constant < RDoc::CodeObject
   ##
   # Constants are equal when their #parent and #name is the same
 
-  def == other
+  def ==(other)
     self.class == other.class and
       @parent == other.parent and
       @name == other.name
@@ -132,7 +132,7 @@ class RDoc::Constant < RDoc::CodeObject
   # * #full_name
   # * #parent_name
 
-  def marshal_load array
+  def marshal_load(array)
     initialize array[1], nil, RDoc::Comment.from_document(array[5])
 
     @full_name     = array[2]
@@ -154,7 +154,7 @@ class RDoc::Constant < RDoc::CodeObject
     "#{@parent.path}##{@name}"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[#{self.class.name} #{full_name}", "]" do
       unless comment.empty? then
         q.breakable
@@ -168,7 +168,7 @@ class RDoc::Constant < RDoc::CodeObject
   ##
   # Sets the store for this class or module and its contained code objects.
 
-  def store= store
+  def store=(store)
     super
 
     @file = @store.add_file @file.full_name if @file

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -180,7 +180,7 @@ class RDoc::Context < RDoc::CodeObject
   #
   # Currently only RDoc::Extend and RDoc::Include are supported.
 
-  def add klass, name, comment
+  def add(klass, name, comment)
     if RDoc::Extend == klass then
       ext = RDoc::Extend.new name, comment
       add_extend ext
@@ -195,7 +195,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Adds +an_alias+ that is automatically resolved
 
-  def add_alias an_alias
+  def add_alias(an_alias)
     return an_alias unless @document_self
 
     method_attr = find_method(an_alias.old_name, an_alias.singleton) ||
@@ -222,7 +222,7 @@ class RDoc::Context < RDoc::CodeObject
   # if method +foo+ exists, but <tt>attr_accessor :foo</tt> will be registered
   # if method +foo+ exists, but <tt>foo=</tt> does not.
 
-  def add_attribute attribute
+  def add_attribute(attribute)
     return attribute unless @document_self
 
     # mainly to check for redefinition of an attribute as a method
@@ -285,7 +285,7 @@ class RDoc::Context < RDoc::CodeObject
   # unless it later sees <tt>class Container</tt>.  +add_class+ automatically
   # upgrades +given_name+ to a class in this case.
 
-  def add_class class_type, given_name, superclass = '::Object'
+  def add_class(class_type, given_name, superclass = '::Object')
     # superclass +nil+ is passed by the C parser in the following cases:
     # - registering Object in 1.8 (correct)
     # - registering BasicObject in 1.9 (correct)
@@ -401,7 +401,7 @@ class RDoc::Context < RDoc::CodeObject
   # unless #done_documenting is +true+. Sets the #parent of +mod+
   # to +self+, and its #section to #current_section. Returns +mod+.
 
-  def add_class_or_module mod, self_hash, all_hash
+  def add_class_or_module(mod, self_hash, all_hash)
     mod.section = current_section # TODO declaring context? something is
                                   # wrong here...
     mod.parent = self
@@ -426,7 +426,7 @@ class RDoc::Context < RDoc::CodeObject
   # Adds +constant+ if not already there. If it is, updates the comment,
   # value and/or is_alias_for of the known constant if they were empty/nil.
 
-  def add_constant constant
+  def add_constant(constant)
     return constant unless @document_self
 
     # HACK: avoid duplicate 'PI' & 'E' in math.c (1.8.7 source code)
@@ -451,7 +451,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Adds included module +include+ which should be an RDoc::Include
 
-  def add_include include
+  def add_include(include)
     add_to @includes, include
 
     include
@@ -460,7 +460,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Adds extension module +ext+ which should be an RDoc::Extend
 
-  def add_extend ext
+  def add_extend(ext)
     add_to @extends, ext
 
     ext
@@ -470,7 +470,7 @@ class RDoc::Context < RDoc::CodeObject
   # Adds +method+ if not already there. If it is (as method or attribute),
   # updates the comment if it was empty.
 
-  def add_method method
+  def add_method(method)
     return method unless @document_self
 
     # HACK: avoid duplicate 'new' in io.c & struct.c (1.8.7 source code)
@@ -524,7 +524,7 @@ class RDoc::Context < RDoc::CodeObject
   # Adds an alias from +from+ (a class or module) to +name+ which was defined
   # in +file+.
 
-  def add_module_alias from, from_name, to, file
+  def add_module_alias(from, from_name, to, file)
     return from if @done_documenting
 
     to_full_name = child_name to.name
@@ -583,7 +583,7 @@ class RDoc::Context < RDoc::CodeObject
   #
   # See also RDoc::Context::Section
 
-  def add_section title, comment = nil
+  def add_section(title, comment = nil)
     if section = @sections[title] then
       section.add_comment comment if comment
     else
@@ -597,7 +597,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Adds +thing+ to the collection +array+
 
-  def add_to array, thing
+  def add_to(array, thing)
     array << thing if @document_self
 
     thing.parent  = self
@@ -629,7 +629,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Creates the full name for a child with +name+
 
-  def child_name name
+  def child_name(name)
     if name =~ /^:+/
       $'  #'
     elsif RDoc::TopLevel === self then
@@ -970,7 +970,7 @@ class RDoc::Context < RDoc::CodeObject
   # If +section+ is provided only methods in that RDoc::Context::Section will
   # be returned.
 
-  def methods_by_type section = nil
+  def methods_by_type(section = nil)
     methods = {}
 
     TYPES.each do |type|
@@ -1062,7 +1062,7 @@ class RDoc::Context < RDoc::CodeObject
   #--
   # TODO mark the visibility of attributes in the template (if not public?)
 
-  def remove_invisible min_visibility
+  def remove_invisible(min_visibility)
     return if [:private, :nodoc].include? min_visibility
     remove_invisible_in @method_list, min_visibility
     remove_invisible_in @attributes, min_visibility
@@ -1072,7 +1072,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Only called when min_visibility == :public or :private
 
-  def remove_invisible_in array, min_visibility # :nodoc:
+  def remove_invisible_in(array, min_visibility) # :nodoc:
     if min_visibility == :public then
       array.reject! { |e|
         e.visibility != :public and not e.force_documentation
@@ -1088,7 +1088,7 @@ class RDoc::Context < RDoc::CodeObject
   # Tries to resolve unmatched aliases when a method or attribute has just
   # been added.
 
-  def resolve_aliases added
+  def resolve_aliases(added)
     # resolve any pending unmatched aliases
     key = added.pretty_name
     unmatched_alias_list = @unmatched_alias_lists[key]
@@ -1139,7 +1139,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Sets the current section to a section with +title+.  See also #add_section
 
-  def set_current_section title, comment
+  def set_current_section(title, comment)
     @current_section = add_section title, comment
   end
 
@@ -1204,7 +1204,7 @@ class RDoc::Context < RDoc::CodeObject
   ##
   # Upgrades NormalModule +mod+ in +enclosing+ to a +class_type+
 
-  def upgrade_to_class mod, class_type, enclosing
+  def upgrade_to_class(mod, class_type, enclosing)
     enclosing.modules_hash.delete mod.name
 
     klass = RDoc::ClassModule.from_module class_type, mod

--- a/lib/rdoc/code_object/context/section.rb
+++ b/lib/rdoc/code_object/context/section.rb
@@ -39,7 +39,7 @@ class RDoc::Context::Section
   ##
   # Creates a new section with +title+ and +comment+
 
-  def initialize parent, title, comment
+  def initialize(parent, title, comment)
     @parent = parent
     @title = title ? title.strip : title
 
@@ -51,7 +51,7 @@ class RDoc::Context::Section
   ##
   # Sections are equal when they have the same #title
 
-  def == other
+  def ==(other)
     self.class === other and @title == other.title
   end
 
@@ -60,7 +60,7 @@ class RDoc::Context::Section
   ##
   # Adds +comment+ to this section
 
-  def add_comment comment
+  def add_comment(comment)
     comments = Array(comment)
     comments.each do |c|
       extracted_comment = extract_comment(c)
@@ -86,7 +86,7 @@ class RDoc::Context::Section
   #   # :section: The title
   #   # The body
 
-  def extract_comment comment
+  def extract_comment(comment)
     case comment
     when nil
       RDoc::Comment.new ''
@@ -138,7 +138,7 @@ class RDoc::Context::Section
   ##
   # De-serializes this Section.  The section parent must be restored manually.
 
-  def marshal_load array
+  def marshal_load(array)
     @parent  = nil
 
     @title    = array[1]
@@ -166,7 +166,7 @@ class RDoc::Context::Section
   # Removes a comment from this section if it is from the same file as
   # +comment+
 
-  def remove_comment target_comment
+  def remove_comment(target_comment)
     @comments.delete_if do |stored_comment|
       stored_comment.file == target_comment.file
     end

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -91,7 +91,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
   ##
   # Resets cached data for the object so it can be rebuilt by accessor methods
 
-  def initialize_copy other # :nodoc:
+  def initialize_copy(other) # :nodoc:
     @full_name = nil
   end
 
@@ -111,7 +111,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
     [other.singleton ? 0 : 1, other.name_ord_range, other.name]
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     equal?(other) or self.class == other.class and full_name == other.full_name
   end
 
@@ -150,7 +150,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
   ##
   # Sets the store for this class or module and its contained code objects.
 
-  def store= store
+  def store=(store)
     super
 
     @file = @store.add_file @file.full_name if @file
@@ -168,7 +168,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
     return find_method_or_attribute name[0..-2]
   end
 
-  def find_method_or_attribute name # :nodoc:
+  def find_method_or_attribute(name) # :nodoc:
     return nil unless parent.respond_to? :ancestors
 
     searched = parent.ancestors
@@ -341,7 +341,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
     @parent_name || super
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     alias_for =
       if @is_alias_for.respond_to? :name then
         "alias for #{@is_alias_for.name}"

--- a/lib/rdoc/code_object/mixin.rb
+++ b/lib/rdoc/code_object/mixin.rb
@@ -23,13 +23,13 @@ class RDoc::Mixin < RDoc::CodeObject
   ##
   # Mixins are sorted by name
 
-  def <=> other
+  def <=>(other)
     return unless self.class === other
 
     name <=> other.name
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and @name == other.name
   end
 
@@ -107,7 +107,7 @@ class RDoc::Mixin < RDoc::CodeObject
   ##
   # Sets the store for this class or module and its contained code objects.
 
-  def store= store
+  def store=(store)
     super
 
     @file = @store.add_file @file.full_name if @file

--- a/lib/rdoc/code_object/normal_class.rb
+++ b/lib/rdoc/code_object/normal_class.rb
@@ -53,7 +53,7 @@ class RDoc::NormalClass < RDoc::ClassModule
     display
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     superclass = @superclass ? " < #{@superclass}" : nil
 
     q.group 2, "[class #{full_name}#{superclass}", "]" do

--- a/lib/rdoc/code_object/normal_module.rb
+++ b/lib/rdoc/code_object/normal_module.rb
@@ -29,7 +29,7 @@ class RDoc::NormalModule < RDoc::ClassModule
     true
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[module #{full_name}:", "]" do
       q.breakable
       q.text "includes:"

--- a/lib/rdoc/code_object/single_class.rb
+++ b/lib/rdoc/code_object/single_class.rb
@@ -22,7 +22,7 @@ class RDoc::SingleClass < RDoc::ClassModule
     "class << #{full_name}"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[class << #{full_name}", "]" do
       next
     end

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -33,7 +33,7 @@ class RDoc::TopLevel < RDoc::Context
   # is being generated outside the source dir +relative_name+ is relative to
   # the source directory.
 
-  def initialize absolute_name, relative_name = absolute_name
+  def initialize(absolute_name, relative_name = absolute_name)
     super()
     @name = nil
     @absolute_name = absolute_name
@@ -55,7 +55,7 @@ class RDoc::TopLevel < RDoc::Context
   ##
   # An RDoc::TopLevel is equal to another with the same relative_name
 
-  def == other
+  def ==(other)
     self.class === other and @relative_name == other.relative_name
   end
 
@@ -73,7 +73,7 @@ class RDoc::TopLevel < RDoc::Context
   ##
   # Adds +constant+ to +Object+ instead of +self+.
 
-  def add_constant constant
+  def add_constant(constant)
     object_class.record_location self
     return constant unless @document_self
     object_class.add_constant constant
@@ -101,7 +101,7 @@ class RDoc::TopLevel < RDoc::Context
   # Adds class or module +mod+. Used in the building phase
   # by the Ruby parser.
 
-  def add_to_classes_or_modules mod
+  def add_to_classes_or_modules(mod)
     @classes_or_modules << mod
   end
 
@@ -128,7 +128,7 @@ class RDoc::TopLevel < RDoc::Context
   # TODO Why do we search through all classes/modules found, not just the
   #       ones of this instance?
 
-  def find_class_or_module name
+  def find_class_or_module(name)
     @store.find_class_or_module name
   end
 
@@ -192,7 +192,7 @@ class RDoc::TopLevel < RDoc::Context
   ##
   # Loads this TopLevel from +array+.
 
-  def marshal_load array # :nodoc:
+  def marshal_load(array) # :nodoc:
     initialize array[1]
 
     @parser  = array[2]
@@ -231,7 +231,7 @@ class RDoc::TopLevel < RDoc::Context
     File.join(prefix, http_url)
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[#{self.class}: ", "]" do
       q.text "base name: #{base_name.inspect}"
       q.breakable

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -53,7 +53,7 @@ class RDoc::Comment
   # Creates a new comment with +text+ that is found in the RDoc::TopLevel
   # +location+.
 
-  def initialize text = nil, location = nil, language = nil
+  def initialize(text = nil, location = nil, language = nil)
     @location = location
     @text     = text.nil? ? nil : text.dup
     @language = language
@@ -67,11 +67,11 @@ class RDoc::Comment
   #--
   # TODO deep copy @document
 
-  def initialize_copy copy # :nodoc:
+  def initialize_copy(copy) # :nodoc:
     @text = copy.text.dup
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       other.text == @text and other.location == @location
   end
@@ -129,7 +129,7 @@ class RDoc::Comment
   ##
   # HACK dubious
 
-  def encode! encoding
+  def encode!(encoding)
     @text = String.new @text, encoding: encoding
     self
   end
@@ -137,7 +137,7 @@ class RDoc::Comment
   ##
   # Sets the format of this comment and resets any parsed document
 
-  def format= format
+  def format=(format)
     @format = format
     @document = nil
   end
@@ -208,7 +208,7 @@ class RDoc::Comment
   #
   # An error is raised if the comment contains a document but no text.
 
-  def text= text
+  def text=(text)
     raise RDoc::Error, 'replacing document-only comment is not allowed' if
       @text.nil? and @document
 

--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -124,7 +124,7 @@ class RDoc::CrossReference
   # Allows cross-references to be created based on the given +context+
   # (RDoc::Context).
 
-  def initialize context
+  def initialize(context)
     @context = context
     @store   = context.store
 
@@ -134,7 +134,7 @@ class RDoc::CrossReference
   ##
   # Returns a method reference to +name+.
 
-  def resolve_method name
+  def resolve_method(name)
     ref = nil
 
     if /#{CLASS_REGEXP_STR}([.#]|::)#{METHOD_REGEXP_STR}/o =~ name then
@@ -187,7 +187,7 @@ class RDoc::CrossReference
   # returned.  If +name+ is escaped +name+ is returned.  If +name+ is not
   # found +text+ is returned.
 
-  def resolve name, text
+  def resolve(name, text)
     return @seen[name] if @seen.include? name
 
     ref = case name

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -29,7 +29,7 @@ module RDoc::Encoding
   # If +force_transcode+ is true the document will be transcoded and any
   # unknown character in the target encoding will be replaced with '?'
 
-  def self.read_file filename, encoding, force_transcode = false
+  def self.read_file(filename, encoding, force_transcode = false)
     content = File.open filename, "rb" do |f| f.read end
     content.gsub!("\r\n", "\n") if RUBY_PLATFORM =~ /mswin|mingw/
 
@@ -89,7 +89,7 @@ module RDoc::Encoding
   ##
   # Detects the encoding of +string+ based on the magic comment
 
-  def self.detect_encoding string
+  def self.detect_encoding(string)
     result = HEADER_REGEXP.match string
     name = result && result[:name]
 
@@ -99,7 +99,7 @@ module RDoc::Encoding
   ##
   # Removes magic comments and shebang
 
-  def self.remove_magic_comment string
+  def self.remove_magic_comment(string)
     string.sub HEADER_REGEXP do |s|
       s.gsub(/[^\n]/, '')
     end
@@ -109,7 +109,7 @@ module RDoc::Encoding
   # Changes encoding based on +encoding+ without converting and returns new
   # string
 
-  def self.change_encoding text, encoding
+  def self.change_encoding(text, encoding)
     if text.kind_of? RDoc::Comment
       text.encode! encoding
     else

--- a/lib/rdoc/erb_partial.rb
+++ b/lib/rdoc/erb_partial.rb
@@ -9,7 +9,7 @@ class RDoc::ERBPartial < ERB
   # Overrides +compiler+ startup to set the +eoutvar+ to an empty string only
   # if it isn't already set.
 
-  def set_eoutvar compiler, eoutvar = '_erbout'
+  def set_eoutvar(compiler, eoutvar = '_erbout')
     super
 
     compiler.pre_cmd = ["#{eoutvar} ||= +''"]

--- a/lib/rdoc/erbio.rb
+++ b/lib/rdoc/erbio.rb
@@ -20,14 +20,14 @@ class RDoc::ERBIO < ERB
   ##
   # Defaults +eoutvar+ to 'io', otherwise is identical to ERB's initialize
 
-  def initialize str, trim_mode: nil, eoutvar: 'io'
+  def initialize(str, trim_mode: nil, eoutvar: 'io')
     super(str, trim_mode: trim_mode, eoutvar: eoutvar)
   end
 
   ##
   # Instructs +compiler+ how to write to +io_variable+
 
-  def set_eoutvar compiler, io_variable
+  def set_eoutvar(compiler, io_variable)
     compiler.put_cmd    = "#{io_variable}.write"
     compiler.insert_cmd = "#{io_variable}.write"
     compiler.pre_cmd    = []

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -150,7 +150,7 @@ class RDoc::Generator::Darkfish
   ##
   # Initialize a few instance variables before we start
 
-  def initialize store, options
+  def initialize(store, options)
     @store   = store
     @options = options
 
@@ -269,7 +269,7 @@ class RDoc::Generator::Darkfish
   # Return a list of the documented modules sorted by salience first, then
   # by name.
 
-  def get_sorted_module_list classes
+  def get_sorted_module_list(classes)
     classes.select do |klass|
       klass.display?
     end.sort
@@ -313,7 +313,7 @@ class RDoc::Generator::Darkfish
   ##
   # Generates a class file for +klass+
 
-  def generate_class klass, template_file = nil
+  def generate_class(klass, template_file = nil)
     current = klass
 
     template_file ||= @template_dir + 'class.rhtml'
@@ -435,7 +435,7 @@ class RDoc::Generator::Darkfish
   ##
   # Generate a page file for +file+
 
-  def generate_page file
+  def generate_page(file)
     template_file = @template_dir + 'page.rhtml'
 
     out_file = @outputdir + file.path
@@ -462,7 +462,7 @@ class RDoc::Generator::Darkfish
   ##
   # Generates the 404 page for the RDoc servlet
 
-  def generate_servlet_not_found message
+  def generate_servlet_not_found(message)
     template_file = @template_dir + 'servlet_not_found.rhtml'
     return unless template_file.exist?
 
@@ -493,7 +493,7 @@ class RDoc::Generator::Darkfish
   ##
   # Generates the servlet root page for the RDoc servlet
 
-  def generate_servlet_root installed
+  def generate_servlet_root(installed)
     template_file = @template_dir + 'servlet_root.rhtml'
     return unless template_file.exist?
 
@@ -547,7 +547,7 @@ class RDoc::Generator::Darkfish
     raise error
   end
 
-  def install_rdoc_static_file source, destination, options # :nodoc:
+  def install_rdoc_static_file(source, destination, options) # :nodoc:
     return unless source.exist?
 
     begin
@@ -586,7 +586,7 @@ class RDoc::Generator::Darkfish
   # For backwards compatibility, if +body_file+ contains "<html" the body is
   # used directly.
 
-  def assemble_template body_file
+  def assemble_template(body_file)
     body = body_file.read
     return body if body =~ /<html/
 
@@ -607,7 +607,7 @@ class RDoc::Generator::Darkfish
   # Renders the ERb contained in +file_name+ relative to the template
   # directory and returns the result based on the current context.
 
-  def render file_name
+  def render(file_name)
     template_file = @template_dir + file_name
 
     template = template_for template_file, false, RDoc::ERBPartial
@@ -625,7 +625,7 @@ class RDoc::Generator::Darkfish
   #
   # An io will be yielded which must be captured by binding in the caller.
 
-  def render_template template_file, out_file = nil # :yield: io
+  def render_template(template_file, out_file = nil) # :yield: io
     io_output = out_file && !@dry_run && @file_output
     erb_klass = io_output ? RDoc::ERBIO : ERB
 
@@ -659,7 +659,7 @@ class RDoc::Generator::Darkfish
   # Creates the result for +template+ with +context+.  If an error is raised a
   # Pathname +template_file+ will indicate the file where the error occurred.
 
-  def template_result template, context, template_file
+  def template_result(template, context, template_file)
     template.filename = template_file.to_s
     template.result context
   rescue NoMethodError => e
@@ -672,7 +672,7 @@ class RDoc::Generator::Darkfish
   ##
   # Retrieves a cache template for +file+, if present, or fills the cache.
 
-  def template_for file, page = true, klass = ERB
+  def template_for(file, page = true, klass = ERB)
     template = @template_cache[file]
 
     return template if template
@@ -793,7 +793,7 @@ class RDoc::Generator::Darkfish
 
   private
 
-  def nesting_namespaces_to_class_modules klass
+  def nesting_namespaces_to_class_modules(klass)
     tree = {}
 
     klass.nesting_namespaces.zip(klass.fully_qualified_nesting_namespaces) do |ns, fqns|
@@ -803,7 +803,7 @@ class RDoc::Generator::Darkfish
     tree
   end
 
-  def generate_nesting_namespaces_breadcrumb klass, rel_prefix
+  def generate_nesting_namespaces_breadcrumb(klass, rel_prefix)
     nesting_namespaces_to_class_modules(klass).map do |namespace, class_module|
       path = class_module ? (rel_prefix + class_module.path).to_s : ""
       { name: namespace, path: path, self: klass.full_name == class_module&.full_name }

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -89,7 +89,7 @@ class RDoc::Generator::JsonIndex
   # Creates a new generator.
   # +options+ are the same options passed to the parent generator.
 
-  def initialize parent_generator, options
+  def initialize(parent_generator, options)
     @parent_generator = parent_generator
     @store            = parent_generator.store
     @options          = options
@@ -263,7 +263,7 @@ class RDoc::Generator::JsonIndex
     end
   end
 
-  def reset files, classes # :nodoc:
+  def reset(files, classes) # :nodoc:
     @files   = files
     @classes = classes
 
@@ -277,7 +277,7 @@ class RDoc::Generator::JsonIndex
   ##
   # Removes whitespace and downcases +string+
 
-  def search_string string
+  def search_string(string)
     string.downcase.gsub(/\s/, '')
   end
 

--- a/lib/rdoc/generator/pot.rb
+++ b/lib/rdoc/generator/pot.rb
@@ -65,7 +65,7 @@ class RDoc::Generator::POT
   ##
   # Set up a new .pot generator
 
-  def initialize store, options #:not-new:
+  def initialize(store, options) #:not-new:
     @options    = options
     @store      = store
   end

--- a/lib/rdoc/generator/pot/message_extractor.rb
+++ b/lib/rdoc/generator/pot/message_extractor.rb
@@ -7,7 +7,7 @@ class RDoc::Generator::POT::MessageExtractor
   ##
   # Creates a message extractor for +store+.
 
-  def initialize store
+  def initialize(store)
     @store = store
     @po = RDoc::Generator::POT::PO.new
   end
@@ -25,7 +25,7 @@ class RDoc::Generator::POT::MessageExtractor
 
   private
 
-  def extract_from_klass klass
+  def extract_from_klass(klass)
     extract_text(klass.comment_location, klass.full_name)
 
     klass.each_section do |section, constants, attributes|
@@ -48,7 +48,7 @@ class RDoc::Generator::POT::MessageExtractor
     end
   end
 
-  def extract_text text, comment, location = nil
+  def extract_text(text, comment, location = nil)
     return if text.nil?
 
     options = {
@@ -61,7 +61,7 @@ class RDoc::Generator::POT::MessageExtractor
     end
   end
 
-  def entry msgid, options
+  def entry(msgid, options)
     RDoc::Generator::POT::POEntry.new(msgid, options)
   end
 

--- a/lib/rdoc/generator/pot/po.rb
+++ b/lib/rdoc/generator/pot/po.rb
@@ -15,7 +15,7 @@ class RDoc::Generator::POT::PO
   ##
   # Adds a PO entry to the PO.
 
-  def add entry
+  def add(entry)
     existing_entry = @entries[entry.msgid]
     if existing_entry
       entry = existing_entry.merge(entry)

--- a/lib/rdoc/generator/pot/po_entry.rb
+++ b/lib/rdoc/generator/pot/po_entry.rb
@@ -26,7 +26,7 @@ class RDoc::Generator::POT::POEntry
   # Creates a PO entry for +msgid+. Other values can be specified by
   # +options+.
 
-  def initialize msgid, options = {}
+  def initialize(msgid, options = {})
     @msgid = msgid
     @msgstr = options[:msgstr] || ""
     @translator_comment = options[:translator_comment]
@@ -53,7 +53,7 @@ msgstr #{format_message(@msgstr)}
   ##
   # Merges the PO entry with +other_entry+.
 
-  def merge other_entry
+  def merge(other_entry)
     options = {
       :extracted_comment  => merge_string(@extracted_comment,
                                           other_entry.extracted_comment),
@@ -69,7 +69,7 @@ msgstr #{format_message(@msgstr)}
 
   private
 
-  def format_comment mark, comment
+  def format_comment(mark, comment)
     return '' unless comment
     return '' if comment.empty?
 
@@ -106,7 +106,7 @@ msgstr #{format_message(@msgstr)}
     "\#, #{formatted_flags}\n"
   end
 
-  def format_message message
+  def format_message(message)
     return "\"#{escape(message)}\"" unless message.include?("\n")
 
     formatted_message = '""'
@@ -117,7 +117,7 @@ msgstr #{format_message(@msgstr)}
     formatted_message
   end
 
-  def escape string
+  def escape(string)
     string.gsub(/["\\\t\n]/) do |special_character|
       case special_character
       when "\t"
@@ -130,11 +130,11 @@ msgstr #{format_message(@msgstr)}
     end
   end
 
-  def merge_string string1, string2
+  def merge_string(string1, string2)
     [string1, string2].compact.join("\n")
   end
 
-  def merge_array array1, array2
+  def merge_array(array1, array2)
       (array1 + array2).uniq
   end
 

--- a/lib/rdoc/generator/ri.rb
+++ b/lib/rdoc/generator/ri.rb
@@ -14,7 +14,7 @@ class RDoc::Generator::RI
   ##
   # Set up a new ri generator
 
-  def initialize store, options #:not-new:
+  def initialize(store, options) #:not-new:
     @options    = options
     @store      = store
     @store.path = '.'

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -118,7 +118,7 @@ class RDoc::Markup
   ##
   # Parses +str+ into an RDoc::Markup::Document.
 
-  def self.parse str
+  def self.parse(str)
     RDoc::Markup::Parser.parse str
   rescue RDoc::Markup::Parser::Error => e
     $stderr.puts <<-EOF
@@ -148,7 +148,7 @@ https://github.com/ruby/rdoc/issues
   # structure (paragraphs, lists, and so on).  Invoke an event handler as we
   # identify significant chunks.
 
-  def initialize attribute_manager = nil
+  def initialize(attribute_manager = nil)
     @attribute_manager = attribute_manager || RDoc::Markup::AttributeManager.new
     @output = nil
   end
@@ -185,7 +185,7 @@ https://github.com/ruby/rdoc/issues
   # We take +input+, parse it if necessary, then invoke the output +formatter+
   # using a Visitor to render the result.
 
-  def convert input, formatter
+  def convert(input, formatter)
     document = case input
                when RDoc::Markup::Document then
                  input

--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -107,7 +107,7 @@ class RDoc::Markup::AttributeManager
   ##
   # Changes the current attribute from +current+ to +new+
 
-  def change_attribute current, new
+  def change_attribute(current, new)
     diff = current ^ new
     attribute(new & diff, current & diff)
   end
@@ -116,7 +116,7 @@ class RDoc::Markup::AttributeManager
   # Used by the tests to change attributes by name from +current_set+ to
   # +new_set+
 
-  def changed_attribute_by_name current_set, new_set
+  def changed_attribute_by_name(current_set, new_set)
     current = new = 0
     current_set.each do |name|
       current |= @attributes.bitmap_for(name)
@@ -220,7 +220,7 @@ class RDoc::Markup::AttributeManager
   ##
   # Converts regexp handling sequences to RDoc attributes
 
-  def convert_regexp_handlings str, attrs, exclusive = false
+  def convert_regexp_handlings(str, attrs, exclusive = false)
     @regexp_handlings.each do |regexp, attribute|
       next unless exclusive == exclusive?(attribute)
       str.scan(regexp) do
@@ -295,7 +295,7 @@ class RDoc::Markup::AttributeManager
   #
   #   @am.add_regexp_handling(/((https?:)\S+\w)/, :HYPERLINK)
 
-  def add_regexp_handling pattern, name, exclusive = false
+  def add_regexp_handling(pattern, name, exclusive = false)
     bitmap = @attributes.bitmap_for(name)
     @regexp_handlings << [pattern, bitmap]
     @exclusive_bitmap |= bitmap if exclusive
@@ -304,7 +304,7 @@ class RDoc::Markup::AttributeManager
   ##
   # Processes +str+ converting attributes, HTML and regexp handlings
 
-  def flow str
+  def flow(str)
     @str = str.dup
 
     mask_protected_sequences

--- a/lib/rdoc/markup/attributes.rb
+++ b/lib/rdoc/markup/attributes.rb
@@ -26,7 +26,7 @@ class RDoc::Markup::Attributes
   ##
   # Returns a unique bit for +name+
 
-  def bitmap_for name
+  def bitmap_for(name)
     bitmap = @name_to_bitmap.assoc name
 
     unless bitmap then
@@ -43,7 +43,7 @@ class RDoc::Markup::Attributes
   ##
   # Returns a string representation of +bitmap+
 
-  def as_string bitmap
+  def as_string(bitmap)
     return 'none' if bitmap.zero?
     res = []
 
@@ -57,7 +57,7 @@ class RDoc::Markup::Attributes
   ##
   # yields each attribute name in +bitmap+
 
-  def each_name_of bitmap
+  def each_name_of(bitmap)
     return enum_for __method__, bitmap unless block_given?
 
     @name_to_bitmap.each do |name, bit|

--- a/lib/rdoc/markup/blank_line.rb
+++ b/lib/rdoc/markup/blank_line.rb
@@ -16,11 +16,11 @@ class RDoc::Markup::BlankLine
   ##
   # Calls #accept_blank_line on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_blank_line self
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.text 'blankline'
   end
 

--- a/lib/rdoc/markup/block_quote.rb
+++ b/lib/rdoc/markup/block_quote.rb
@@ -7,7 +7,7 @@ class RDoc::Markup::BlockQuote < RDoc::Markup::Raw
   ##
   # Calls #accept_block_quote on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_block_quote self
   end
 

--- a/lib/rdoc/markup/document.rb
+++ b/lib/rdoc/markup/document.rb
@@ -37,7 +37,7 @@ class RDoc::Markup::Document
   ##
   # Appends +part+ to the document
 
-  def << part
+  def <<(part)
     case part
     when RDoc::Markup::Document then
       unless part.empty? then
@@ -53,7 +53,7 @@ class RDoc::Markup::Document
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class == other.class and
       @file == other.file and
       @parts == other.parts
@@ -62,7 +62,7 @@ class RDoc::Markup::Document
   ##
   # Runs this document and all its #items through +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.start_accepting
 
     visitor.accept_document self
@@ -73,14 +73,14 @@ class RDoc::Markup::Document
   ##
   # Concatenates the given +parts+ onto the document
 
-  def concat parts
+  def concat(parts)
     self.parts.concat parts
   end
 
   ##
   # Enumerator for the parts of this document
 
-  def each &block
+  def each(&block)
     @parts.each(&block)
   end
 
@@ -94,7 +94,7 @@ class RDoc::Markup::Document
   ##
   # The file this Document was created from.
 
-  def file= location
+  def file=(location)
     @file = case location
             when RDoc::TopLevel then
               location.relative_name
@@ -111,7 +111,7 @@ class RDoc::Markup::Document
   #
   # The information in +other+ is preferred over the receiver
 
-  def merge other
+  def merge(other)
     if empty? then
       @parts = other.parts
       return self
@@ -135,7 +135,7 @@ class RDoc::Markup::Document
     RDoc::Markup::Document === @parts.first
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     start = @file ? "[doc (#{@file}): " : '[doc: '
 
     q.group 2, start, ']' do

--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -21,7 +21,7 @@ class RDoc::Markup::Formatter
   ##
   # Converts a target url to one that is relative to a given path
 
-  def self.gen_relative_url path, target
+  def self.gen_relative_url(path, target)
     from        = File.dirname path
     to, to_file = File.split target
 
@@ -45,7 +45,7 @@ class RDoc::Markup::Formatter
   ##
   # Creates a new Formatter
 
-  def initialize options, markup = nil
+  def initialize(options, markup = nil)
     @options = options
 
     @markup = markup || RDoc::Markup.new
@@ -66,7 +66,7 @@ class RDoc::Markup::Formatter
   ##
   # Adds +document+ to the output
 
-  def accept_document document
+  def accept_document(document)
     document.parts.each do |item|
       case item
       when RDoc::Markup::Document then # HACK
@@ -117,7 +117,7 @@ class RDoc::Markup::Formatter
   ##
   # Marks up +content+
 
-  def convert content
+  def convert(content)
     @markup.convert content, self
   end
 
@@ -147,7 +147,7 @@ class RDoc::Markup::Formatter
   ##
   # Converts added regexp handlings. See RDoc::Markup#add_regexp_handling
 
-  def convert_regexp_handling target
+  def convert_regexp_handling(target)
     return target.text if in_tt?
 
     handled = false
@@ -173,7 +173,7 @@ class RDoc::Markup::Formatter
   ##
   # Converts a string to be fancier if desired
 
-  def convert_string string
+  def convert_string(string)
     string
   end
 
@@ -195,7 +195,7 @@ class RDoc::Markup::Formatter
     @in_tt > 0
   end
 
-  def tt_tag? attr_mask, reverse = false
+  def tt_tag?(attr_mask, reverse = false)
     each_attr_tag(attr_mask, reverse) do |tag|
       return true if tt? tag
     end
@@ -205,7 +205,7 @@ class RDoc::Markup::Formatter
   ##
   # Turns on tags for +item+ on +res+
 
-  def on_tags res, item
+  def on_tags(res, item)
     each_attr_tag(item.turn_on) do |tag|
       res << annotate(tag.on)
       @in_tt += 1 if tt? tag
@@ -215,14 +215,14 @@ class RDoc::Markup::Formatter
   ##
   # Turns off tags for +item+ on +res+
 
-  def off_tags res, item
+  def off_tags(res, item)
     each_attr_tag(item.turn_off, true) do |tag|
       @in_tt -= 1 if tt? tag
       res << annotate(tag.off)
     end
   end
 
-  def each_attr_tag attr_mask, reverse = false
+  def each_attr_tag(attr_mask, reverse = false)
     return if attr_mask.zero?
 
     @attr_tags.public_send(reverse ? :reverse_each : :each) do |tag|
@@ -235,7 +235,7 @@ class RDoc::Markup::Formatter
   ##
   # Extracts and a scheme, url and an anchor id from +url+ and returns them.
 
-  def parse_url url
+  def parse_url(url)
     case url
     when /^rdoc-label:([^:]*)(?::(.*))?/ then
       scheme = 'link'
@@ -265,7 +265,7 @@ class RDoc::Markup::Formatter
   ##
   # Is +tag+ a tt tag?
 
-  def tt? tag
+  def tt?(tag)
     tag.bit == @tt_bit
   end
 

--- a/lib/rdoc/markup/hard_break.rb
+++ b/lib/rdoc/markup/hard_break.rb
@@ -16,15 +16,15 @@ class RDoc::Markup::HardBreak
   ##
   # Calls #accept_hard_break on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_hard_break self
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.text "[break]"
   end
 

--- a/lib/rdoc/markup/heading.rb
+++ b/lib/rdoc/markup/heading.rb
@@ -27,7 +27,7 @@ RDoc::Markup::Heading =
 
     @to_html = RDoc::Markup::ToHtml.new nil
 
-    def @to_html.handle_regexp_CROSSREF target
+    def @to_html.handle_regexp_CROSSREF(target)
       target.text.sub(/^\\/, '')
     end
 
@@ -37,7 +37,7 @@ RDoc::Markup::Heading =
   ##
   # Calls #accept_heading on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_heading self
   end
 
@@ -52,7 +52,7 @@ RDoc::Markup::Heading =
   # Creates a fully-qualified label which will include the label from
   # +context+.  This helps keep ids unique in HTML.
 
-  def label context = nil
+  def label(context = nil)
     label = aref
 
     label = [context.aref, label].compact.join '-' if
@@ -75,7 +75,7 @@ RDoc::Markup::Heading =
     self.class.to_html.to_html(text)
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[head: #{level} ", ']' do
       q.pp text
     end

--- a/lib/rdoc/markup/include.rb
+++ b/lib/rdoc/markup/include.rb
@@ -20,17 +20,17 @@ class RDoc::Markup::Include
   ##
   # Creates a new include that will import +file+ from +include_path+
 
-  def initialize file, include_path
+  def initialize(file, include_path)
     @file = file
     @include_path = include_path
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @file == other.file and @include_path == other.include_path
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[incl ', ']' do
       q.text file
       q.breakable

--- a/lib/rdoc/markup/indented_paragraph.rb
+++ b/lib/rdoc/markup/indented_paragraph.rb
@@ -19,14 +19,14 @@ class RDoc::Markup::IndentedParagraph < RDoc::Markup::Raw
     super(*parts)
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     super and indent == other.indent
   end
 
   ##
   # Calls #accept_indented_paragraph on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_indented_paragraph self
   end
 
@@ -34,7 +34,7 @@ class RDoc::Markup::IndentedParagraph < RDoc::Markup::Raw
   # Joins the raw paragraph text and converts inline HardBreaks to the
   # +hard_break+ text followed by the indent.
 
-  def text hard_break = nil
+  def text(hard_break = nil)
     @parts.map do |part|
       if RDoc::Markup::HardBreak === part then
         '%1$s%3$*2$s' % [hard_break, @indent, ' '] if hard_break

--- a/lib/rdoc/markup/list.rb
+++ b/lib/rdoc/markup/list.rb
@@ -46,11 +46,11 @@ class RDoc::Markup::List
   ##
   # Appends +item+ to the list
 
-  def << item
+  def <<(item)
     @items << item
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class == other.class and
       @type == other.type and
       @items == other.items
@@ -59,7 +59,7 @@ class RDoc::Markup::List
   ##
   # Runs this list and all its #items through +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_list_start self
 
     @items.each do |item|
@@ -83,7 +83,7 @@ class RDoc::Markup::List
     @items.last
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, "[list: #{@type} ", ']' do
       q.seplist @items do |item|
         q.pp item

--- a/lib/rdoc/markup/list_item.rb
+++ b/lib/rdoc/markup/list_item.rb
@@ -33,11 +33,11 @@ class RDoc::Markup::ListItem
   ##
   # Appends +part+ to the ListItem
 
-  def << part
+  def <<(part)
     @parts << part
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class == other.class and
       @label == other.label and
       @parts == other.parts
@@ -46,7 +46,7 @@ class RDoc::Markup::ListItem
   ##
   # Runs this list item and all its #parts through +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_list_item_start self
 
     @parts.each do |part|
@@ -70,7 +70,7 @@ class RDoc::Markup::ListItem
     @parts.length
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[item: ', ']' do
       case @label
       when Array then

--- a/lib/rdoc/markup/paragraph.rb
+++ b/lib/rdoc/markup/paragraph.rb
@@ -7,7 +7,7 @@ class RDoc::Markup::Paragraph < RDoc::Markup::Raw
   ##
   # Calls #accept_paragraph on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_paragraph self
   end
 
@@ -15,7 +15,7 @@ class RDoc::Markup::Paragraph < RDoc::Markup::Raw
   # Joins the raw paragraph text and converts inline HardBreaks to the
   # +hard_break+ text.
 
-  def text hard_break = ''
+  def text(hard_break = '')
     @parts.map do |part|
       if RDoc::Markup::HardBreak === part then
         hard_break

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -57,7 +57,7 @@ class RDoc::Markup::Parser
   #
   # Use RDoc::Markup#parse instead of this method.
 
-  def self.parse str
+  def self.parse(str)
     parser = new
     parser.tokenize str
     doc = RDoc::Markup::Document.new
@@ -67,7 +67,7 @@ class RDoc::Markup::Parser
   ##
   # Returns a token stream for +str+, for testing
 
-  def self.tokenize str
+  def self.tokenize(str)
     parser = new
     parser.tokenize str
     parser.tokens
@@ -87,7 +87,7 @@ class RDoc::Markup::Parser
   ##
   # Builds a Heading of +level+
 
-  def build_heading level
+  def build_heading(level)
     type, text, = get
 
     text = case type
@@ -105,7 +105,7 @@ class RDoc::Markup::Parser
   ##
   # Builds a List flush to +margin+
 
-  def build_list margin
+  def build_list(margin)
     p :list_start => margin if @debug
 
     list = RDoc::Markup::List.new
@@ -205,7 +205,7 @@ class RDoc::Markup::Parser
   ##
   # Builds a Paragraph that is flush to +margin+
 
-  def build_paragraph margin
+  def build_paragraph(margin)
     p :paragraph_start => margin if @debug
 
     paragraph = RDoc::Markup::Paragraph.new
@@ -240,7 +240,7 @@ class RDoc::Markup::Parser
   # terminated by a newline.  Blank lines always consist of a single newline
   # character, and there is never a single newline at the end of the verbatim.
 
-  def build_verbatim margin
+  def build_verbatim(margin)
     p :verbatim_begin => margin if @debug
     verbatim = RDoc::Markup::Verbatim.new
 
@@ -339,7 +339,7 @@ class RDoc::Markup::Parser
   #
   # Returns +parent+.
 
-  def parse parent, indent = 0
+  def parse(parent, indent = 0)
     p :parse_start => indent if @debug
 
     until @tokens.empty? do
@@ -403,7 +403,7 @@ class RDoc::Markup::Parser
   ##
   # Small hook that is overridden by RDoc::TomDoc
 
-  def parse_text parent, indent # :nodoc:
+  def parse_text(parent, indent) # :nodoc:
     parent << build_paragraph(indent)
   end
 
@@ -465,7 +465,7 @@ class RDoc::Markup::Parser
   ##
   # Creates the StringScanner
 
-  def setup_scanner input
+  def setup_scanner(input)
     @s = MyStringScanner.new input
   end
 
@@ -474,7 +474,7 @@ class RDoc::Markup::Parser
   #
   # Optionally raises an error if the next token is not of the expected type.
 
-  def skip token_type, error = true
+  def skip(token_type, error = true)
     type, = get
     return unless type # end of stream
     return @current_token if token_type == type
@@ -485,7 +485,7 @@ class RDoc::Markup::Parser
   ##
   # Turns text +input+ into a stream of tokens
 
-  def tokenize input
+  def tokenize(input)
     setup_scanner input
 
     until @s.eos? do

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -27,7 +27,7 @@ class RDoc::Markup::PreProcess
   # with the result RDoc::Comment (or text String) and the code object for the
   # comment (if any).
 
-  def self.post_process &block
+  def self.post_process(&block)
     @post_processors << block
   end
 
@@ -50,7 +50,7 @@ class RDoc::Markup::PreProcess
   #     # replace text, etc.
   #   end
 
-  def self.register directive, &block
+  def self.register(directive, &block)
     @registered[directive] = block
   end
 
@@ -96,7 +96,7 @@ class RDoc::Markup::PreProcess
   # directive's parameter is set as metadata on the +code_object+.  See
   # RDoc::CodeObject#metadata for details.
 
-  def handle text, code_object = nil, &block
+  def handle(text, code_object = nil, &block)
     first_line = 1
     if RDoc::Comment === text then
       comment = text
@@ -150,8 +150,8 @@ class RDoc::Markup::PreProcess
   #--
   # When 1.8.7 support is ditched prefix can be defaulted to ''
 
-  def handle_directive prefix, directive, param, code_object = nil,
-                       encoding = nil, line = nil
+  def handle_directive(prefix, directive, param, code_object = nil,
+                       encoding = nil, line = nil)
     blankline = "#{prefix.strip}\n"
     directive = directive.downcase
 
@@ -279,7 +279,7 @@ class RDoc::Markup::PreProcess
   # TODO shift left the whole file content in that case
   # TODO comment stop/start #-- and #++ in included file must be processed here
 
-  def include_file name, indent, encoding
+  def include_file(name, indent, encoding)
     full_name = find_include_file name
 
     unless full_name then

--- a/lib/rdoc/markup/raw.rb
+++ b/lib/rdoc/markup/raw.rb
@@ -20,29 +20,29 @@ class RDoc::Markup::Raw
   ##
   # Appends +text+
 
-  def << text
+  def <<(text)
     @parts << text
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class == other.class and @parts == other.parts
   end
 
   ##
   # Calls #accept_raw+ on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_raw self
   end
 
   ##
   # Appends +other+'s parts
 
-  def merge other
+  def merge(other)
     @parts.concat other.parts
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     self.class.name =~ /.*::(\w{1,4})/i
 
     q.group 2, "[#{$1.downcase}: ", ']' do

--- a/lib/rdoc/markup/rule.rb
+++ b/lib/rdoc/markup/rule.rb
@@ -7,11 +7,11 @@ class RDoc::Markup::Rule < Struct.new :weight
   ##
   # Calls #accept_rule on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_rule self
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[rule:', ']' do
       q.pp weight
     end

--- a/lib/rdoc/markup/table.rb
+++ b/lib/rdoc/markup/table.rb
@@ -13,23 +13,23 @@ class RDoc::Markup::Table
   attr_accessor :body
 
   # Creates new instance
-  def initialize header, align, body
+  def initialize(header, align, body)
     @header, @align, @body = header, align, body
   end
 
   # :stopdoc:
-  def == other
+  def ==(other)
     self.class == other.class and
       @header == other.header and
       @align == other.align and
       @body == other.body
   end
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_table @header, @body, @align
   end
 
-  def pretty_print q
+  def pretty_print(q)
     q.group 2, '[Table: ', ']' do
       q.group 2, '[Head: ', ']' do
         q.seplist @header.zip(@align) do |text, align|

--- a/lib/rdoc/markup/to_ansi.rb
+++ b/lib/rdoc/markup/to_ansi.rb
@@ -7,7 +7,7 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
   ##
   # Creates a new ToAnsi visitor that is ready to output vibrant ANSI color!
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super
 
     @headings.clear
@@ -28,7 +28,7 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
   ##
   # Overrides indent width to ensure output lines up correctly.
 
-  def accept_list_item_end list_item
+  def accept_list_item_end(list_item)
     width = case @list_type.last
             when :BULLET then
               2
@@ -52,7 +52,7 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
   ##
   # Adds coloring to note and label list items
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     bullet = case @list_type.last
              when :BULLET then
                '*'

--- a/lib/rdoc/markup/to_bs.rb
+++ b/lib/rdoc/markup/to_bs.rb
@@ -10,7 +10,7 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   ##
   # Returns a new ToBs that is ready for hot backspace action!
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super
 
     @in_b  = false
@@ -30,7 +30,7 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   ##
   # Makes heading text bold.
 
-  def accept_heading heading
+  def accept_heading(heading)
     use_prefix or @res << ' ' * @indent
     @res << @headings[heading.level][0]
     @in_b = true
@@ -43,7 +43,7 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   ##
   # Prepares the visitor for consuming +list_item+
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     type = @list_type.last
 
     case type
@@ -68,7 +68,7 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   ##
   # Turns on or off regexp handling for +convert_string+
 
-  def annotate tag
+  def annotate(tag)
     case tag
     when '+b' then @in_b = true
     when '-b' then @in_b = false
@@ -81,14 +81,14 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
   ##
   # Calls convert_string on the result of convert_regexp_handling
 
-  def convert_regexp_handling target
+  def convert_regexp_handling(target)
     convert_string super
   end
 
   ##
   # Adds bold or underline mixed with backspaces
 
-  def convert_string string
+  def convert_string(string)
     return string unless @in_b or @in_em
     chars = if @in_b then
               string.chars.map do |char| "#{char}\b#{char}" end

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -42,7 +42,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Creates a new formatter that will output HTML
 
-  def initialize options, markup = nil
+  def initialize(options, markup = nil)
     super
 
     @code_object = nil
@@ -82,7 +82,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
     add_regexp_handling_TIDYLINK
   end
 
-  def handle_RDOCLINK url # :nodoc:
+  def handle_RDOCLINK(url) # :nodoc:
     case url
     when /^rdoc-ref:/
       CGI.escapeHTML($')
@@ -112,7 +112,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # +target+ is a <code><br></code>
 
-  def handle_regexp_HARD_BREAK target
+  def handle_regexp_HARD_BREAK(target)
     '<br>'
   end
 
@@ -143,7 +143,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # For the +rdoc-label+ scheme the footnote and label prefixes are stripped
   # when creating a link.  All other contents will be linked verbatim.
 
-  def handle_regexp_RDOCLINK target
+  def handle_regexp_RDOCLINK(target)
     handle_RDOCLINK target.text
   end
 
@@ -192,7 +192,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Adds +block_quote+ to the output
 
-  def accept_block_quote block_quote
+  def accept_block_quote(block_quote)
     @res << "\n<blockquote>"
 
     block_quote.parts.each do |part|
@@ -205,7 +205,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Adds +paragraph+ to the output
 
-  def accept_paragraph paragraph
+  def accept_paragraph(paragraph)
     @res << "\n<p>"
     text = paragraph.text @hard_break
     text = text.gsub(/(#{SPACE_SEPARATED_LETTER_CLASS})?\K\r?\n(?=(?(1)(#{SPACE_SEPARATED_LETTER_CLASS})?))/o) {
@@ -218,7 +218,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Adds +verbatim+ to the output
 
-  def accept_verbatim verbatim
+  def accept_verbatim(verbatim)
     text = verbatim.text.rstrip
 
     klass = nil
@@ -248,7 +248,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Adds +rule+ to the output
 
-  def accept_rule rule
+  def accept_rule(rule)
     @res << "<hr>\n"
   end
 
@@ -301,7 +301,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # Adds +heading+ to the output.  The headings greater than 6 are trimmed to
   # level 6.
 
-  def accept_heading heading
+  def accept_heading(heading)
     level = [6, heading.level].min
 
     label = heading.label @code_object
@@ -322,14 +322,14 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Adds +raw+ to the output
 
-  def accept_raw raw
+  def accept_raw(raw)
     @res << raw.parts.join("\n")
   end
 
   ##
   # Adds +table+ to the output
 
-  def accept_table header, body, aligns
+  def accept_table(header, body, aligns)
     @res << "\n<table role=\"table\">\n<thead>\n<tr>\n"
     header.zip(aligns) do |text, align|
       @res << '<th'
@@ -362,7 +362,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # Generate a link to +url+ with content +text+.  Handles the special cases
   # for img: and link: described under handle_regexp_HYPERLINK
 
-  def gen_url url, text
+  def gen_url(url, text)
     scheme, url, id = parse_url url
 
     if %w[http https link].include?(scheme) and
@@ -436,7 +436,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Returns true if text is valid ruby syntax
 
-  def parseable? text
+  def parseable?(text)
     verbose, $VERBOSE = $VERBOSE, nil
     catch(:valid) do
       eval("BEGIN { throw :valid, true }\n#{text}")
@@ -450,7 +450,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   ##
   # Converts +item+ to HTML using RDoc::Text#to_html
 
-  def to_html item
+  def to_html(item)
     super convert_flow @am.flow item
   end
 

--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -58,7 +58,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
   # Creates a link to the reference +name+ if the name exists.  If +text+ is
   # given it is used as the link text, otherwise +name+ is used.
 
-  def cross_reference name, text = nil, code = true, rdoc_ref: false
+  def cross_reference(name, text = nil, code = true, rdoc_ref: false)
     lookup = name
 
     name = name[1..-1] unless @show_hash if name[0, 1] == '#'
@@ -101,7 +101,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
   # Handles <tt>rdoc-ref:</tt> scheme links and allows RDoc::Markup::ToHtml to
   # handle other schemes.
 
-  def handle_regexp_HYPERLINK target
+  def handle_regexp_HYPERLINK(target)
     url = target.text
 
     case url
@@ -120,7 +120,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
   # All other contents are handled by
   # {the superclass}[rdoc-ref:RDoc::Markup::ToHtml#handle_regexp_RDOCLINK]
 
-  def handle_regexp_RDOCLINK target
+  def handle_regexp_RDOCLINK(target)
     url = target.text
 
     case url
@@ -135,7 +135,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
   # Generates links for <tt>rdoc-ref:</tt> scheme URLs and allows
   # RDoc::Markup::ToHtml to handle other schemes.
 
-  def gen_url url, text
+  def gen_url(url, text)
     if url =~ /\Ardoc-ref:/
       name = $'
       cross_reference name, text, name == text, rdoc_ref: true
@@ -147,7 +147,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
   ##
   # Creates an HTML link to +name+ with the given +text+.
 
-  def link name, text, code = true, rdoc_ref: false
+  def link(name, text, code = true, rdoc_ref: false)
     if !(name.end_with?('+@', '-@')) and name =~ /(.*[^#:])?@/
       name = $1
       label = $'

--- a/lib/rdoc/markup/to_html_snippet.rb
+++ b/lib/rdoc/markup/to_html_snippet.rb
@@ -34,7 +34,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   # next word boundary after the given number of +characters+ or +paragraphs+
   # of text have been encountered.
 
-  def initialize options, characters = 100, paragraphs = 3, markup = nil
+  def initialize(options, characters = 100, paragraphs = 3, markup = nil)
     super options, markup
 
     @character_limit = characters
@@ -50,7 +50,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Adds +heading+ to the output as a paragraph
 
-  def accept_heading heading
+  def accept_heading(heading)
     @res << "<p>#{to_html heading.text}\n"
 
     add_paragraph
@@ -69,7 +69,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Adds +paragraph+ to the output
 
-  def accept_paragraph paragraph
+  def accept_paragraph(paragraph)
     para = @in_list_entry.last || "<p>"
 
     text = paragraph.text @hard_break
@@ -82,20 +82,20 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Finishes consumption of +list_item+
 
-  def accept_list_item_end list_item
+  def accept_list_item_end(list_item)
   end
 
   ##
   # Prepares the visitor for consuming +list_item+
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     @res << list_item_start(list_item, @list.last)
   end
 
   ##
   # Prepares the visitor for consuming +list+
 
-  def accept_list_start list
+  def accept_list_start(list)
     @list << list.type
     @res << html_list_name(list.type, true)
     @in_list_entry.push ''
@@ -104,7 +104,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Adds +verbatim+ to the output
 
-  def accept_verbatim verbatim
+  def accept_verbatim(verbatim)
     throw :done if @characters >= @character_limit
     input = verbatim.text.rstrip
 
@@ -128,14 +128,14 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Removes escaping from the cross-references in +target+
 
-  def handle_regexp_CROSSREF target
+  def handle_regexp_CROSSREF(target)
     target.text.sub(/\A\\/, '')
   end
 
   ##
   # +target+ is a <code><br></code>
 
-  def handle_regexp_HARD_BREAK target
+  def handle_regexp_HARD_BREAK(target)
     @characters -= 4
     '<br>'
   end
@@ -143,7 +143,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Lists are paragraphs, but notes and labels have a separator
 
-  def list_item_start list_item, list_type
+  def list_item_start(list_item, list_type)
     throw :done if @characters >= @character_limit
 
     case list_type
@@ -168,7 +168,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   # Returns just the text of +link+, +url+ is only used to determine the link
   # type.
 
-  def gen_url url, text
+  def gen_url(url, text)
     if url =~ /^rdoc-label:([^:]*)(?::(.*))?/ then
       type = "link"
     elsif url =~ /([A-Za-z]+):(.*)/ then
@@ -188,7 +188,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # In snippets, there are no lists
 
-  def html_list_name list_type, open_tag
+  def html_list_name(list_type, open_tag)
     ''
   end
 
@@ -204,7 +204,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Marks up +content+
 
-  def convert content
+  def convert(content)
     catch :done do
       return super
     end
@@ -215,7 +215,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Converts flow items +flow+
 
-  def convert_flow flow
+  def convert_flow(flow)
     throw :done if @characters >= @character_limit
 
     res = []
@@ -251,7 +251,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   # Maintains a bitmask to allow HTML elements to be closed properly.  See
   # RDoc::Markup::Formatter.
 
-  def on_tags res, item
+  def on_tags(res, item)
     @mask ^= item.turn_on
 
     super
@@ -261,7 +261,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   # Maintains a bitmask to allow HTML elements to be closed properly.  See
   # RDoc::Markup::Formatter.
 
-  def off_tags res, item
+  def off_tags(res, item)
     @mask ^= item.turn_off
 
     super
@@ -270,7 +270,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   ##
   # Truncates +text+ at the end of the first word after the character_limit.
 
-  def truncate text
+  def truncate(text)
     length = text.length
     characters = @characters
     @characters += length

--- a/lib/rdoc/markup/to_joined_paragraph.rb
+++ b/lib/rdoc/markup/to_joined_paragraph.rb
@@ -22,7 +22,7 @@ class RDoc::Markup::ToJoinedParagraph < RDoc::Markup::Formatter
   ##
   # Converts the parts of +paragraph+ to a single entry.
 
-  def accept_paragraph paragraph
+  def accept_paragraph(paragraph)
     parts = paragraph.parts.chunk do |part|
       String === part
     end.flat_map do |string, chunk|

--- a/lib/rdoc/markup/to_label.rb
+++ b/lib/rdoc/markup/to_label.rb
@@ -13,7 +13,7 @@ class RDoc::Markup::ToLabel < RDoc::Markup::Formatter
   ##
   # Creates a new formatter that will output HTML-safe labels
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super nil, markup
 
     @markup.add_regexp_handling RDoc::CrossReference::CROSSREF_REGEXP, :CROSSREF
@@ -29,7 +29,7 @@ class RDoc::Markup::ToLabel < RDoc::Markup::Formatter
   ##
   # Converts +text+ to an HTML-safe label
 
-  def convert text
+  def convert(text)
     label = convert_flow @am.flow text
 
     CGI.escape(label).gsub('%', '-').sub(/^-/, '')
@@ -39,7 +39,7 @@ class RDoc::Markup::ToLabel < RDoc::Markup::Formatter
   # Converts the CROSSREF +target+ to plain text, removing the suppression
   # marker, if any
 
-  def handle_regexp_CROSSREF target
+  def handle_regexp_CROSSREF(target)
     text = target.text
 
     text.sub(/^\\/, '')
@@ -48,7 +48,7 @@ class RDoc::Markup::ToLabel < RDoc::Markup::Formatter
   ##
   # Converts the TIDYLINK +target+ to just the text part
 
-  def handle_regexp_TIDYLINK target
+  def handle_regexp_TIDYLINK(target)
     text = target.text
 
     return text unless text =~ /\{(.*?)\}\[(.*?)\]/ or text =~ /(\S+)\[(.*?)\]/

--- a/lib/rdoc/markup/to_markdown.rb
+++ b/lib/rdoc/markup/to_markdown.rb
@@ -9,7 +9,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Creates a new formatter that will output Markdown format text
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super
 
     @headings[1] = ['# ',      '']
@@ -37,21 +37,21 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Adds a newline to the output
 
-  def handle_regexp_HARD_BREAK target
+  def handle_regexp_HARD_BREAK(target)
     "  \n"
   end
 
   ##
   # Finishes consumption of `list`
 
-  def accept_list_end list
+  def accept_list_end(list)
     super
   end
 
   ##
   # Finishes consumption of `list_item`
 
-  def accept_list_item_end list_item
+  def accept_list_item_end(list_item)
     width = case @list_type.last
             when :BULLET then
               4
@@ -72,7 +72,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Prepares the visitor for consuming `list_item`
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     type = @list_type.last
 
     case type
@@ -97,7 +97,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Prepares the visitor for consuming `list`
 
-  def accept_list_start list
+  def accept_list_start(list)
     case list.type
     when :BULLET, :LABEL, :NOTE then
       @list_index << nil
@@ -114,7 +114,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Adds `rule` to the output
 
-  def accept_rule rule
+  def accept_rule(rule)
     use_prefix or @res << ' ' * @indent
     @res << '-' * 3
     @res << "\n"
@@ -123,7 +123,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Outputs `verbatim` indented 4 columns
 
-  def accept_verbatim verbatim
+  def accept_verbatim(verbatim)
     indent = ' ' * (@indent + 4)
 
     verbatim.parts.each do |part|
@@ -137,7 +137,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Creates a Markdown-style URL from +url+ with +text+.
 
-  def gen_url url, text
+  def gen_url(url, text)
     scheme, url, = parse_url url
 
     "[#{text.sub(%r{^#{scheme}:/*}i, '')}](#{url})"
@@ -146,7 +146,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Handles <tt>rdoc-</tt> type links for footnotes.
 
-  def handle_rdoc_link url
+  def handle_rdoc_link(url)
     case url
     when /^rdoc-ref:/ then
       $'
@@ -166,7 +166,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Converts the RDoc markup tidylink into a Markdown.style link.
 
-  def handle_regexp_TIDYLINK target
+  def handle_regexp_TIDYLINK(target)
     text = target.text
 
     return text unless text =~ /\{(.*?)\}\[(.*?)\]/ or text =~ /(\S+)\[(.*?)\]/
@@ -184,7 +184,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   ##
   # Converts the rdoc-...: links into a Markdown.style links.
 
-  def handle_regexp_RDOCLINK target
+  def handle_regexp_RDOCLINK(target)
     handle_rdoc_link target.text
   end
 

--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -42,7 +42,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Creates a new formatter that will output (mostly) \RDoc markup
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super nil, markup
 
     @markup.add_regexp_handling(/\\\S/, :SUPPRESSED_CROSSREF)
@@ -74,14 +74,14 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +blank_line+ to the output
 
-  def accept_blank_line blank_line
+  def accept_blank_line(blank_line)
     @res << "\n"
   end
 
   ##
   # Adds +paragraph+ to the output
 
-  def accept_block_quote block_quote
+  def accept_block_quote(block_quote)
     @indent += 2
 
     block_quote.parts.each do |part|
@@ -96,7 +96,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +heading+ to the output
 
-  def accept_heading heading
+  def accept_heading(heading)
     use_prefix or @res << ' ' * @indent
     @res << @headings[heading.level][0]
     @res << attributes(heading.text)
@@ -107,7 +107,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Finishes consumption of +list+
 
-  def accept_list_end list
+  def accept_list_end(list)
     @list_index.pop
     @list_type.pop
     @list_width.pop
@@ -116,7 +116,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Finishes consumption of +list_item+
 
-  def accept_list_item_end list_item
+  def accept_list_item_end(list_item)
     width = case @list_type.last
             when :BULLET then
               2
@@ -140,7 +140,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Prepares the visitor for consuming +list_item+
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     type = @list_type.last
 
     case type
@@ -173,7 +173,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Prepares the visitor for consuming +list+
 
-  def accept_list_start list
+  def accept_list_start(list)
     case list.type
     when :BULLET then
       @list_index << nil
@@ -200,7 +200,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +paragraph+ to the output
 
-  def accept_paragraph paragraph
+  def accept_paragraph(paragraph)
     text = paragraph.text @hard_break
     wrap attributes text
   end
@@ -208,7 +208,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +paragraph+ to the output
 
-  def accept_indented_paragraph paragraph
+  def accept_indented_paragraph(paragraph)
     @indent += paragraph.indent
     text = paragraph.text @hard_break
     wrap attributes text
@@ -218,14 +218,14 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +raw+ to the output
 
-  def accept_raw raw
+  def accept_raw(raw)
     @res << raw.parts.join("\n")
   end
 
   ##
   # Adds +rule+ to the output
 
-  def accept_rule rule
+  def accept_rule(rule)
     use_prefix or @res << ' ' * @indent
     @res << '-' * (@width - @indent)
     @res << "\n"
@@ -234,7 +234,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Outputs +verbatim+ indented 2 columns
 
-  def accept_verbatim verbatim
+  def accept_verbatim(verbatim)
     indent = ' ' * (@indent + 2)
 
     verbatim.parts.each do |part|
@@ -248,7 +248,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds +table+ to the output
 
-  def accept_table header, body, aligns
+  def accept_table(header, body, aligns)
     widths = header.zip(*body).map do |cols|
       cols.map(&:size).max
     end
@@ -276,7 +276,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Applies attribute-specific markup to +text+ using RDoc::AttributeManager
 
-  def attributes text
+  def attributes(text)
     flow = @am.flow text.dup
     convert_flow flow
   end
@@ -291,7 +291,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Removes preceding \\ from the suppressed crossref +target+
 
-  def handle_regexp_SUPPRESSED_CROSSREF target
+  def handle_regexp_SUPPRESSED_CROSSREF(target)
     text = target.text
     text = text.sub('\\', '') unless in_tt?
     text
@@ -300,7 +300,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Adds a newline to the output
 
-  def handle_regexp_HARD_BREAK target
+  def handle_regexp_HARD_BREAK(target)
     "\n"
   end
 
@@ -331,7 +331,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   ##
   # Wraps +text+ to #width
 
-  def wrap text
+  def wrap(text)
     return unless text && !text.empty?
 
     text_len = @width - @indent

--- a/lib/rdoc/markup/to_table_of_contents.rb
+++ b/lib/rdoc/markup/to_table_of_contents.rb
@@ -33,7 +33,7 @@ class RDoc::Markup::ToTableOfContents < RDoc::Markup::Formatter
   ##
   # Adds +document+ to the output, using its heading cutoff if present
 
-  def accept_document document
+  def accept_document(document)
     @omit_headings_below = document.omit_headings_below
 
     super
@@ -42,7 +42,7 @@ class RDoc::Markup::ToTableOfContents < RDoc::Markup::Formatter
   ##
   # Adds +heading+ to the table of contents
 
-  def accept_heading heading
+  def accept_heading(heading)
     @res << heading unless suppressed? heading
   end
 
@@ -64,7 +64,7 @@ class RDoc::Markup::ToTableOfContents < RDoc::Markup::Formatter
   ##
   # Returns true if +heading+ is below the display threshold
 
-  def suppressed? heading
+  def suppressed?(heading)
     return false unless @omit_headings_below
 
     heading.level > @omit_headings_below

--- a/lib/rdoc/markup/to_test.rb
+++ b/lib/rdoc/markup/to_test.rb
@@ -22,7 +22,7 @@ class RDoc::Markup::ToTest < RDoc::Markup::Formatter
     @res << convert_flow(@am.flow(paragraph.text))
   end
 
-  def accept_raw raw
+  def accept_raw(raw)
     @res << raw.parts.join
   end
 

--- a/lib/rdoc/markup/to_tt_only.rb
+++ b/lib/rdoc/markup/to_tt_only.rb
@@ -18,7 +18,7 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
   ##
   # Creates a new tt-only formatter.
 
-  def initialize markup = nil
+  def initialize(markup = nil)
     super nil, markup
 
     add_tag :TT, nil, nil
@@ -27,28 +27,28 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
   ##
   # Adds tts from +block_quote+ to the output
 
-  def accept_block_quote block_quote
+  def accept_block_quote(block_quote)
     tt_sections block_quote.text
   end
 
   ##
   # Pops the list type for +list+ from #list_type
 
-  def accept_list_end list
+  def accept_list_end(list)
     @list_type.pop
   end
 
   ##
   # Pushes the list type for +list+ onto #list_type
 
-  def accept_list_start list
+  def accept_list_start(list)
     @list_type << list.type
   end
 
   ##
   # Prepares the visitor for consuming +list_item+
 
-  def accept_list_item_start list_item
+  def accept_list_item_start(list_item)
     case @list_type.last
     when :NOTE, :LABEL then
       Array(list_item.label).map do |label|
@@ -60,7 +60,7 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
   ##
   # Adds +paragraph+ to the output
 
-  def accept_paragraph paragraph
+  def accept_paragraph(paragraph)
     tt_sections(paragraph.text)
   end
 
@@ -68,7 +68,7 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
   # Does nothing to +markup_item+ because it doesn't have any user-built
   # content
 
-  def do_nothing markup_item
+  def do_nothing(markup_item)
   end
 
   alias accept_blank_line    do_nothing # :nodoc:
@@ -81,7 +81,7 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
   ##
   # Extracts tt sections from +text+
 
-  def tt_sections text
+  def tt_sections(text)
     flow = @am.flow text.dup
 
     flow.each do |item|

--- a/lib/rdoc/markup/verbatim.rb
+++ b/lib/rdoc/markup/verbatim.rb
@@ -15,14 +15,14 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
     @format = nil
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     super and @format == other.format
   end
 
   ##
   # Calls #accept_verbatim on +visitor+
 
-  def accept visitor
+  def accept(visitor)
     visitor.accept_verbatim self
   end
 
@@ -50,7 +50,7 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
     @parts = parts
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     self.class.name =~ /.*::(\w{1,4})/i
 
     q.group 2, "[#{$1.downcase}: ", ']' do

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -373,7 +373,7 @@ class RDoc::Options
 
   attr_accessor :file_path_prefix
 
-  def initialize loaded_options = nil # :nodoc:
+  def initialize(loaded_options = nil) # :nodoc:
     init_ivars
     override loaded_options if loaded_options
   end
@@ -431,7 +431,7 @@ class RDoc::Options
     @file_path_prefix = nil
   end
 
-  def init_with map # :nodoc:
+  def init_with(map) # :nodoc:
     init_ivars
 
     encoding = map['encoding']
@@ -462,11 +462,11 @@ class RDoc::Options
     @static_path  = sanitize_path map['static_path']
   end
 
-  def yaml_initialize tag, map # :nodoc:
+  def yaml_initialize(tag, map) # :nodoc:
     init_with map
   end
 
-  def override map # :nodoc:
+  def override(map) # :nodoc:
     if map.has_key?('encoding')
       encoding = map['encoding']
       @encoding = encoding ? Encoding.find(encoding) : encoding
@@ -503,7 +503,7 @@ class RDoc::Options
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @encoding       == other.encoding       and
       @embed_mixins   == other.embed_mixins   and
@@ -695,7 +695,7 @@ class RDoc::Options
   ##
   # Parses command line options.
 
-  def parse argv
+  def parse(argv)
     ignore_invalid = true
 
     argv.insert(0, *ENV['RDOCOPT'].split) if ENV['RDOCOPT']
@@ -1274,14 +1274,14 @@ Usage: #{opt.program_name} [options] [names...]
   ##
   # Set quietness to +bool+
 
-  def quiet= bool
+  def quiet=(bool)
     @verbosity = bool ? 0 : 1
   end
 
   ##
   # Removes directories from +path+ that are outside the current directory
 
-  def sanitize_path path
+  def sanitize_path(path)
     require 'pathname'
     dot = Pathname.new('.').expand_path
 
@@ -1308,7 +1308,7 @@ Usage: #{opt.program_name} [options] [names...]
   # the options instance.  This allows generators to add custom options or set
   # default options.
 
-  def setup_generator generator_name = @generator_name
+  def setup_generator(generator_name = @generator_name)
     @generator = @generators[generator_name]
 
     unless @generator then
@@ -1330,7 +1330,7 @@ Usage: #{opt.program_name} [options] [names...]
   ##
   # Finds the template dir for +template+
 
-  def template_dir_for template
+  def template_dir_for(template)
     template_path = File.join 'rdoc', 'generator', 'template', template
 
     $LOAD_PATH.map do |path|
@@ -1347,7 +1347,7 @@ Usage: #{opt.program_name} [options] [names...]
   # When +:all+ is passed, visibility is set to +:private+, similarly to
   # RDOCOPT="--all", see #visibility for more information.
 
-  def visibility= visibility
+  def visibility=(visibility)
     case visibility
     when :all
       @visibility = :private
@@ -1359,7 +1359,7 @@ Usage: #{opt.program_name} [options] [names...]
   ##
   # Displays a warning using Kernel#warn if we're being verbose
 
-  def warn message
+  def warn(message)
     super message if @verbosity > 1
   end
 

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -91,7 +91,7 @@ class RDoc::Parser
   # Checks if +file+ is a zip file in disguise.  Signatures from
   # http://www.garykessler.net/library/file_sigs.html
 
-  def self.zip? file
+  def self.zip?(file)
     zip_signature = File.read file, 4
 
     zip_signature == "PK\x03\x04" or
@@ -104,7 +104,7 @@ class RDoc::Parser
   ##
   # Return a parser that can handle a particular extension
 
-  def self.can_parse file_name
+  def self.can_parse(file_name)
     parser = can_parse_by_name file_name
 
     # HACK Selenium hides a jar file using a .txt extension
@@ -117,7 +117,7 @@ class RDoc::Parser
   # Returns a parser that can handle the extension for +file_name+.  This does
   # not depend upon the file being readable.
 
-  def self.can_parse_by_name file_name
+  def self.can_parse_by_name(file_name)
     _, parser = RDoc::Parser.parsers.find { |regexp,| regexp =~ file_name }
 
     # The default parser must not parse binary files
@@ -140,7 +140,7 @@ class RDoc::Parser
   ##
   # Returns the file type from the modeline in +file_name+
 
-  def self.check_modeline file_name
+  def self.check_modeline(file_name)
     line = File.open file_name do |io|
       io.gets
     end
@@ -166,7 +166,7 @@ class RDoc::Parser
   # Finds and instantiates the correct parser for the given +file_name+ and
   # +content+.
 
-  def self.for top_level, content, options, stats
+  def self.for(top_level, content, options, stats)
     file_name = top_level.absolute_name
     return if binary? file_name
 
@@ -208,7 +208,7 @@ class RDoc::Parser
   ##
   # Removes an emacs-style modeline from the first line of the document
 
-  def self.remove_modeline content
+  def self.remove_modeline(content)
     content.sub(/\A.*-\*-\s*(.*?\S)\s*-\*-.*\r?\n/, '')
   end
 
@@ -229,7 +229,7 @@ class RDoc::Parser
   #
   # Any comment style may be used to hide the markup comment.
 
-  def self.use_markup content
+  def self.use_markup(content)
     markup = content.lines.first(3).grep(/markup:\s+(\w+)/) { $1 }.first
 
     return unless markup
@@ -252,7 +252,7 @@ class RDoc::Parser
   # RDoc::Markup::PreProcess object is created which allows processing of
   # directives.
 
-  def initialize top_level, content, options, stats
+  def initialize(top_level, content, options, stats)
     @top_level = top_level
     @top_level.parser = self.class
     @store = @top_level.store

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -168,7 +168,7 @@ class RDoc::Parser::C < RDoc::Parser
   # Prepares for parsing a C file.  See RDoc::Parser#initialize for details on
   # the arguments.
 
-  def initialize top_level, content, options, stats
+  def initialize(top_level, content, options, stats)
     super
 
     @known_classes = RDoc::KNOWN_CLASSES.dup
@@ -193,7 +193,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     @enclosure_dependencies.extend TSort
 
-    def @enclosure_dependencies.tsort_each_node &block
+    def @enclosure_dependencies.tsort_each_node(&block)
       each_key(&block)
     rescue TSort::Cyclic => e
       cycle_vars = e.message.scan(/"(.*?)"/).flatten
@@ -211,7 +211,7 @@ class RDoc::Parser::C < RDoc::Parser
       retry
     end
 
-    def @enclosure_dependencies.tsort_each_child node, &block
+    def @enclosure_dependencies.tsort_each_child(node, &block)
       fetch(node, []).each(&block)
     end
   end
@@ -519,7 +519,7 @@ class RDoc::Parser::C < RDoc::Parser
   # Finds the comment for an alias on +class_name+ from +new_name+ to
   # +old_name+
 
-  def find_alias_comment class_name, new_name, old_name
+  def find_alias_comment(class_name, new_name, old_name)
     content =~ %r%((?>/\*.*?\*/\s+))
                   rb_define_alias\(\s*#{Regexp.escape class_name}\s*,
                                    \s*"#{Regexp.escape new_name}"\s*,
@@ -537,7 +537,7 @@ class RDoc::Parser::C < RDoc::Parser
   # +read+ and +write+ are the read/write flags ('1' or '0').  Either both or
   # neither must be provided.
 
-  def find_attr_comment var_name, attr_name, read = nil, write = nil
+  def find_attr_comment(var_name, attr_name, read = nil, write = nil)
     attr_name = Regexp.escape attr_name
 
     rw = if read and write then
@@ -570,7 +570,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Generate a Ruby-method table
 
-  def gen_body_table file_content
+  def gen_body_table(file_content)
     table = {}
     file_content.scan(%r{
       ((?>/\*.*?\*/\s*)?)
@@ -594,7 +594,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Find the C code corresponding to a Ruby method
 
-  def find_body class_name, meth_name, meth_obj, file_content, quiet = false
+  def find_body(class_name, meth_name, meth_obj, file_content, quiet = false)
     if file_content
       @body_table ||= {}
       @body_table[file_content] ||= gen_body_table file_content
@@ -719,7 +719,7 @@ class RDoc::Parser::C < RDoc::Parser
   #    */
   #   VALUE cFoo = rb_define_class("Foo", rb_cObject);
 
-  def find_class_comment class_name, class_mod
+  def find_class_comment(class_name, class_mod)
     comment = nil
 
     if @content =~ %r%
@@ -752,7 +752,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Generate a const table
 
-  def gen_const_table file_content
+  def gen_const_table(file_content)
     table = {}
     @content.scan(%r{
       (?<doc>(?>^\s*/\*.*?\*/\s+))
@@ -806,7 +806,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Handles modifiers in +comment+ and updates +meth_obj+ as appropriate.
 
-  def find_modifiers comment, meth_obj
+  def find_modifiers(comment, meth_obj)
     comment.normalize
     meth_obj.call_seq = comment.extract_call_seq
 
@@ -816,7 +816,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Finds a <tt>Document-method</tt> override for +meth_obj+ on +class_name+
 
-  def find_override_comment class_name, meth_obj
+  def find_override_comment(class_name, meth_obj)
     name = Regexp.escape meth_obj.name
     prefix = Regexp.escape meth_obj.name_prefix
 
@@ -1060,7 +1060,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Registers a singleton class +sclass_var+ as a singleton of +class_var+
 
-  def handle_singleton sclass_var, class_var
+  def handle_singleton(sclass_var, class_var)
     class_name = @known_classes[class_var]
 
     @known_classes[sclass_var]     = class_name
@@ -1071,7 +1071,7 @@ class RDoc::Parser::C < RDoc::Parser
   # Loads the variable map with the given +name+ from the RDoc::Store, if
   # present.
 
-  def load_variable_map map_name
+  def load_variable_map(map_name)
     return {} unless files = @store.cache[map_name]
     return {} unless name_map = files[@file_name]
 
@@ -1101,7 +1101,7 @@ class RDoc::Parser::C < RDoc::Parser
   # This method modifies the +comment+
   # Both :main: and :title: directives are deprecated and will be removed in RDoc 7.
 
-  def look_for_directives_in context, comment
+  def look_for_directives_in(context, comment)
     @preprocess.handle comment, context do |directive, param|
       case directive
       when 'main' then
@@ -1138,7 +1138,7 @@ class RDoc::Parser::C < RDoc::Parser
   # Extracts parameters from the +method_body+ and returns a method
   # parameter string.  Follows 1.9.3dev's scan-arg-spec, see README.EXT
 
-  def rb_scan_args method_body
+  def rb_scan_args(method_body)
     method_body =~ /rb_scan_args\((.*?)\)/m
     return '(*args)' unless $1
 
@@ -1249,7 +1249,7 @@ class RDoc::Parser::C < RDoc::Parser
   ##
   # Creates a RDoc::Comment instance.
 
-  def new_comment text = nil, location = nil, language = nil
+  def new_comment(text = nil, location = nil, language = nil)
     RDoc::Comment.new(text, location, language).tap do |comment|
       comment.format = @markup
     end

--- a/lib/rdoc/parser/changelog.rb
+++ b/lib/rdoc/parser/changelog.rb
@@ -23,7 +23,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   # Continued function listings are joined together as a single entry.
   # Continued descriptions are joined to make a single paragraph.
 
-  def continue_entry_body entry_body, continuation
+  def continue_entry_body(entry_body, continuation)
     return unless last = entry_body.last
 
     if last =~ /\)\s*\z/ and continuation =~ /\A\(/ then
@@ -41,7 +41,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   ##
   # Creates an RDoc::Markup::Document given the +groups+ of ChangeLog entries.
 
-  def create_document groups
+  def create_document(groups)
     doc = RDoc::Markup::Document.new
     doc.omit_headings_below = 2
     doc.file = @top_level
@@ -63,7 +63,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   # Returns a list of ChangeLog entries an RDoc::Markup nodes for the given
   # +entries+.
 
-  def create_entries entries
+  def create_entries(entries)
     out = []
 
     entries.each do |entry, items|
@@ -80,7 +80,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   # Returns an RDoc::Markup::List containing the given +items+ in the
   # ChangeLog
 
-  def create_items items
+  def create_items(items)
     list = RDoc::Markup::List.new :NOTE
 
     items.each do |item|
@@ -100,7 +100,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   ##
   # Groups +entries+ by date.
 
-  def group_entries entries
+  def group_entries(entries)
     @time_cache ||= {}
     entries.group_by do |title, _|
       begin
@@ -260,7 +260,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
     # RDoc::Parser::ChangeLog::Git::LogEntry list for the given
     # +entries+.
 
-    def create_entries entries
+    def create_entries(entries)
       # git log entries have no strictly itemized style like the old
       # style, just assume Markdown.
       entries.map do |commit, entry|
@@ -296,7 +296,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
         "label-#{commit}"
       end
 
-      def label context = nil
+      def label(context = nil)
         aref
       end
 
@@ -311,7 +311,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
         end + " {#{author}}[mailto:#{email}]"
       end
 
-      def accept visitor
+      def accept(visitor)
         visitor.accept_heading self
         begin
           if visitor.respond_to?(:code_object=)
@@ -328,7 +328,7 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
         end
       end
 
-      def pretty_print q # :nodoc:
+      def pretty_print(q) # :nodoc:
         q.group(2, '[log_entry: ', ']') do
           q.text commit
           q.text ','

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -77,7 +77,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
   # Records the location of this +container+ in the file for this parser and
   # adds it to the list of classes and modules in the file.
 
-  def record_location container # :nodoc:
+  def record_location(container) # :nodoc:
     case container
     when RDoc::ClassModule then
       @top_level.add_to_classes_or_modules container

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -200,7 +200,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Retrieves the read token stream and replaces +pattern+ with +replacement+
   # using gsub.  If the result is only a ";" returns an empty string.
 
-  def get_tkread_clean pattern, replacement # :nodoc:
+  def get_tkread_clean(pattern, replacement) # :nodoc:
     read = get_tkread.gsub(pattern, replacement).strip
     return '' if read == ';'
     read
@@ -214,7 +214,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # +singleton+ if the methods following should be converted to singleton
   # methods.
 
-  def get_visibility_information tk, single # :nodoc:
+  def get_visibility_information(tk, single) # :nodoc:
     vis_type  = tk[:text]
     singleton = single == SINGLE
 
@@ -292,7 +292,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Creates a new attribute in +container+ with +name+.
 
-  def create_attr container, single, name, rw, comment # :nodoc:
+  def create_attr(container, single, name, rw, comment) # :nodoc:
     att = RDoc::Attr.new get_tkread, name, rw, comment, singleton: single == SINGLE
     record_location att
 
@@ -306,7 +306,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Creates a module alias in +container+ at +rhs_name+ (or at the top-level
   # for "::") with the name from +constant+.
 
-  def create_module_alias container, constant, rhs_name # :nodoc:
+  def create_module_alias(container, constant, rhs_name) # :nodoc:
     mod = if rhs_name =~ /^::/ then
             @store.find_class_or_module rhs_name
           else
@@ -346,7 +346,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # with :: separated named) and return the ultimate name, the associated
   # container, and the given name (with the ::).
 
-  def get_class_or_module container, ignore_constants = false
+  def get_class_or_module(container, ignore_constants = false)
     skip_tkspace
     name_t = get_tk
     given_name = ''.dup
@@ -564,7 +564,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # We see the RPAREN as the next token, so we need to exit early.  This still
   # won't catch all cases (such as "a = yield + 1"
 
-  def get_end_token tk # :nodoc:
+  def get_end_token(tk) # :nodoc:
     case tk[:kind]
     when :on_lparen
       token = RDoc::Parser::RipperStateLex::Token.new
@@ -584,7 +584,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Retrieves the method container for a singleton method.
 
-  def get_method_container container, name_t # :nodoc:
+  def get_method_container(container, name_t) # :nodoc:
     prev_container = container
     container = container.find_module_named(name_t[:text])
 
@@ -652,7 +652,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Marks containers between +container+ and +ancestor+ as ignored
 
-  def suppress_parents container, ancestor # :nodoc:
+  def suppress_parents(container, ancestor) # :nodoc:
     while container and container != ancestor do
       container.suppress unless container.documented?
       container = container.parent
@@ -667,7 +667,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   #
   # This routine modifies its +comment+ parameter.
 
-  def look_for_directives_in container, comment
+  def look_for_directives_in(container, comment)
     @preprocess.handle comment, container do |directive, param|
       case directive
       when 'method', 'singleton-method',
@@ -687,7 +687,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Adds useful info about the parser to +message+
 
-  def make_message message
+  def make_message(message)
     prefix = "#{@file_name}:".dup
 
     tk = peek_tk
@@ -699,7 +699,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Creates a comment with the correct format
 
-  def new_comment comment, line_no = nil
+  def new_comment(comment, line_no = nil)
     c = RDoc::Comment.new comment, @top_level, :ruby
     c.line = line_no
     c.format = @markup
@@ -851,7 +851,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses a class in +context+ with +comment+
 
-  def parse_class container, single, tk, comment
+  def parse_class(container, single, tk, comment)
     line_no = tk[:line_no]
 
     declaration_context = container
@@ -885,8 +885,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses and creates a regular class
 
-  def parse_class_regular container, declaration_context, single, # :nodoc:
-                          name_t, given_name, comment
+  def parse_class_regular(container, declaration_context, single, # :nodoc:
+                          name_t, given_name, comment)
     superclass = '::Object'
 
     if given_name =~ /^::/ then
@@ -925,7 +925,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parses a singleton class in +container+ with the given +name+ and
   # +comment+.
 
-  def parse_class_singleton container, name, comment # :nodoc:
+  def parse_class_singleton(container, name, comment) # :nodoc:
     other = @store.find_class_named name
 
     unless other then
@@ -964,7 +964,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parses a constant in +context+ with +comment+.  If +ignore_constants+ is
   # true, no found constants will be added to RDoc.
 
-  def parse_constant container, tk, comment, ignore_constants = false
+  def parse_constant(container, tk, comment, ignore_constants = false)
     line_no = tk[:line_no]
 
     name = tk[:text]
@@ -1031,7 +1031,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     true
   end
 
-  def parse_constant_body container, constant, is_array_or_hash # :nodoc:
+  def parse_constant_body(container, constant, is_array_or_hash) # :nodoc:
     nest     = 0
     rhs_name = ''.dup
 
@@ -1090,7 +1090,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Generates an RDoc::Method or RDoc::Attr from +comment+ by looking for
   # :method: or :attr: directives in +comment+.
 
-  def parse_comment container, tk, comment
+  def parse_comment(container, tk, comment)
     return parse_comment_tomdoc container, tk, comment if @markup == 'tomdoc'
     column  = tk[:char_no]
     line_no = comment.line.nil? ? tk[:line_no] : comment.line
@@ -1118,7 +1118,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parse a comment that is describing an attribute in +container+ with the
   # given +name+ and +comment+.
 
-  def parse_comment_attr container, type, name, comment # :nodoc:
+  def parse_comment_attr(container, type, name, comment) # :nodoc:
     return if name.empty?
 
     rw = case type
@@ -1130,8 +1130,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
     create_attr container, NORMAL, name, rw, comment
   end
 
-  def parse_comment_ghost container, text, name, column, line_no, # :nodoc:
-                          comment
+  def parse_comment_ghost(container, text, name, column, line_no, # :nodoc:
+                          comment)
     name = nil if name.empty?
 
     meth = RDoc::GhostMethod.new get_tkread, name
@@ -1169,7 +1169,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Creates an RDoc::Method on +container+ from +comment+ if there is a
   # Signature section in the comment
 
-  def parse_comment_tomdoc container, tk, comment
+  def parse_comment_tomdoc(container, tk, comment)
     return unless signature = RDoc::TomDoc.signature(comment)
     column  = tk[:char_no]
     line_no = tk[:line_no]
@@ -1204,7 +1204,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parses an +include+ or +extend+, indicated by the +klass+ and adds it to
   # +container+ # with +comment+
 
-  def parse_extend_or_include klass, container, comment # :nodoc:
+  def parse_extend_or_include(klass, container, comment) # :nodoc:
     loop do
       skip_tkspace_comment
 
@@ -1224,7 +1224,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses an +included+ with a block feature of ActiveSupport::Concern.
 
-  def parse_included_with_activesupport_concern container, comment # :nodoc:
+  def parse_included_with_activesupport_concern(container, comment) # :nodoc:
     skip_tkspace_without_nl
     tk = get_tk
     unless tk[:kind] == :on_lbracket || (tk[:kind] == :on_kw && tk[:text] == 'do')
@@ -1242,7 +1242,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   #
   # Returns true if the comment was not consumed.
 
-  def parse_identifier container, single, tk, comment # :nodoc:
+  def parse_identifier(container, single, tk, comment) # :nodoc:
     case tk[:text]
     when 'private', 'protected', 'public', 'private_class_method',
          'public_class_method', 'module_function' then
@@ -1385,7 +1385,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # determine the name while +tk+ is used in an error message if the name
   # cannot be determined.
 
-  def parse_meta_method_name comment, tk # :nodoc:
+  def parse_meta_method_name(comment, tk) # :nodoc:
     if comment.text.sub!(/^# +:?method: *(\S*).*?\n/i, '') then
       return $1 unless $1.empty?
     end
@@ -1409,7 +1409,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses the parameters and block for a meta-programmed method.
 
-  def parse_meta_method_params container, single, meth, tk, comment # :nodoc:
+  def parse_meta_method_params(container, single, meth, tk, comment) # :nodoc:
     token_listener meth do
       meth.params = ''
 
@@ -1495,7 +1495,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses the parameters and body of +meth+
 
-  def parse_method_params_and_body container, single, meth, added_container
+  def parse_method_params_and_body(container, single, meth, added_container)
     token_listener meth do
       parse_method_parameters meth
 
@@ -1525,7 +1525,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses a method that needs to be ignored.
 
-  def parse_method_dummy container
+  def parse_method_dummy(container)
     dummy = RDoc::Context.new
     dummy.parent = container
     dummy.store  = container.store
@@ -1538,7 +1538,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Returns the method name, the container it is in (for def Foo.name) and if
   # it is a singleton or regular method.
 
-  def parse_method_name container # :nodoc:
+  def parse_method_name(container) # :nodoc:
     skip_tkspace
     name_t = get_tk
     back_tk = skip_tkspace_without_nl
@@ -1565,7 +1565,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # For the given +container+ and initial name token +name_t+ the method name
   # is parsed from the token stream for a regular method.
 
-  def parse_method_name_regular container, name_t # :nodoc:
+  def parse_method_name_regular(container, name_t) # :nodoc:
     if :on_op == name_t[:kind] && (%w{* & [] []= <<}.include?(name_t[:text])) then
       name_t[:text]
     else
@@ -1583,7 +1583,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # and the new +container+ (if necessary) are parsed from the token stream
   # for a singleton method.
 
-  def parse_method_name_singleton container, name_t # :nodoc:
+  def parse_method_name_singleton(container, name_t) # :nodoc:
     skip_tkspace
     name_t2 = get_tk
 
@@ -1694,7 +1694,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   #
   # and add this as the block_params for the method
 
-  def parse_method_parameters method
+  def parse_method_parameters(method)
     res = parse_method_or_yield_parameters method
 
     res = "(#{res})" unless res =~ /\A\(/
@@ -1709,7 +1709,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses an RDoc::NormalModule in +container+ with +comment+
 
-  def parse_module container, single, tk, comment
+  def parse_module(container, single, tk, comment)
     container, name_t, = get_class_or_module container
 
     name = name_t[:text]
@@ -1989,7 +1989,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parses up to +no+ symbol arguments surrounded by () and places them in
   # +args+.
 
-  def parse_symbol_arg_paren no # :nodoc:
+  def parse_symbol_arg_paren(no) # :nodoc:
     args = []
 
     loop do
@@ -2017,7 +2017,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Parses up to +no+ symbol arguments separated by spaces and places them in
   # +args+.
 
-  def parse_symbol_arg_space no, tk # :nodoc:
+  def parse_symbol_arg_space(no, tk) # :nodoc:
     args = []
 
     unget_tk tk
@@ -2065,7 +2065,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Parses statements in the top-level +container+
 
-  def parse_top_level_statements container
+  def parse_top_level_statements(container)
     comment = collect_first_comment
 
     look_for_directives_in container, comment
@@ -2143,7 +2143,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # the name is in +allowed+.  A directive can be found anywhere up to the end
   # of the current line.
 
-  def read_directive allowed
+  def read_directive(allowed)
     tokens = []
 
     while tk = get_tk do
@@ -2175,7 +2175,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   #
   # See also RDoc::Markup::PreProcess#handle_directive
 
-  def read_documentation_modifiers context, allowed
+  def read_documentation_modifiers(context, allowed)
     skip_tkspace_without_nl
     directive, value = read_directive allowed
 
@@ -2194,7 +2194,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Records the location of this +container+ in the file for this parser and
   # adds it to the list of classes and modules in the file.
 
-  def record_location container # :nodoc:
+  def record_location(container) # :nodoc:
     case container
     when RDoc::ClassModule then
       @top_level.add_to_classes_or_modules container
@@ -2305,7 +2305,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Skips the next method in +container+
 
-  def skip_method container
+  def skip_method(container)
     meth = RDoc::AnyMethod.new "", "anon"
     parse_method_parameters meth
     parse_statements container, false, meth
@@ -2326,7 +2326,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Updates visibility in +container+ from +vis_type+ and +vis+.
 
-  def update_visibility container, vis_type, vis, singleton # :nodoc:
+  def update_visibility(container, vis_type, vis, singleton) # :nodoc:
     new_methods = []
 
     case vis_type
@@ -2371,7 +2371,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   ##
   # Prints +message+ to +$stderr+ unless we're being quiet
 
-  def warn message
+  def warn(message)
     @options.warn make_message message
   end
 

--- a/lib/rdoc/parser/simple.rb
+++ b/lib/rdoc/parser/simple.rb
@@ -38,7 +38,7 @@ class RDoc::Parser::Simple < RDoc::Parser
   ##
   # Removes the encoding magic comment from +text+
 
-  def remove_coding_comment text
+  def remove_coding_comment(text)
     text.sub(/\A# .*coding[=:].*$/, '')
   end
 
@@ -49,7 +49,7 @@ class RDoc::Parser::Simple < RDoc::Parser
   # dashes at the beginning of the line.  Three or more dashes are considered
   # to be a rule and ignored.
 
-  def remove_private_comment comment
+  def remove_private_comment(comment)
     # Workaround for gsub encoding for Ruby 1.9.2 and earlier
     empty = ''
     empty = RDoc::Encoding.change_encoding empty, comment.encoding

--- a/lib/rdoc/rd.rb
+++ b/lib/rdoc/rd.rb
@@ -75,7 +75,7 @@ class RDoc::RD
   # Parses +rd+ source and returns an RDoc::Markup::Document.  If the
   # <tt>=begin</tt> or <tt>=end</tt> lines are missing they will be added.
 
-  def self.parse rd
+  def self.parse(rd)
     rd = rd.lines.to_a
 
     if rd.find { |i| /\S/ === i } and !rd.find{|i| /^=begin\b/ === i } then

--- a/lib/rdoc/rd/inline.rb
+++ b/lib/rdoc/rd/inline.rb
@@ -20,7 +20,7 @@ class RDoc::RD::Inline
   # +rdoc+ may be another Inline or a String.  If +reference+ is not given it
   # will use the text from +rdoc+.
 
-  def self.new rdoc, reference = rdoc
+  def self.new(rdoc, reference = rdoc)
     if self === rdoc and reference.equal? rdoc then
       rdoc
     else
@@ -31,7 +31,7 @@ class RDoc::RD::Inline
   ##
   # Initializes the Inline with +rdoc+ and +inline+
 
-  def initialize rdoc, reference # :not-new:
+  def initialize(rdoc, reference) # :not-new:
     @reference = reference.equal?(rdoc) ? reference.dup : reference
 
     # unpack
@@ -39,7 +39,7 @@ class RDoc::RD::Inline
     @rdoc      = rdoc
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @reference == other.reference and @rdoc == other.rdoc
   end
@@ -47,7 +47,7 @@ class RDoc::RD::Inline
   ##
   # Appends +more+ to this inline.  +more+ may be a String or another Inline.
 
-  def append more
+  def append(more)
     case more
     when String then
       @reference += more

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -89,7 +89,7 @@ class RDoc::RDoc
   ##
   # Sets the active RDoc::RDoc instance
 
-  def self.current= rdoc
+  def self.current=(rdoc)
     @current = rdoc
   end
 
@@ -118,7 +118,7 @@ class RDoc::RDoc
   # Gathers a set of parseable files from the files and directories listed in
   # +files+.
 
-  def gather_files files
+  def gather_files(files)
     files = [@options.root.to_s] if files.empty?
 
     file_list = normalized_file_list files, true, @options.exclude
@@ -237,7 +237,7 @@ option)
   # representing candidates for documentation. It may also contain comments
   # (starting with '#')
 
-  def parse_dot_doc_file in_dir, filename
+  def parse_dot_doc_file(in_dir, filename)
     # read and strip comments
     patterns = File.read(filename).gsub(/#.*/, '')
 
@@ -311,7 +311,7 @@ option)
   # files. However we may well contain subdirectories which must be tested
   # for .document files.
 
-  def list_files_in_directory dir
+  def list_files_in_directory(dir)
     files = Dir.glob File.join(dir, "*")
 
     normalized_file_list files, false, @options.exclude
@@ -320,7 +320,7 @@ option)
   ##
   # Parses +filename+ and returns an RDoc::TopLevel
 
-  def parse_file filename
+  def parse_file(filename)
     encoding = @options.encoding
     filename = filename.encode encoding
 
@@ -391,7 +391,7 @@ The internal error was:
   ##
   # Parse each file on the command line, recursively entering directories.
 
-  def parse_files files
+  def parse_files(files)
     file_list = gather_files files
     @stats = RDoc::Stats.new @store, file_list.length, @options.verbosity
 
@@ -418,7 +418,7 @@ The internal error was:
   # Removes file extensions known to be unparseable from +files+ and TAGS
   # files for emacs and vim.
 
-  def remove_unparseable files
+  def remove_unparseable(files)
     files.reject do |file, *|
       file =~ /\.(?:class|eps|erb|scpt\.txt|svg|ttf|yml)$/i or
         (file =~ /tags$/i and
@@ -440,7 +440,7 @@ The internal error was:
   # By default, output will be stored in a directory called "doc" below the
   # current directory, so make sure you're somewhere writable before invoking.
 
-  def document options
+  def document(options)
     if RDoc::Options === options then
       @options = options
     else

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -96,7 +96,7 @@ class RDoc::RI::Driver
   ##
   # Dump +data_path+ using pp
 
-  def self.dump data_path
+  def self.dump(data_path)
     require 'pp'
 
     File.open data_path, 'rb' do |io|
@@ -107,7 +107,7 @@ class RDoc::RI::Driver
   ##
   # Parses +argv+ and returns a Hash of options
 
-  def self.process_args argv
+  def self.process_args(argv)
     options = default_options
 
     opts = OptionParser.new do |opt|
@@ -384,7 +384,7 @@ or the PAGER environment variable.
   ##
   # Runs the ri command line executable using +argv+
 
-  def self.run argv = ARGV
+  def self.run(argv = ARGV)
     options = process_args argv
 
     if options[:dump_path] then
@@ -399,7 +399,7 @@ or the PAGER environment variable.
   ##
   # Creates a new driver using +initial_options+ from ::process_args
 
-  def initialize initial_options = {}
+  def initialize(initial_options = {})
     @paging = false
     @classes = nil
 
@@ -438,7 +438,7 @@ or the PAGER environment variable.
   ##
   # Adds paths for undocumented classes +also_in+ to +out+
 
-  def add_also_in out, also_in
+  def add_also_in(out, also_in)
     return if also_in.empty?
 
     out << RDoc::Markup::Rule.new(1)
@@ -455,7 +455,7 @@ or the PAGER environment variable.
   # Adds a class header to +out+ for class +name+ which is described in
   # +classes+.
 
-  def add_class out, name, classes
+  def add_class(out, name, classes)
     heading = if classes.all? { |klass| klass.module? } then
                 name
               else
@@ -475,14 +475,14 @@ or the PAGER environment variable.
   ##
   # Adds "(from ...)" to +out+ for +store+
 
-  def add_from out, store
+  def add_from(out, store)
     out << RDoc::Markup::Paragraph.new("(from #{store.friendly_path})")
   end
 
   ##
   # Adds +extends+ to +out+
 
-  def add_extends out, extends
+  def add_extends(out, extends)
     add_extension_modules out, 'Extended by', extends
   end
 
@@ -490,7 +490,7 @@ or the PAGER environment variable.
   # Adds a list of +extensions+ to this module of the given +type+ to +out+.
   # add_includes and add_extends call this, so you should use those directly.
 
-  def add_extension_modules out, type, extensions
+  def add_extension_modules(out, type, extensions)
     return if extensions.empty?
 
     out << RDoc::Markup::Rule.new(1)
@@ -508,7 +508,7 @@ or the PAGER environment variable.
   ##
   # Renders multiple included +modules+ from +store+ to +out+.
 
-  def add_extension_modules_multiple out, store, modules # :nodoc:
+  def add_extension_modules_multiple(out, store, modules) # :nodoc:
     out << RDoc::Markup::Paragraph.new("(from #{store.friendly_path})")
 
     wout, with = modules.partition { |incl| incl.comment.empty? }
@@ -535,7 +535,7 @@ or the PAGER environment variable.
   ##
   # Adds a single extension module +include+ from +store+ to +out+
 
-  def add_extension_modules_single out, store, include # :nodoc:
+  def add_extension_modules_single(out, store, include) # :nodoc:
     name = include.name
     path = store.friendly_path
     out << RDoc::Markup::Paragraph.new("#{name} (from #{path})")
@@ -549,14 +549,14 @@ or the PAGER environment variable.
   ##
   # Adds +includes+ to +out+
 
-  def add_includes out, includes
+  def add_includes(out, includes)
     add_extension_modules out, 'Includes', includes
   end
 
   ##
   # Looks up the method +name+ and adds it to +out+
 
-  def add_method out, name
+  def add_method(out, name)
     filtered = lookup_method name
     method_document out, name, filtered
   end
@@ -564,7 +564,7 @@ or the PAGER environment variable.
   ##
   # Adds documentation for all methods in +klass+ to +out+
 
-  def add_method_documentation out, klass
+  def add_method_documentation(out, klass)
     klass.method_list.each do |method|
       begin
         add_method out, method.full_name
@@ -577,7 +577,7 @@ or the PAGER environment variable.
   ##
   # Adds a list of +methods+ to +out+ with a heading of +name+
 
-  def add_method_list out, methods, name
+  def add_method_list(out, methods, name)
     return if methods.empty?
 
     out << RDoc::Markup::Heading.new(1, "#{name}:")
@@ -597,7 +597,7 @@ or the PAGER environment variable.
   ##
   # Returns ancestor classes of +klass+
 
-  def ancestors_of klass
+  def ancestors_of(klass)
     ancestors = []
 
     unexamined = [klass]
@@ -634,7 +634,7 @@ or the PAGER environment variable.
   ##
   # Builds a RDoc::Markup::Document from +found+, +klasess+ and +includes+
 
-  def class_document name, found, klasses, includes, extends
+  def class_document(name, found, klasses, includes, extends)
     also_in = []
 
     out = RDoc::Markup::Document.new
@@ -657,7 +657,7 @@ or the PAGER environment variable.
   ##
   # Adds the class +comment+ to +out+.
 
-  def class_document_comment out, document # :nodoc:
+  def class_document_comment(out, document) # :nodoc:
     unless document.empty? then
       out << RDoc::Markup::Rule.new(1)
 
@@ -677,7 +677,7 @@ or the PAGER environment variable.
   ##
   # Adds the constants from +klass+ to the Document +out+.
 
-  def class_document_constants out, klass # :nodoc:
+  def class_document_constants(out, klass) # :nodoc:
     return if klass.constants.empty?
 
     out << RDoc::Markup::Heading.new(1, "Constants:")
@@ -721,7 +721,7 @@ or the PAGER environment variable.
   # Returns the stores wherein +name+ is found along with the classes,
   # extends and includes that match it
 
-  def classes_and_includes_and_extends_for name
+  def classes_and_includes_and_extends_for(name)
     klasses = []
     extends = []
     includes = []
@@ -746,7 +746,7 @@ or the PAGER environment variable.
   ##
   # Completes +name+ based on the caches.  For Readline
 
-  def complete name
+  def complete(name)
     completions = []
 
     klass, selector, method = parse_name name
@@ -757,7 +757,7 @@ or the PAGER environment variable.
     completions.uniq.select {|s| s.start_with? name }.sort
   end
 
-  def complete_klass name, klass, selector, method, completions # :nodoc:
+  def complete_klass(name, klass, selector, method, completions) # :nodoc:
     klasses = classes.keys
 
     # may need to include Foo when given Foo::
@@ -776,7 +776,7 @@ or the PAGER environment variable.
     end
   end
 
-  def complete_method name, klass, selector, completions # :nodoc:
+  def complete_method(name, klass, selector, completions) # :nodoc:
     if completions.include? klass and name =~ /#|\.|::/ then
       methods = list_methods_matching name
 
@@ -804,7 +804,7 @@ or the PAGER environment variable.
   ##
   # Converts +document+ to text and writes it to the pager
 
-  def display document
+  def display(document)
     page do |io|
       f = formatter(io)
       f.width = @width if @width and f.respond_to?(:width)
@@ -817,7 +817,7 @@ or the PAGER environment variable.
   ##
   # Outputs formatted RI data for class +name+.  Groups undocumented classes
 
-  def display_class name
+  def display_class(name)
     return if name =~ /#|\./
 
     found, klasses, includes, extends =
@@ -833,7 +833,7 @@ or the PAGER environment variable.
   ##
   # Outputs formatted RI data for method +name+
 
-  def display_method name
+  def display_method(name)
     out = RDoc::Markup::Document.new
 
     add_method out, name
@@ -849,7 +849,7 @@ or the PAGER environment variable.
   # Returns true if +name+ was found, false if it was not an alternative could
   # be guessed, raises an error if +name+ couldn't be guessed.
 
-  def display_name name
+  def display_name(name)
     if name =~ /\w:(\w|$)/ then
       display_page name
       return true
@@ -878,7 +878,7 @@ or the PAGER environment variable.
   ##
   # Displays each name in +name+
 
-  def display_names names
+  def display_names(names)
     names.each do |name|
       name = expand_name name
 
@@ -889,7 +889,7 @@ or the PAGER environment variable.
   ##
   # Outputs formatted RI data for page +name+.
 
-  def display_page name
+  def display_page(name)
     store_name, page_name = name.split ':', 2
 
     store = @stores.find { |s| s.source == store_name }
@@ -920,7 +920,7 @@ or the PAGER environment variable.
   ##
   # Outputs a formatted RI page list for the pages in +store+.
 
-  def display_page_list store, pages = store.cache[:pages], search = nil
+  def display_page_list(store, pages = store.cache[:pages], search = nil)
     out = RDoc::Markup::Document.new
 
     title = if search then
@@ -964,7 +964,7 @@ or the PAGER environment variable.
   # Expands abbreviated klass +klass+ into a fully-qualified class.  "Zl::Da"
   # will be expanded to Zlib::DataError.
 
-  def expand_class klass
+  def expand_class(klass)
     class_names = classes.keys
     ary = class_names.grep(Regexp.new("\\A#{klass.gsub(/(?=::|\z)/, '[^:]*')}\\z"))
     if ary.length != 1 && ary.first != klass
@@ -982,7 +982,7 @@ or the PAGER environment variable.
   # Expands the class portion of +name+ into a fully-qualified class.  See
   # #expand_class.
 
-  def expand_name name
+  def expand_name(name)
     klass, selector, method = parse_name name
 
     return [selector, method].join if klass.empty?
@@ -998,7 +998,7 @@ or the PAGER environment variable.
   ##
   # Filters the methods in +found+ trying to find a match for +name+.
 
-  def filter_methods found, name
+  def filter_methods(found, name)
     regexp = name_regexp name
 
     filtered = found.find_all do |store, methods|
@@ -1016,7 +1016,7 @@ or the PAGER environment variable.
   # types of methods to look up (from #method_type), and the method name being
   # searched for
 
-  def find_methods name
+  def find_methods(name)
     klass, selector, method = parse_name name
 
     types = method_type selector
@@ -1062,7 +1062,7 @@ or the PAGER environment variable.
   #
   # See also RDoc::Store#source
 
-  def find_store name
+  def find_store(name)
     @stores.each do |store|
       source = store.source
 
@@ -1131,7 +1131,7 @@ or the PAGER environment variable.
   # Lists classes known to ri starting with +names+.  If +names+ is empty all
   # known classes are shown.
 
-  def list_known_classes names = []
+  def list_known_classes(names = [])
     classes = []
 
     stores.each do |store|
@@ -1163,7 +1163,7 @@ or the PAGER environment variable.
   ##
   # Returns an Array of methods matching +name+
 
-  def list_methods_matching name
+  def list_methods_matching(name)
     found = []
 
     find_methods name do |store, klass, ancestor, types, method|
@@ -1202,7 +1202,7 @@ or the PAGER environment variable.
   # Loads RI data for method +name+ on +klass+ from +store+.  +type+ and
   # +cache+ indicate if it is a class or instance method.
 
-  def load_method store, cache, klass, type, name
+  def load_method(store, cache, klass, type, name)
     methods = store.public_send(cache)[klass]
 
     return unless methods
@@ -1226,7 +1226,7 @@ or the PAGER environment variable.
   ##
   # Returns an Array of RI data for methods matching +name+
 
-  def load_methods_matching name
+  def load_methods_matching(name)
     found = []
 
     find_methods name do |store, klass, ancestor, types, method|
@@ -1247,7 +1247,7 @@ or the PAGER environment variable.
   ##
   # Returns a filtered list of methods matching +name+
 
-  def lookup_method name
+  def lookup_method(name)
     found = load_methods_matching name
 
     if found.empty?
@@ -1272,7 +1272,7 @@ or the PAGER environment variable.
   ##
   # Builds a RDoc::Markup::Document from +found+, +klasses+ and +includes+
 
-  def method_document out, name, filtered
+  def method_document(out, name, filtered)
     out << RDoc::Markup::Heading.new(1, name)
     out << RDoc::Markup::BlankLine.new
 
@@ -1288,7 +1288,7 @@ or the PAGER environment variable.
   ##
   # Returns the type of method (:both, :instance, :class) for +selector+
 
-  def method_type selector
+  def method_type(selector)
     case selector
     when '.', nil then :both
     when '#'      then :instance
@@ -1300,7 +1300,7 @@ or the PAGER environment variable.
   # Returns a regular expression for +name+ that will match an
   # RDoc::AnyMethod's name.
 
-  def name_regexp name
+  def name_regexp(name)
     klass, type, name = parse_name name
 
     case type
@@ -1343,7 +1343,7 @@ or the PAGER environment variable.
   # NOTE: Given Foo::Bar, Bar is considered a class even though it may be a
   # method
 
-  def parse_name name
+  def parse_name(name)
     parts = name.split(/(::?|#|\.)/)
 
     if parts.length == 1 then
@@ -1375,7 +1375,7 @@ or the PAGER environment variable.
   # Renders the +klass+ from +store+ to +out+.  If the klass has no
   # documentable items the class is added to +also_in+ instead.
 
-  def render_class out, store, klass, also_in # :nodoc:
+  def render_class(out, store, klass, also_in) # :nodoc:
     document = klass.comment.parse
     # TODO the store's cache should always return an empty Array
     class_methods    = store.class_methods[klass.full_name]    || []
@@ -1405,7 +1405,7 @@ or the PAGER environment variable.
     add_method_documentation out, klass if @show_all
   end
 
-  def render_method out, store, method, name # :nodoc:
+  def render_method(out, store, method, name) # :nodoc:
     out << RDoc::Markup::Paragraph.new("(from #{store.friendly_path})")
 
     unless name =~ /^#{Regexp.escape method.parent_name}/ then
@@ -1425,7 +1425,7 @@ or the PAGER environment variable.
     end
   end
 
-  def render_method_arguments out, arglists # :nodoc:
+  def render_method_arguments(out, arglists) # :nodoc:
     return unless arglists
 
     arglists = arglists.chomp.split "\n"
@@ -1434,7 +1434,7 @@ or the PAGER environment variable.
     out << RDoc::Markup::Rule.new(1)
   end
 
-  def render_method_comment out, method, alias_for = nil# :nodoc:
+  def render_method_comment(out, method, alias_for = nil)# :nodoc:
     if alias_for
       unless method.comment.nil? or method.comment.empty?
         out << RDoc::Markup::BlankLine.new
@@ -1452,7 +1452,7 @@ or the PAGER environment variable.
     end
   end
 
-  def render_method_superclass out, method # :nodoc:
+  def render_method_superclass(out, method) # :nodoc:
     return unless
       method.respond_to?(:superclass_method) and method.superclass_method
 

--- a/lib/rdoc/ri/paths.rb
+++ b/lib/rdoc/ri/paths.rb
@@ -52,7 +52,7 @@ module RDoc::RI::Paths
   ##
   # The ri directory for the gem with +gem_name+.
 
-  def self.gem_dir name, version
+  def self.gem_dir(name, version)
     req = Gem::Requirement.new "= #{version}"
 
     spec = Gem::Specification.find_by_name name, req
@@ -67,7 +67,7 @@ module RDoc::RI::Paths
   # A +filter+ :all includes all versions of gems and includes gems without
   # ri documentation.
 
-  def self.gemdirs filter = :latest
+  def self.gemdirs(filter = :latest)
     ri_paths = {}
 
     all = Gem::Specification.map do |spec|

--- a/lib/rdoc/ri/task.rb
+++ b/lib/rdoc/ri/task.rb
@@ -44,7 +44,7 @@ class RDoc::RI::Task < RDoc::Task
   # Create an ri task with the given name. See RDoc::Task for documentation on
   # setting names.
 
-  def initialize name = DEFAULT_NAMES # :yield: self
+  def initialize(name = DEFAULT_NAMES) # :yield: self
     super
   end
 

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -51,7 +51,7 @@ class RDoc::RubyGemsHook
   # Post installs hook that generates documentation for each specification in
   # +specs+
 
-  def self.generate installer, specs
+  def self.generate(installer, specs)
     start = Time.now
     types = installer.document
 
@@ -70,7 +70,7 @@ class RDoc::RubyGemsHook
     say "Done installing documentation for #{names} after #{duration} seconds"
   end
 
-  def self.remove uninstaller
+  def self.remove(uninstaller)
     new(uninstaller.spec).remove
   end
 
@@ -92,7 +92,7 @@ class RDoc::RubyGemsHook
   #
   # Only +generate_ri+ is enabled by default.
 
-  def initialize spec, generate_rdoc = false, generate_ri = true
+  def initialize(spec, generate_rdoc = false, generate_ri = true)
     @doc_dir   = spec.doc_dir
     @force     = false
     @rdoc      = nil
@@ -110,7 +110,7 @@ class RDoc::RubyGemsHook
   #--
   # TODO move to RDoc::Options
 
-  def delete_legacy_args args
+  def delete_legacy_args(args)
     args.delete '--inline-source'
     args.delete '--promiscuous'
     args.delete '-p'
@@ -123,7 +123,7 @@ class RDoc::RubyGemsHook
   #
   # Documentation will be generated into +destination+
 
-  def document generator, options, destination
+  def document(generator, options, destination)
     generator_name = generator
 
     options = options.dup
@@ -297,7 +297,7 @@ module RDoc
       RubyGemsHook.new(@spec).remove
     end
 
-    def self.generation_hook installer, specs
+    def self.generation_hook(installer, specs)
       # Do nothing if this is NOT a default gem.
       return unless default_gem?
 

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -26,7 +26,7 @@ class RDoc::Stats
   # Creates a new Stats that will have +num_files+.  +verbosity+ defaults to 1
   # which will create an RDoc::Stats::Normal outputter.
 
-  def initialize store, num_files, verbosity = 1
+  def initialize(store, num_files, verbosity = 1)
     @num_files = num_files
     @store     = store
 
@@ -49,28 +49,28 @@ class RDoc::Stats
   ##
   # Records the parsing of an alias +as+.
 
-  def add_alias as
+  def add_alias(as)
     @display.print_alias as
   end
 
   ##
   # Records the parsing of an attribute +attribute+
 
-  def add_attribute attribute
+  def add_attribute(attribute)
     @display.print_attribute attribute
   end
 
   ##
   # Records the parsing of a class +klass+
 
-  def add_class klass
+  def add_class(klass)
     @display.print_class klass
   end
 
   ##
   # Records the parsing of +constant+
 
-  def add_constant constant
+  def add_constant(constant)
     @display.print_constant constant
   end
 
@@ -155,7 +155,7 @@ class RDoc::Stats
   # 0:: Classes, modules, constants, attributes, methods
   # 1:: Level 0 + method parameters
 
-  def coverage_level= level
+  def coverage_level=(level)
     level = -1 unless level
 
     @coverage_level = level
@@ -164,7 +164,7 @@ class RDoc::Stats
   ##
   # Returns the length and number of undocumented items in +collection+.
 
-  def doc_stats collection
+  def doc_stats(collection)
     visible = collection.select { |item| item.display? }
     [visible.length, visible.count { |item| not item.documented? }]
   end
@@ -256,7 +256,7 @@ class RDoc::Stats
   ##
   # Returns a report on undocumented attributes in ClassModule +cm+
 
-  def report_attributes cm
+  def report_attributes(cm)
     return if cm.attributes.empty?
 
     report = []
@@ -274,7 +274,7 @@ class RDoc::Stats
   ##
   # Returns a report on undocumented items in ClassModule +cm+
 
-  def report_class_module cm
+  def report_class_module(cm)
     return if cm.fully_documented? and @coverage_level.zero?
     return unless cm.display?
 
@@ -326,7 +326,7 @@ class RDoc::Stats
   ##
   # Returns a report on undocumented constants in ClassModule +cm+
 
-  def report_constants cm
+  def report_constants(cm)
     return if cm.constants.empty?
 
     report = []
@@ -348,7 +348,7 @@ class RDoc::Stats
   ##
   # Returns a report on undocumented methods in ClassModule +cm+
 
-  def report_methods cm
+  def report_methods(cm)
     return if cm.method_list.empty?
 
     report = []
@@ -436,7 +436,7 @@ class RDoc::Stats
   # Determines which parameters in +method+ were not documented.  Returns a
   # total parameter count and an Array of undocumented methods.
 
-  def undoc_params method
+  def undoc_params(method)
     @formatter ||= RDoc::Markup::ToTtOnly.new
 
     params = method.param_list

--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -20,7 +20,7 @@ class RDoc::Stats::Normal < RDoc::Stats::Quiet
   ##
   # Prints a file with a progress bar
 
-  def print_file files_so_far, filename
+  def print_file(files_so_far, filename)
     progress_bar = sprintf("%3d%% [%2d/%2d]  ",
                            100 * files_so_far / @num_files,
                            files_so_far,

--- a/lib/rdoc/stats/quiet.rb
+++ b/lib/rdoc/stats/quiet.rb
@@ -7,7 +7,7 @@ class RDoc::Stats::Quiet
   ##
   # Creates a new Quiet that will print nothing
 
-  def initialize num_files
+  def initialize(num_files)
     @num_files = num_files
   end
 

--- a/lib/rdoc/stats/verbose.rb
+++ b/lib/rdoc/stats/verbose.rb
@@ -8,15 +8,15 @@ class RDoc::Stats::Verbose < RDoc::Stats::Normal
   ##
   # Returns a marker for RDoc::CodeObject +co+ being undocumented
 
-  def nodoc co
+  def nodoc(co)
     " (undocumented)" unless co.documented?
   end
 
-  def print_alias as # :nodoc:
+  def print_alias(as) # :nodoc:
     puts "    alias #{as.new_name} #{as.old_name}#{nodoc as}"
   end
 
-  def print_attribute attribute # :nodoc:
+  def print_attribute(attribute) # :nodoc:
     puts "    #{attribute.definition} #{attribute.name}#{nodoc attribute}"
   end
 

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -54,7 +54,7 @@ class RDoc::Store
     # Creates a new MissingFileError for the missing +file+ for the given
     # +name+ that should have been in the +store+.
 
-    def initialize store, file, name
+    def initialize(store, file, name)
       @store = store
       @file  = file
       @name  = name
@@ -162,14 +162,14 @@ class RDoc::Store
   # Adds +module+ as an enclosure (namespace) for the given +variable+ for C
   # files.
 
-  def add_c_enclosure variable, namespace
+  def add_c_enclosure(variable, namespace)
     @c_enclosure_classes[variable] = namespace
   end
 
   ##
   # Adds C variables from an RDoc::Parser::C
 
-  def add_c_variables c_parser
+  def add_c_variables(c_parser)
     filename = c_parser.top_level.relative_name
 
     @c_class_variables[filename] = make_variable_map c_parser.classes
@@ -181,7 +181,7 @@ class RDoc::Store
   # Adds the file with +name+ as an RDoc::TopLevel to the store.  Returns the
   # created RDoc::TopLevel.
 
-  def add_file absolute_name, relative_name: absolute_name, parser: nil
+  def add_file(absolute_name, relative_name: absolute_name, parser: nil)
     unless top_level = @files_hash[relative_name] then
       top_level = RDoc::TopLevel.new absolute_name, relative_name
       top_level.parser = parser if parser
@@ -268,7 +268,7 @@ class RDoc::Store
   ##
   # Path to the ri data for +klass_name+
 
-  def class_file klass_name
+  def class_file(klass_name)
     name = klass_name.split('::').last
     File.join class_path(klass_name), "cdesc-#{name}.ri"
   end
@@ -284,7 +284,7 @@ class RDoc::Store
   ##
   # Path where data for +klass_name+ will be stored (methods or class data)
 
-  def class_path klass_name
+  def class_path(klass_name)
     File.join @path, *klass_name.split('::')
   end
 
@@ -299,7 +299,7 @@ class RDoc::Store
   # Removes empty items and ensures item in each collection are unique and
   # sorted
 
-  def clean_cache_collection collection # :nodoc:
+  def clean_cache_collection(collection) # :nodoc:
     collection.each do |name, item|
       if item.empty? then
         collection.delete name
@@ -327,7 +327,7 @@ class RDoc::Store
   #
   # See also RDoc::Context#remove_from_documentation?
 
-  def complete min_visibility
+  def complete(min_visibility)
     fix_basic_object_inheritance
 
     # cache included modules before they are removed from the documentation
@@ -374,7 +374,7 @@ class RDoc::Store
   ##
   # Finds the enclosure (namespace) for the given C +variable+.
 
-  def find_c_enclosure variable
+  def find_c_enclosure(variable)
     @c_enclosure_classes.fetch variable do
       break unless name = @c_enclosure_names[variable]
 
@@ -399,14 +399,14 @@ class RDoc::Store
   ##
   # Finds the class with +name+ in all discovered classes
 
-  def find_class_named name
+  def find_class_named(name)
     @classes_hash[name]
   end
 
   ##
   # Finds the class with +name+ starting in namespace +from+
 
-  def find_class_named_from name, from
+  def find_class_named_from(name, from)
     from = find_class_named from unless RDoc::Context === from
 
     until RDoc::TopLevel === from do
@@ -424,7 +424,7 @@ class RDoc::Store
   ##
   # Finds the class or module with +name+
 
-  def find_class_or_module name
+  def find_class_or_module(name)
     name = $' if name =~ /^::/
     @classes_hash[name] || @modules_hash[name]
   end
@@ -432,14 +432,14 @@ class RDoc::Store
   ##
   # Finds the file with +name+ in all discovered files
 
-  def find_file_named name
+  def find_file_named(name)
     @files_hash[name]
   end
 
   ##
   # Finds the module with +name+ in all discovered modules
 
-  def find_module_named name
+  def find_module_named(name)
     @modules_hash[name]
   end
 
@@ -447,7 +447,7 @@ class RDoc::Store
   # Returns the RDoc::TopLevel that is a text file and has the given
   # +file_name+
 
-  def find_text_page file_name
+  def find_text_page(file_name)
     @text_files_hash.each_value.find do |file|
       file.full_name == file_name
     end
@@ -460,7 +460,7 @@ class RDoc::Store
   #--
   # TODO  aliases should be registered by Context#add_module_alias
 
-  def find_unique all_hash
+  def find_unique(all_hash)
     unique = []
 
     all_hash.each_pair do |full_name, cm|
@@ -603,7 +603,7 @@ class RDoc::Store
   ##
   # Loads ri data for +klass_name+ and hooks it up to this store.
 
-  def load_class klass_name
+  def load_class(klass_name)
     obj = load_class_data klass_name
 
     obj.store = self
@@ -621,7 +621,7 @@ class RDoc::Store
   ##
   # Loads ri data for +klass_name+
 
-  def load_class_data klass_name
+  def load_class_data(klass_name)
     file = class_file klass_name
 
     marshal_load(file)
@@ -634,7 +634,7 @@ class RDoc::Store
   ##
   # Loads ri data for +method_name+ in +klass_name+
 
-  def load_method klass_name, method_name
+  def load_method(klass_name, method_name)
     file = method_file klass_name, method_name
 
     obj = marshal_load(file)
@@ -650,7 +650,7 @@ class RDoc::Store
   ##
   # Loads ri data for +page_name+
 
-  def load_page page_name
+  def load_page(page_name)
     file = page_file page_name
 
     obj = marshal_load(file)
@@ -673,7 +673,7 @@ class RDoc::Store
   ##
   # Sets the main page for this RDoc store.
 
-  def main= page
+  def main=(page)
     @cache[:main] = page
   end
 
@@ -681,7 +681,7 @@ class RDoc::Store
   # Converts the variable => ClassModule map +variables+ from a C parser into
   # a variable => class name map.
 
-  def make_variable_map variables
+  def make_variable_map(variables)
     map = {}
 
     variables.each { |variable, class_module|
@@ -694,7 +694,7 @@ class RDoc::Store
   ##
   # Path to the ri data for +method_name+ in +klass_name+
 
-  def method_file klass_name, method_name
+  def method_file(klass_name, method_name)
     method_name = method_name.split('::').last
     method_name =~ /#(.*)/
     method_type = $1 ? 'i' : 'c'
@@ -722,7 +722,7 @@ class RDoc::Store
   ##
   # Returns the RDoc::TopLevel that is a text file and has the given +name+
 
-  def page name
+  def page(name)
     @text_files_hash.each_value.find do |file|
       file.page_name == name or file.base_name == name
     end
@@ -731,7 +731,7 @@ class RDoc::Store
   ##
   # Path to the ri data for +page_name+
 
-  def page_file page_name
+  def page_file(page_name)
     file_name = File.basename(page_name).gsub('.', '_')
 
     File.join @path, File.dirname(page_name), "page-#{file_name}.ri"
@@ -742,7 +742,7 @@ class RDoc::Store
   #
   # See RDoc::Context#remove_from_documentation?
 
-  def remove_nodoc all_hash
+  def remove_nodoc(all_hash)
     all_hash.keys.each do |name|
       context = all_hash[name]
       all_hash.delete(name) if context.remove_from_documentation?
@@ -804,7 +804,7 @@ class RDoc::Store
   ##
   # Writes the ri data for +klass+ (or module)
 
-  def save_class klass
+  def save_class(klass)
     full_name = klass.full_name
 
     FileUtils.mkdir_p class_path(full_name) unless @dry_run
@@ -878,7 +878,7 @@ class RDoc::Store
   ##
   # Writes the ri data for +method+ on +klass+
 
-  def save_method klass, method
+  def save_method(klass, method)
     full_name = klass.full_name
 
     FileUtils.mkdir_p class_path(full_name) unless @dry_run
@@ -901,7 +901,7 @@ class RDoc::Store
   ##
   # Writes the ri data for +page+
 
-  def save_page page
+  def save_page(page)
     return unless page.text?
 
     path = page_file page.full_name
@@ -948,7 +948,7 @@ class RDoc::Store
   ##
   # Sets the title page for this RDoc store.
 
-  def title= title
+  def title=(title)
     @cache[:title] = title
   end
 

--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -154,7 +154,7 @@ class RDoc::Task < Rake::TaskLib
   # Create an RDoc task with the given name. See the RDoc::Task class overview
   # for documentation.
 
-  def initialize name = :rdoc # :yield: self
+  def initialize(name = :rdoc) # :yield: self
     defaults
 
     check_names name
@@ -170,7 +170,7 @@ class RDoc::Task < Rake::TaskLib
   # Ensures that +names+ only includes names for the :rdoc, :clobber_rdoc and
   # :rerdoc.  If other names are given an ArgumentError is raised.
 
-  def check_names names
+  def check_names(names)
     return unless Hash === names
 
     invalid_options =

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -52,7 +52,7 @@ module RDoc::Text
   ##
   # Transcodes +character+ to +encoding+ with a +fallback+ character.
 
-  def self.encode_fallback character, encoding, fallback
+  def self.encode_fallback(character, encoding, fallback)
     character.encode(encoding, :fallback => { character => fallback },
                      :undef => :replace, :replace => fallback)
   end
@@ -60,7 +60,7 @@ module RDoc::Text
   ##
   # Expands tab characters in +text+ to eight spaces
 
-  def expand_tabs text
+  def expand_tabs(text)
     expanded = []
 
     text.each_line do |line|
@@ -79,7 +79,7 @@ module RDoc::Text
   ##
   # Flush +text+ left based on the shortest line
 
-  def flush_left text
+  def flush_left(text)
     indent = 9999
 
     text.each_line do |line|
@@ -98,7 +98,7 @@ module RDoc::Text
   #
   # Requires the including class to implement #formatter
 
-  def markup text
+  def markup(text)
     if @store.options
       locale = @store.options.locale
     else
@@ -114,7 +114,7 @@ module RDoc::Text
   ##
   # Strips hashes, expands tabs then flushes +text+ to the left
 
-  def normalize_comment text
+  def normalize_comment(text)
     return text if text.empty?
 
     case language
@@ -132,7 +132,7 @@ module RDoc::Text
   ##
   # Normalizes +text+ then builds a RDoc::Markup::Document from it
 
-  def parse text, format = 'rdoc'
+  def parse(text, format = 'rdoc')
     return text if RDoc::Markup::Document === text
     return text.parse if RDoc::Comment === text
 
@@ -146,7 +146,7 @@ module RDoc::Text
   ##
   # The first +limit+ characters of +text+ as HTML
 
-  def snippet text, limit = 100
+  def snippet(text, limit = 100)
     document = parse text
 
     RDoc::Markup::ToHtmlSnippet.new(options, limit).convert document
@@ -155,7 +155,7 @@ module RDoc::Text
   ##
   # Strips leading # characters from +text+
 
-  def strip_hashes text
+  def strip_hashes(text)
     return text if text =~ /^(?>\s*)[^\#]/
 
     empty = ''
@@ -167,14 +167,14 @@ module RDoc::Text
   ##
   # Strips leading and trailing \n characters from +text+
 
-  def strip_newlines text
+  def strip_newlines(text)
     text.gsub(/\A\n*(.*?)\n*\z/m) do $1 end # block preserves String encoding
   end
 
   ##
   # Strips /* */ style comments
 
-  def strip_stars text
+  def strip_stars(text)
     return text unless text =~ %r%/\*.*\*/%m
 
     encoding = text.encoding
@@ -197,7 +197,7 @@ module RDoc::Text
   # Converts ampersand, dashes, ellipsis, quotes, copyright and registered
   # trademark symbols in +text+ to properly encoded characters.
 
-  def to_html text
+  def to_html(text)
     html = (''.encode text.encoding).dup
 
     encoded = RDoc::Text::TO_HTML_CHARACTERS[text.encoding]

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -13,7 +13,7 @@ module RDoc::TokenStream
   # <tt><span></tt> elements. Some tokens types are wrapped in spans
   # with the given class names. Other token types are not wrapped in spans.
 
-  def self.to_html token_stream
+  def self.to_html(token_stream)
     starting_title = false
 
     token_stream.map do |t|

--- a/lib/rdoc/tom_doc.rb
+++ b/lib/rdoc/tom_doc.rb
@@ -75,7 +75,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns an RDoc::Markup::Document representing the TomDoc format.
 
-  def self.parse text
+  def self.parse(text)
     parser = new
 
     parser.tokenize text
@@ -91,7 +91,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns a String containing the signature and nil if not
 
-  def self.signature comment
+  def self.signature(comment)
     return unless comment.tomdoc?
 
     document = comment.parse
@@ -134,7 +134,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns an RDoc::Markup::Heading
 
-  def build_heading level
+  def build_heading(level)
     heading = super
 
     @section = heading.text
@@ -150,7 +150,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns an RDoc::Markup::Verbatim
 
-  def build_verbatim margin
+  def build_verbatim(margin)
     verbatim = super
 
     verbatim.format = :ruby if @section == 'Examples'
@@ -164,7 +164,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns an RDoc::Markup::Paragraph.
 
-  def build_paragraph margin
+  def build_paragraph(margin)
     p :paragraph_start => margin if @debug
 
     paragraph = RDoc::Markup::Paragraph.new
@@ -204,7 +204,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   ##
   # Detects a section change to "Returns" and adds a heading
 
-  def parse_text parent, indent # :nodoc:
+  def parse_text(parent, indent) # :nodoc:
     paragraph = build_paragraph indent
 
     if false == @seen_returns and 'Returns' == @section then
@@ -222,7 +222,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   #
   # Returns self.
 
-  def tokenize text
+  def tokenize(text)
     text = text.sub(/\A(Public|Internal|Deprecated):\s+/, '')
 
     setup_scanner text

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -72,21 +72,21 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Asserts +path+ is a file
 
-  def assert_file path
+  def assert_file(path)
     assert File.file?(path), "#{path} is not a file"
   end
 
   ##
   # Asserts +path+ is a directory
 
-  def assert_directory path
+  def assert_directory(path)
     assert File.directory?(path), "#{path} is not a directory"
   end
 
   ##
   # Refutes +path+ exists
 
-  def refute_file path
+  def refute_file(path)
     refute File.exist?(path), "#{path} exists"
   end
 
@@ -108,7 +108,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   # Creates an RDoc::Comment with +text+ which was defined on +top_level+.
   # By default the comment has the 'rdoc' format.
 
-  def comment text, top_level = @top_level, language = nil
+  def comment(text, top_level = @top_level, language = nil)
     comment = RDoc::Comment.new text, top_level, language
     comment
   end
@@ -130,7 +130,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Heading.new with +level+ and +text+
 
-  def head level, text
+  def head(level, text)
     @RM::Heading.new level, text
   end
 
@@ -151,7 +151,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Enables pretty-print output
 
-  def mu_pp obj # :nodoc:
+  def mu_pp(obj) # :nodoc:
     s = obj.pretty_inspect
     s = RDoc::Encoding.change_encoding s, Encoding.default_external
     s.chomp
@@ -167,7 +167,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Rule.new with +weight+
 
-  def rule weight
+  def rule(weight)
     @RM::Rule.new weight
   end
 

--- a/test/rdoc/test_rdoc_cross_reference.rb
+++ b/test/rdoc/test_rdoc_cross_reference.rb
@@ -12,11 +12,11 @@ class TestRDocCrossReference < XrefTestCase
     @xref = RDoc::CrossReference.new @c1
   end
 
-  def assert_ref expected, name
+  def assert_ref(expected, name)
     assert_equal expected, @xref.resolve(name, 'fail')
   end
 
-  def refute_ref name
+  def refute_ref(name)
     assert_equal name, @xref.resolve(name, name)
   end
 

--- a/test/rdoc/test_rdoc_generator_darkfish.rb
+++ b/test/rdoc/test_rdoc_generator_darkfish.rb
@@ -518,7 +518,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
   # Asserts that +filename+ has a link count greater than 1 if hard links to
   # @tmpdir are supported.
 
-  def assert_hard_link filename
+  def assert_hard_link(filename)
     assert_file filename
 
     src = @g.template_dir + '_head.rhtml'

--- a/test/rdoc/test_rdoc_generator_markup.rb
+++ b/test/rdoc/test_rdoc_generator_markup.rb
@@ -52,7 +52,7 @@ class TestRDocGeneratorMarkup < RDoc::TestCase
 
   attr_reader :path
 
-  def find_symbol name
+  def find_symbol(name)
     @symbols[name]
   end
 

--- a/test/rdoc/test_rdoc_markdown.rb
+++ b/test/rdoc/test_rdoc_markdown.rb
@@ -1133,7 +1133,7 @@ and an extra note.[^2]
     assert_equal expected, doc
   end
 
-  def parse text
+  def parse(text)
     @parser.parse text
   end
 

--- a/test/rdoc/test_rdoc_markup_attribute_manager.rb
+++ b/test/rdoc/test_rdoc_markup_attribute_manager.rb
@@ -388,7 +388,7 @@ class TestRDocMarkupAttributeManager < RDoc::TestCase
                  @am.flow('<tt>"\n"</tt>')
   end
 
-  def output str
+  def output(str)
     @formatter.convert_flow @am.flow str
   end
 

--- a/test/rdoc/test_rdoc_markup_formatter.rb
+++ b/test/rdoc/test_rdoc_markup_formatter.rb
@@ -5,21 +5,21 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
   class ToTest < RDoc::Markup::Formatter
 
-    def initialize markup
+    def initialize(markup)
       super nil, markup
 
       add_tag :TT, '<code>', '</code>'
     end
 
-    def accept_paragraph paragraph
+    def accept_paragraph(paragraph)
       @res += attributes(paragraph.text)
     end
 
-    def attributes text
+    def attributes(text)
       convert_flow @am.flow text.dup
     end
 
-    def handle_regexp_CAPS target
+    def handle_regexp_CAPS(target)
       "handled #{target.text}"
     end
 
@@ -73,7 +73,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_includes regexp_handling_names, 'RDOCLINK'
 
-    def @to.handle_regexp_RDOCLINK target
+    def @to.handle_regexp_RDOCLINK(target)
       "<#{target.text}>"
     end
 
@@ -89,7 +89,7 @@ class TestRDocMarkupFormatter < RDoc::TestCase
 
     assert_includes regexp_handling_names, 'TIDYLINK'
 
-    def @to.handle_regexp_TIDYLINK target
+    def @to.handle_regexp_TIDYLINK(target)
       "<#{target.text}>"
     end
 

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -947,7 +947,7 @@ EXPECTED
     assert_equal "\n<p><code>--</code></p>\n", util_format("<tt>--</tt>")
   end
 
-  def util_format text
+  def util_format(text)
     paragraph = RDoc::Markup::Paragraph.new text
 
     @to.start_accepting

--- a/test/rdoc/test_rdoc_markup_to_html_crossref.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_crossref.rb
@@ -302,23 +302,23 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
                  @to.link('Parent::m', 'Parent::m')
   end
 
-  def para text
+  def para(text)
     "\n<p>#{text}</p>\n"
   end
 
-  def REGEXP_HANDLING text
+  def REGEXP_HANDLING(text)
     @to.handle_regexp_CROSSREF regexp_handling text
   end
 
-  def hyper reference
+  def hyper(reference)
     RDoc::Markup::RegexpHandling.new 0, "rdoc-ref:#{reference}"
   end
 
-  def regexp_handling text
+  def regexp_handling(text)
     RDoc::Markup::RegexpHandling.new 0, text
   end
 
-  def tidy reference
+  def tidy(reference)
     RDoc::Markup::RegexpHandling.new 0, "{tidy}[rdoc-ref:#{reference}]"
   end
 

--- a/test/rdoc/test_rdoc_markup_to_html_snippet.rb
+++ b/test/rdoc/test_rdoc_markup_to_html_snippet.rb
@@ -698,7 +698,7 @@ This routine modifies its +comment+ parameter.
     assert_equal 2, @to.characters
   end
 
-  def util_format text
+  def util_format(text)
     paragraph = RDoc::Markup::Paragraph.new text
 
     @to.start_accepting

--- a/test/rdoc/test_rdoc_options.rb
+++ b/test/rdoc/test_rdoc_options.rb
@@ -402,7 +402,7 @@ rdoc_include:
 
   def test_parse_help_extra_generator
     RDoc::RDoc::GENERATORS['test'] = Class.new do
-      def self.setup_options options
+      def self.setup_options(options)
         op = options.option_parser
 
         op.separator 'test generator options:'
@@ -423,7 +423,7 @@ rdoc_include:
 
   def test_parse_format_for_extra_generator
     RDoc::RDoc::GENERATORS['test'] = Class.new do
-      def self.setup_options options
+      def self.setup_options(options)
         op = options.option_parser
 
         op.separator 'test generator options:'
@@ -763,7 +763,7 @@ rdoc_include:
 
   def test_setup_generator
     test_generator = Class.new do
-      def self.setup_options op
+      def self.setup_options(op)
         @op = op
       end
 
@@ -784,7 +784,7 @@ rdoc_include:
 
   def test_setup_generator_no_option_parser
     test_generator = Class.new do
-      def self.setup_options op
+      def self.setup_options(op)
         op.option_parser.separator nil
         @op = op
       end

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -2136,14 +2136,14 @@ void Init_Blah(void) {
     assert_equal("markdown", klass.attributes.find {|a| a.name == "default_format"}.comment.format)
   end
 
-  def util_get_class content, name = nil
+  def util_get_class(content, name = nil)
     @parser = util_parser content
     @parser.scan
 
     @parser.classes[name] if name
   end
 
-  def util_parser content = ''
+  def util_parser(content = '')
     RDoc::Parser::C.new @top_level, content, @options, @stats
   end
 

--- a/test/rdoc/test_rdoc_parser_changelog.rb
+++ b/test/rdoc/test_rdoc_parser_changelog.rb
@@ -473,7 +473,7 @@ ChangeLog
     assert_equal expected, @top_level.comment.parse
   end
 
-  def util_parser content = ''
+  def util_parser(content = '')
     RDoc::Parser::ChangeLog.new @top_level, content, @options, @stats
   end
 

--- a/test/rdoc/test_rdoc_parser_markdown.rb
+++ b/test/rdoc/test_rdoc_parser_markdown.rb
@@ -54,7 +54,7 @@ class TestRDocParserMarkdown < RDoc::TestCase
     assert_equal expected, @top_level.comment.parse
   end
 
-  def util_parser content
+  def util_parser(content)
     RDoc::Parser::Markdown.new @top_level, content, @options, @stats
   end
 

--- a/test/rdoc/test_rdoc_parser_rd.rb
+++ b/test/rdoc/test_rdoc_parser_rd.rb
@@ -48,7 +48,7 @@ class TestRDocParserRd < RDoc::TestCase
     assert_equal expected, @top_level.comment.parse
   end
 
-  def util_parser content
+  def util_parser(content)
     RDoc::Parser::RD.new @top_level, content, @options, @stats
   end
 

--- a/test/rdoc/test_rdoc_rd_block_parser.rb
+++ b/test/rdoc/test_rdoc_rd_block_parser.rb
@@ -543,7 +543,7 @@ two
     assert_equal expected, parse("one\ntwo")
   end
 
-  def parse text
+  def parse(text)
     text = ["=begin", text, "=end"].join "\n"
 
     doc = @block_parser.parse text.lines.to_a

--- a/test/rdoc/test_rdoc_rd_inline_parser.rb
+++ b/test/rdoc/test_rdoc_rd_inline_parser.rb
@@ -171,7 +171,7 @@ class TestRDocRdInlineParser < RDoc::TestCase
     assert_equal '<tt>((*text*))</tt>', parse("(('((*text*))'))")
   end
 
-  def parse text
+  def parse(text)
     @inline_parser.parse text
   end
 

--- a/test/rdoc/test_rdoc_servlet.rb
+++ b/test/rdoc/test_rdoc_servlet.rb
@@ -35,7 +35,7 @@ class TestRDocServlet < RDoc::TestCase
     @req = WEBrick::HTTPRequest.new :Logger => nil
     @res = WEBrick::HTTPResponse.new :HTTPVersion => '1.0'
 
-    def @req.path= path
+    def @req.path=(path)
       instance_variable_set :@path, path
     end
 

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -74,8 +74,8 @@ class TestRDocStore < XrefTestCase
     FileUtils.rm_rf @tmpdir
   end
 
-  def assert_cache imethods, cmethods, attrs, modules,
-                   ancestors = {}, pages = [], main = nil, title = nil
+  def assert_cache(imethods, cmethods, attrs, modules,
+                   ancestors = {}, pages = [], main = nil, title = nil)
     imethods ||= { 'Object' => %w[method method! method_bang] }
     cmethods ||= { 'Object' => %w[cmethod] }
     attrs    ||= { 'Object' => ['attr_accessor attr'] }


### PR DESCRIPTION
The RDoc codebase has very few conventions. I think it would be nice to standardize the style of the code a bit more. I propose we start requiring parenthesis in method definitions, which in my opinion makes the code more readable.

This PR just changes the configurations and then runs `bundle exec rubocop -a`. I also excluded generated files from linting.