### PR TITLE
Runs ruby-core workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -43,6 +43,11 @@ jobs:
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev bison autoconf ruby
       - name: Build Ruby
         run: |
+          # Download the required auxiliary files for autoconf
+          # This is necessary because autoconf 2.71+ (included in Ubuntu latest)
+          # fails with "cannot find required auxiliary files" error
+          # These files (config.guess and config.sub) are needed for system detection
+          ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
           autoconf
           ./configure -C --disable-install-doc
         working-directory: ruby/ruby

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -1,4 +1,4 @@
-name: ruby-core
+name: Document generation test with ruby/ruby
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ permissions: # added using https://github.com/step-security/secure-workflows
 jobs:
   ruby_core:
     name: Generate ruby/ruby documentation with the current RDoc commit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     timeout-minutes: 30


### PR DESCRIPTION
Ubuntu 20.04 is now retired on GH Actions and jobs using it are stopped automatically. [Reference](https://github.com/actions/runner-images/issues/11101)