### PR TITLE
Fix rubygems hook execution when gemspec.rdoc_options contains --ri

### DIFF
--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -182,18 +182,18 @@ class RDoc::RubyGemsHook
       options.default_title = "#{@spec.full_name} Documentation"
       options.parse args
       options.quiet = !Gem.configuration.really_verbose
-      options.finish
     end
 
     @rdoc = new_rdoc
-    @rdoc.options = options
-
-    @rdoc.store = RDoc::Store.new(options)
 
     say "Parsing documentation for #{@spec.full_name}"
 
     Dir.chdir @spec.full_gem_path do
-      @rdoc.parse_files options.files
+      parse_options = options.dup
+      parse_options.finish
+      @rdoc.options = parse_options
+      @rdoc.store = RDoc::Store.new(parse_options)
+      @rdoc.parse_files parse_options.files
     end
 
     document 'ri',       options, @ri_dir if

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -189,6 +189,9 @@ class RDoc::RubyGemsHook
     say "Parsing documentation for #{@spec.full_name}"
 
     Dir.chdir @spec.full_gem_path do
+      # RDoc::Options#finish must be called before parse_files.
+      # RDoc::Options#finish is also called after ri/darkfish generator setup.
+      # We need to dup the options to avoid modifying it after finish is called.
       parse_options = options.dup
       parse_options.finish
       @rdoc.options = parse_options

--- a/test/rdoc/test_rdoc_rubygems_hook.rb
+++ b/test/rdoc/test_rdoc_rubygems_hook.rb
@@ -241,6 +241,18 @@ class TestRDocRubyGemsHook < Test::Unit::TestCase
     assert_path_not_exist File.join(@a.doc_dir('ri'),   'cache.ri')
   end
 
+  def test_generate_with_ri_opt
+    @a.rdoc_options << '--ri'
+    FileUtils.mkdir_p @a.doc_dir
+    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
+    @hook.generate_rdoc = true
+    @hook.generate_ri   = true
+    @hook.generate
+
+    assert_path_exist File.join(@a.doc_dir('rdoc'), 'index.html')
+    assert_path_exist File.join(@a.doc_dir('ri'),   'cache.ri')
+  end
+
   def test_new_rdoc
     assert_kind_of RDoc::RDoc, @hook.new_rdoc
   end


### PR DESCRIPTION
Probably fixes #1343

`options.finish` is called twice while generating document through rubygems_hook.
If gemspec has `spec.rdoc_options << '--ri'`, document generation fails.
Looks like this double-finish is introduced in #1274

### Detail of the bug
```ruby
options = ::RDoc::Options.new
options.parse args # if --ri is specified, generator is set to 'ri'
options.finish # @template='ri' and @template_dir=nil is configured here
@rdoc.parse_files options.files

document 'ri', options, @rdoc_dir
document 'darkfish', options, @rdoc_dir # Calls options.setup_generator('darkfish') and options.finish but @template_dir is already configured for 'ri'
```

### Fix
Constraints are:
- Need to call finish only once for each RDoc::Options instance
- `finish` should be called before `rdoc.parse_files(options.files)`
- `finish` should be called after `options.setup_generator`
- It is better to call `rdoc.parse_files` only once

We need to use a different RDoc::Options object for parse_files phase and document generation phase.
