### PR TITLE
Fix image tag with external source

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -98,7 +98,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
       gen_url CGI.escapeHTML(url), CGI.escapeHTML(text)
     when /^rdoc-image:/
-     # Split the string after "rdoc-image:" into url and alt.
+      # Split the string after "rdoc-image:" into url and alt.
       #   "path/to/image.jpg:alt text" => ["path/to/image.jpg", "alt text"]
       #   "http://example.com/path/to/image.jpg:alt text" => ["http://example.com/path/to/image.jpg", "alt text"]
       url, alt = $'.split(/:(?!\/)/, 2)

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -98,7 +98,11 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
       gen_url CGI.escapeHTML(url), CGI.escapeHTML(text)
     when /^rdoc-image:/
-      url, alt = $'.split(":", 2) # Split the string after "rdoc-image:" into url and alt
+      # Split the string after "rdoc-image:" into url and alt
+      url_alt = $'
+      split_pos = url_alt.index(%r{:[^/]})
+      url = split_pos ? url_alt[0, split_pos] : url_alt
+      alt = split_pos ? url_alt[split_pos + 1, url_alt.size] : nil
       if alt && !alt.empty?
         %[<img src="#{CGI.escapeHTML(url)}" alt="#{CGI.escapeHTML(alt)}">]
       else

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -98,11 +98,10 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
       gen_url CGI.escapeHTML(url), CGI.escapeHTML(text)
     when /^rdoc-image:/
-      # Split the string after "rdoc-image:" into url and alt
-      url_alt = $'
-      split_pos = url_alt.index(%r{:[^/]})
-      url = split_pos ? url_alt[0, split_pos] : url_alt
-      alt = split_pos ? url_alt[split_pos + 1, url_alt.size] : nil
+     # Split the string after "rdoc-image:" into url and alt.
+      #   "path/to/image.jpg:alt text" => ["path/to/image.jpg", "alt text"]
+      #   "http://example.com/path/to/image.jpg:alt text" => ["http://example.com/path/to/image.jpg", "alt text"]
+      url, alt = $'.split(/:(?!\/)/, 2)
       if alt && !alt.empty?
         %[<img src="#{CGI.escapeHTML(url)}" alt="#{CGI.escapeHTML(alt)}">]
       else

--- a/test/rdoc/test_rdoc_markup_to_html.rb
+++ b/test/rdoc/test_rdoc_markup_to_html.rb
@@ -749,6 +749,36 @@ EXPECTED
     assert_not_include result, "<script>"
   end
 
+  def test_convert_TIDYLINK_image_with_alt
+    result =
+      @to.convert '{rdoc-image:path/to/image.jpg:alt text}[http://example.com]'
+
+    expected =
+      "\n<p><a href=\"http://example.com\"><img src=\"path/to/image.jpg\" alt=\"alt text\"></a></p>\n"
+
+    assert_equal expected, result
+  end
+
+  def test_convert_TIDYLINK_image_external
+    result =
+      @to.convert '{rdoc-image:http://example.com/path/to/image.jpg}[http://example.com]'
+
+    expected =
+      "\n<p><a href=\"http://example.com\"><img src=\"http://example.com/path/to/image.jpg\"></a></p>\n"
+
+    assert_equal expected, result
+  end
+
+  def test_convert_TIDYLINK_image_external_with_alt
+    result =
+      @to.convert '{rdoc-image:http://example.com/path/to/image.jpg:alt text}[http://example.com]'
+
+    expected =
+      "\n<p><a href=\"http://example.com\"><img src=\"http://example.com/path/to/image.jpg\" alt=\"alt text\"></a></p>\n"
+
+    assert_equal expected, result
+  end
+
   def test_convert_TIDYLINK_rdoc_label
     result = @to.convert '{foo}[rdoc-label:foottext-1]'
 


### PR DESCRIPTION
When `rdoc-image` contains an external source, such as `https://example.com/path/to/image.svg`, the rendered `<img>` tag is broken. This PR fixes the bug.

For example, I found the problem on the IRB website, where a Markdown image is present as a source.

Rendered HTML on the website <https://ruby.github.io/irb/>:

```html
<a href="https://badge.fury.io/rb/irb"><img src="https" alt="//badge.fury.io/rb/irb.svg:Gem Version"></a>
```

Screenshot:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/bf138616-4296-4e30-9eaa-5ee7301e8681" />

Markdown source: <https://github.com/ruby/irb/blob/6349b03f64f173a9d31bc9042430e1134f3e1689/doc/Index.md?plain=1#L3>

```markdown
[![Gem Version](https://badge.fury.io/rb/irb.svg)](https://badge.fury.io/rb/irb)
```

Probably, this bug was introduced in the commit 894b2f1cd147a760449a52b621af7bf206452127, i.e., <https://github.com/ruby/rdoc/releases/tag/v6.13.0>.
