### PR TITLE
Polish link underline in Darkfish CSS

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -97,7 +97,7 @@ a {
   color: var(--link-color);
   transition: color 0.3s ease;
   text-decoration: underline;
-  text-underline-offset: 2px; /* Make sure it doesn't overlap with underscores in a method name. */
+  text-underline-offset: 0.2em; /* Make sure it doesn't overlap with underscores in a method name. */
 }
 
 a:hover {

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -96,6 +96,8 @@ main .anchor-link:target {
 a {
   color: var(--link-color);
   transition: color 0.3s ease;
+  text-decoration: underline;
+  text-underline-offset: 2px; /* Make sure it doesn't overlap with underscores in a method name. */
 }
 
 a:hover {


### PR DESCRIPTION
This aims to make sure an underline in a link doesn't overlap with underscores in a method name.

For example, method names on the following page seem a bit hard to read because underscores in a method name are hidden in an underline:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/70f4846a-5dd5-40e3-88c8-f2a0e1d19c94" />
https://ruby.github.io/rdoc/table_of_contents.html#methods

This PR improves it a bit:

2px:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/09a53889-900b-44b8-9fa0-a0957e2ca849" />

3px:
<img width="332" alt="image" src="https://github.com/user-attachments/assets/24e4584a-9c6e-4762-89f0-3a9d4f6ac594" />

Note: The [`text-underline-offset`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-offset) CSS property is widely available now.

