### PR TITLE
Fix link to CONTRIBUTING on README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -123,7 +123,7 @@ Please follow the theme's README for usage instructions.
 
 == Bugs
 
-See CONTRIBUTING@Bugs for information on filing a bug report.  It's OK to file
+See CONTRIBUTING.rdoc for information on filing a bug report.  It's OK to file
 a bug report for anything you're having a problem with.  If you can't figure
 out how to make RDoc produce the output you like that is probably a
 documentation bug.


### PR DESCRIPTION
I probably think it should be a link to the CONTRIBUTING page, instead of an inline code `CONTRIBUTING`. See https://ruby.github.io/rdoc/#label-Bugs
<img width="349" alt="image" src="https://github.com/user-attachments/assets/9f279bf8-ae4b-4cfd-8726-2755e32d305e" />

If applying this PR, it becomes:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/00bcd5c1-1986-45a9-982d-c554f0eb44d9" />
