### PR TITLE
Don't run CI jobs for push by Dependabot

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+  pull_request:
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+  pull_request:
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read


### PR DESCRIPTION
Dependabot creates a PR automatically. So we can run CI jobs only for `pull_request` for Dependabot.