### PR TITLE
Set language in HTML

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -595,7 +595,7 @@ class RDoc::Generator::Darkfish
     <<-TEMPLATE
 <!DOCTYPE html>
 
-<html>
+<html lang="#{@options.locale&.name || 'en'}">
 <head>
 #{head_file.read}
 

--- a/test/rdoc/rdoc_generator_darkfish_test.rb
+++ b/test/rdoc/rdoc_generator_darkfish_test.rb
@@ -388,6 +388,21 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
     assert_include File.binread('index.html'), %Q[href="./#{base}"]
   end
 
+  def test_html_lang
+    @g.generate
+
+    content = File.binread("index.html")
+    assert_include(content, '<html lang="en">')
+  end
+
+  def test_html_lang_from_locale
+    @options.locale = RDoc::I18n::Locale.new 'ja'
+    @g.generate
+
+    content = File.binread("index.html")
+    assert_include(content, '<html lang="ja">')
+  end
+
   def test_title
     title = "RDoc Test".freeze
     @options.title = title


### PR DESCRIPTION
Setting the language helps with search engines, screen readers and text rendering. The language defaults to `en` as that is probably most common (it's also the default for navigation in Darkfish).

Setting the `locale` option will override the language to the locale.