### PR TITLE
Load `cgi/escape` instead of `cgi/util`

### DIFF
--- a/lib/rdoc/code_object/context/section.rb
+++ b/lib/rdoc/code_object/context/section.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cgi/util'
+require 'cgi/escape'
 
 ##
 # A section of documentation like:

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -282,7 +282,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
   # HTML id-friendly method/attribute name
 
   def html_name
-    require 'cgi/util'
+    require 'cgi/escape'
 
     CGI.escape(@name.gsub('-', '-2D')).gsub('%', '-').sub(/^-/, '')
   end

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-require 'cgi/util'
+require 'cgi/escape'
+# For CGI.unescape on earlier rubies
+require 'cgi/util' if RUBY_VERSION < '3.5'
 
 ##
 # Outputs RDoc markup as HTML.

--- a/lib/rdoc/markup/to_label.rb
+++ b/lib/rdoc/markup/to_label.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cgi/util'
+require 'cgi/escape'
 
 ##
 # Creates HTML-safe labels suitable for use in id attributes.  Tidylinks are


### PR DESCRIPTION
`cgi/util` will warn on Ruby 3.5. `cgi/escape` is available since Ruby 2.4, but to use CGI.unescape* methods on Ruby 3.4 and earlier, `cgi/util` must still be required.

There's only one place in rdoc that uses such a method, so only one place needs to handle earlier rubies.

https://bugs.ruby-lang.org/issues/21258