### PR TITLE
Declare erb as a dependency

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -64,4 +64,5 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
   s.add_dependency 'psych', '>= 4.0.0'
+  s.add_dependency 'erb'
 end


### PR DESCRIPTION
Although `erb` is still a default gem, it's better to declare it as a dependency to make sure its dependencies (e.g. `cgi`) gets properly resolved too.