### PR TITLE
Bump version to 6.14.0

### DIFF
--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -5,6 +5,6 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '6.13.1'
+  VERSION = '6.14.0'
 
 end


### PR DESCRIPTION
https://github.com/ruby/rdoc/compare/v6.13.1...master

We can then bump `ruby/ruby`'s RDoc to [set canonical url](https://github.com/ruby/rdoc/pull/1354).