### PR TITLE
`test/lib/helper.rb` is only for `ruby/rdoc` repository

### DIFF
--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -13,7 +13,10 @@ require 'tempfile'
 require 'tmpdir'
 require 'stringio'
 
-require_relative '../../lib/helper'
+begin
+  require_relative '../../lib/helper'
+rescue LoadError
+end
 require_relative '../../../lib/rdoc'
 
 ##


### PR DESCRIPTION
from https://github.com/ruby/ruby/pull/13421

The rdoc test is broken with in `ruby_3_4` branch of `ruby/ruby`. Because `test/lib/helper.rb` is only available `ruby/rdoc` repository. I added simple workaround for that.