### PR TITLE
Allow rdoc-ref to link to non-text files

### DIFF
--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -115,14 +115,6 @@ class RDoc::TopLevel < RDoc::Context
   alias name base_name
 
   ##
-  # Only a TopLevel that contains text file) will be displayed.  See also
-  # RDoc::CodeObject#display?
-
-  def display?
-    text? and super
-  end
-
-  ##
   # See RDoc::TopLevel::find_class_or_module
   #--
   # TODO Why do we search through all classes/modules found, not just the

--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -200,7 +200,7 @@ class RDoc::CrossReference
     ref = resolve_method name unless ref
 
     # Try a page name
-    ref = @store.page name if not ref and name =~ /^[\w.]+$/
+    ref = @store.page name if not ref and name =~ /^[\w.\/]+$/
 
     ref = nil if RDoc::Alias === ref # external alias, can't link to it
 

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -723,7 +723,7 @@ class RDoc::Store
   # Returns the RDoc::TopLevel that is a text file and has the given +name+
 
   def page(name)
-    @text_files_hash.each_value.find do |file|
+    @files_hash.each_value.find do |file|
       file.page_name == name or file.base_name == name
     end
   end

--- a/test/rdoc/rdoc_cross_reference_test.rb
+++ b/test/rdoc/rdoc_cross_reference_test.rb
@@ -115,7 +115,7 @@ class RDocCrossReferenceTest < XrefTestCase
   end
 
   def test_resolve_file
-    refute_ref 'xref_data.rb'
+    assert_ref @top_level, 'xref_data.rb'
   end
 
   def test_resolve_method

--- a/test/rdoc/rdoc_top_level_test.rb
+++ b/test/rdoc/rdoc_top_level_test.rb
@@ -110,12 +110,7 @@ class RDocTopLevelTest < XrefTestCase
   end
 
   def test_display_eh
-    refute @top_level.display?
-
-    page = @store.add_file 'README.txt'
-    page.parser = RDoc::Parser::Simple
-
-    assert page.display?
+    assert @top_level.display?
   end
 
   def test_eql_eh


### PR DESCRIPTION
It appears the current behavior of disallowing links to non-text files is deliberate, as it was explicitly added in 3628e196cbbac4767f5b845c5b795c635a671b04.  While the commit message explains the change, it doesn't provide a justification for excluding non-text TopLevels. The issue mentioned in the commit message is also unrelated to the change.

It's just as useful to link to a non-text file as it is to link to a text file, so I think it should be allowed.  I was surprised when it didn't work. I want to use this feature in tilt's documentation.

If there is a reason to disallow it by default, I think this limitation should be documented.  I also I think we should add an option to allow it in that case.
