### PR TITLE
Added gemspec file to gem package

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -54,9 +54,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     "rdoc.gemspec",
   ]
   template_files = Dir.glob("lib/rdoc/generator/template/**/*")
-  lib_files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    Dir.glob("lib/**/*.{rb,kpeg,ry}")
-  end
+  lib_files = Dir.glob("lib/**/*.{rb,kpeg,ry}", base: File.expand_path('..', __FILE__))
 
   s.files = (non_lib_files + template_files + lib_files).uniq
 

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -54,7 +54,9 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     "rdoc.gemspec",
   ]
   template_files = Dir.glob("lib/rdoc/generator/template/**/*")
-  lib_files = Dir.glob("lib/**/*.{rb,kpeg,ry}")
+  lib_files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    Dir.glob("lib/**/*.{rb,kpeg,ry}")
+  end
 
   s.files = (non_lib_files + template_files + lib_files).uniq
 

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -51,6 +51,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     "exe/rdoc",
     "exe/ri",
     "man/ri.1",
+    "rdoc.gemspec",
   ]
   template_files = Dir.glob("lib/rdoc/generator/template/**/*")
   lib_files = Dir.glob("lib/**/*.{rb,kpeg,ry}")


### PR DESCRIPTION
The original `gemspec` need to install `rdoc` as bundled gems at the official Ruby package.

Fix https://bugs.ruby-lang.org/issues/21312