### PR TITLE
Use GITHUB_TOKEN instead of admin credential

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -43,4 +43,4 @@ jobs:
           tag_name="$(git describe --tags --abbrev=0)"
           gh release create "${tag_name}" --verify-tag --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`MATZBOT_GITHUB_WORKFLOW_TOKEN` have admin grant. It's unnecessary for `gh release create`.