### PR TITLE
Support markdown syntax in table cells

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -496,6 +496,46 @@
       "<s>#{text}</s>"
     end
   end
+
+  ##
+  # Parses inline markdown in table cells
+
+  def parse_table_cells(table)
+    # Parse header cells
+    table.header = table.header.map { |cell| parse_cell_inline(cell) }
+
+    # Parse body cells
+    table.body = table.body.map do |row|
+      row.map { |cell| parse_cell_inline(cell) }
+    end
+
+    table
+  end
+
+  ##
+  # Parses inline markdown in a single table cell
+
+  def parse_cell_inline(text)
+    return text if text.nil? || text.empty?
+
+    # Create a new parser instance for the cell
+    cell_parser = RDoc::Markdown.new(@extensions, @debug)
+
+    # Parse the cell content
+    doc = cell_parser.parse(text)
+
+    # Extract the parsed content
+    if doc && doc.parts && !doc.parts.empty?
+      para = doc.parts.first
+      if para.is_a?(RDoc::Markup::Paragraph)
+        para.parts.join
+      else
+        text
+      end
+    else
+      text
+    end
+  end
 }
 
 root = Doc
@@ -1201,7 +1241,10 @@ CodeFence = &{ github? }
 
 Table = &{ github? }
         TableHead:header TableLine:line TableRow+:body
-        { table = RDoc::Markup::Table.new(header, line, body) }
+        {
+          table = RDoc::Markup::Table.new(header, line, body)
+          parse_table_cells(table)
+        }
 
 TableHead = TableItem2+:items "|"? @Newline
             { items }

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1133,6 +1133,30 @@ and an extra note.[^2]
     assert_equal expected, doc
   end
 
+  def test_gfm_table_with_links_and_code
+    doc = parse <<~MD
+    | Feature | Description | Example |
+    |---------|-------------|---------|
+    | Link    | [RDoc](https://github.com/ruby/rdoc) | See docs |
+    | Code    | `puts "hello"` | Inline code |
+    | Both    | Link to [`method`](https://example.com) | Combined |
+    MD
+
+    head = %w[Feature Description Example]
+    align = [nil, nil, nil]
+
+    # Expected behavior: table cells should contain parsed markup
+    body = [
+      ['Link', '{RDoc}[https://github.com/ruby/rdoc]', 'See docs'],
+      ['Code', '<code>puts "hello"</code>', 'Inline code'],
+      ['Both', 'Link to {<code>method</code>}[https://example.com]', 'Combined'],
+    ]
+
+    expected = doc(@RM::Table.new(head, align, body))
+
+    assert_equal expected, doc
+  end
+
   def parse(text)
     @parser.parse text
   end


### PR DESCRIPTION
This will allow things like backticks and links being rendered in table cells.

Fixes #1233 

### Before

<img width="70%" alt="Screenshot 2025-07-02 at 21 57 59" src="https://github.com/user-attachments/assets/f2222915-6825-4f6b-b690-c6e44262286c" />

### After

<img width="70%" alt="Screenshot 2025-07-02 at 21 56 52" src="https://github.com/user-attachments/assets/c015e2ce-0231-4f3f-881e-94f6f9f447b1" />
