### PR TITLE
Bump version to 6.14.2

### DIFF
--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -5,6 +5,6 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '6.14.1'
+  VERSION = '6.14.2'
 
 end


### PR DESCRIPTION
https://github.com/ruby/rdoc/compare/v6.14.1...master but mostly for #1386 which can immediately improve `ruby/ruby`'s documentation.