### PR TITLE
Standardize table and heading markup elements

### DIFF
--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -210,6 +210,7 @@ https://github.com/ruby/rdoc/issues
   autoload :BlankLine,             "#{__dir__}/markup/blank_line"
   autoload :BlockQuote,            "#{__dir__}/markup/block_quote"
   autoload :Document,              "#{__dir__}/markup/document"
+  autoload :Element,               "#{__dir__}/markup/element"
   autoload :HardBreak,             "#{__dir__}/markup/hard_break"
   autoload :Heading,               "#{__dir__}/markup/heading"
   autoload :Include,               "#{__dir__}/markup/include"

--- a/lib/rdoc/markup/element.rb
+++ b/lib/rdoc/markup/element.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RDoc
+  class Markup
+    # Base class defining the interface for all markup elements found in documentation
+    # @abstract
+    class Element
+      # @abstract
+      #: (untyped) -> void
+      def accept(visitor)
+        raise NotImplementedError, "#{self.class} must implement the accept method"
+      end
+
+      # @abstract
+      #: (PP) -> void
+      def pretty_print(q)
+        raise NotImplementedError, "#{self.class} must implement the pretty_print method"
+      end
+    end
+  end
+end

--- a/lib/rdoc/markup/heading.rb
+++ b/lib/rdoc/markup/heading.rb
@@ -1,84 +1,100 @@
 # frozen_string_literal: true
-##
-# A heading with a level (1-6) and text
 
-RDoc::Markup::Heading =
-  Struct.new :level, :text do
+module RDoc
+  class Markup
+    # A heading with a level (1-6) and text
+    #
+    #  RDoc syntax:
+    #   = Heading 1
+    #   == Heading 2
+    #   === Heading 3
+    #
+    #  Markdown syntax:
+    #   # Heading 1
+    #   ## Heading 2
+    #   ### Heading 3
+    class Heading < Element
+      #: String
+      attr_reader :text
 
-  @to_html = nil
-  @to_label = nil
+      #: Integer
+      attr_accessor :level
 
-  ##
-  # A singleton RDoc::Markup::ToLabel formatter for headings.
+      # A singleton RDoc::Markup::ToLabel formatter for headings.
+      #: () -> RDoc::Markup::ToLabel
+      def self.to_label
+        @to_label ||= Markup::ToLabel.new
+      end
 
-  def self.to_label
-    @to_label ||= RDoc::Markup::ToLabel.new
-  end
+      # A singleton plain HTML formatter for headings. Used for creating labels for the Table of Contents
+      #: () -> RDoc::Markup::ToHtml
+      def self.to_html
+        @to_html ||= begin
+          markup = Markup.new
+          markup.add_regexp_handling CrossReference::CROSSREF_REGEXP, :CROSSREF
 
-  ##
-  # A singleton plain HTML formatter for headings.  Used for creating labels
-  # for the Table of Contents
+          @to_html = Markup::ToHtml.new nil
 
-  def self.to_html
-    return @to_html if @to_html
+          def @to_html.handle_regexp_CROSSREF(target)
+            target.text.sub(/^\\/, '')
+          end
 
-    markup = RDoc::Markup.new
-    markup.add_regexp_handling RDoc::CrossReference::CROSSREF_REGEXP, :CROSSREF
+          @to_html
+        end
+      end
 
-    @to_html = RDoc::Markup::ToHtml.new nil
+      #: (Integer, String) -> void
+      def initialize(level, text)
+        @level = level
+        @text = text
+        super()
+      end
 
-    def @to_html.handle_regexp_CROSSREF(target)
-      target.text.sub(/^\\/, '')
+      #: (Object) -> bool
+      def ==(other)
+        other.is_a?(Heading) && other.level == @level && other.text == @text
+      end
+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_heading(self)
+      end
+
+      # An HTML-safe anchor reference for this header.
+      #: () -> String
+      def aref
+        "label-#{self.class.to_label.convert text.dup}"
+      end
+
+      # Creates a fully-qualified label which will include the label from +context+. This helps keep ids unique in HTML.
+      #: (RDoc::Context?) -> String
+      def label(context = nil)
+        label = +""
+        label << "#{context.aref}-" if context&.respond_to?(:aref)
+        label << aref
+        label
+      end
+
+      # HTML markup of the text of this label without the surrounding header element.
+      #: () -> String
+      def plain_html
+        text = self.text.dup
+
+        if matched = text.match(/rdoc-image:[^:]+:(.*)/)
+          text = matched[1]
+        end
+
+        self.class.to_html.to_html(text)
+      end
+
+      # @override
+      #: (PP) -> void
+      def pretty_print(q)
+        q.group 2, "[head: #{level} ", ']' do
+          q.pp text
+        end
+      end
     end
-
-    @to_html
   end
-
-  ##
-  # Calls #accept_heading on +visitor+
-
-  def accept(visitor)
-    visitor.accept_heading self
-  end
-
-  ##
-  # An HTML-safe anchor reference for this header.
-
-  def aref
-    "label-#{self.class.to_label.convert text.dup}"
-  end
-
-  ##
-  # Creates a fully-qualified label which will include the label from
-  # +context+.  This helps keep ids unique in HTML.
-
-  def label(context = nil)
-    label = aref
-
-    label = [context.aref, label].compact.join '-' if
-      context and context.respond_to? :aref
-
-    label
-  end
-
-  ##
-  # HTML markup of the text of this label without the surrounding header
-  # element.
-
-  def plain_html
-    text = self.text.dup
-
-    if matched = text.match(/rdoc-image:[^:]+:(.*)/)
-      text = matched[1]
-    end
-
-    self.class.to_html.to_html(text)
-  end
-
-  def pretty_print(q) # :nodoc:
-    q.group 2, "[head: #{level} ", ']' do
-      q.pp text
-    end
-  end
-
 end

--- a/lib/rdoc/markup/table.rb
+++ b/lib/rdoc/markup/table.rb
@@ -1,52 +1,60 @@
 # frozen_string_literal: true
-##
-# A section of table
 
-class RDoc::Markup::Table
-  # headers of each column
-  attr_accessor :header
+module RDoc
+  class Markup
+    # A section of table
+    class Table < Element
+      # Headers of each column
+      #: Array[String]
+      attr_accessor :header
 
-  # alignments of each column
-  attr_accessor :align
+      # Alignments of each column
+      #: Array[Symbol?]
+      attr_accessor :align
 
-  # body texts of each column
-  attr_accessor :body
+      # Body texts of each column
+      #: Array[String]
+      attr_accessor :body
 
-  # Creates new instance
-  def initialize(header, align, body)
-    @header, @align, @body = header, align, body
-  end
-
-  # :stopdoc:
-  def ==(other)
-    self.class == other.class and
-      @header == other.header and
-      @align == other.align and
-      @body == other.body
-  end
-
-  def accept(visitor)
-    visitor.accept_table @header, @body, @align
-  end
-
-  def pretty_print(q)
-    q.group 2, '[Table: ', ']' do
-      q.group 2, '[Head: ', ']' do
-        q.seplist @header.zip(@align) do |text, align|
-          q.pp text
-          if align
-            q.text ":"
-            q.breakable
-            q.text align.to_s
-          end
-        end
+      #: (Array[String], Array[Symbol?], Array[String]) -> void
+      def initialize(header, align, body)
+        @header, @align, @body = header, align, body
       end
-      q.breakable
-      q.group 2, '[Body: ', ']' do
-        q.seplist @body do |body|
-          q.group 2, '[', ']' do
-            q.seplist body do |text|
+
+      #: (Object) -> bool
+      def ==(other)
+        self.class == other.class && @header == other.header &&
+          @align == other.align && @body == other.body
+      end
+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_table(@header, @body, @align)
+      end
+
+      # @override
+      #: (untyped) -> String
+      def pretty_print(q)
+        q.group 2, '[Table: ', ']' do
+          q.group 2, '[Head: ', ']' do
+            q.seplist @header.zip(@align) do |text, align|
               q.pp text
+              if align
+                q.text ":"
+                q.breakable
+                q.text align.to_s
+              end
+            end
+          end
+          q.breakable
+          q.group 2, '[Body: ', ']' do
+            q.seplist @body do |body|
+              q.group 2, '[', ']' do
+                q.seplist body do |text|
+                  q.pp text
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
I noticed that Markup elements are currently not standardized in any way - even though the code does make some assumptions.

For example, there are visitors that depend on all elements implementing `accept`, but no parent class or interface that will help guarantee every element implements it. Some elements are implemented as structs, while other are classes. Some have parent classes for shared functionality and APIs and others don't.

I propose that we standardize the markup elements a bit more, so that we can have a common interface for them. It will make it easier for the RDoc to Markdown translator if we can enforce that every markup element has to be able to print itself in Markdown - and I believe the code will be easier to understand too.

This PR creates a base `Markup::Element` class and I standardized `Heading` and `Table` as an example. I'm also finding it challenging to understand the logic with no clue about what types are and what is expected from each method, so I also propose we annotate some of these as documentation - even if we're not adopting type checking.

If folks agree, I will continue to standardize more markup elements.