### PR TITLE
Fix backslash in RDoc monofont causing unwanted linking

### DIFF
--- a/test/rdoc/rdoc_markup_to_html_crossref_test.rb
+++ b/test/rdoc/rdoc_markup_to_html_crossref_test.rb
@@ -33,6 +33,22 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
     assert_equal para("<code># :stopdoc:</code>:"), result
   end
 
+  def test_convert_CROSSREF_backslash_escapes_in_monofont
+    # Test that backslash escapes in monofont don't create unwanted links
+    result = @to.convert '<tt>.bar.hello(\)</tt>'
+    assert_equal para("<code>.bar.hello(\\)</code>"), result
+
+    result = @to.convert '<tt>.bar.hello(\\\\)</tt>'
+    assert_equal para("<code>.bar.hello(\\)</code>"), result
+
+    # Regular method references should still work
+    result = @to.convert '<tt>C1#m</tt>'
+    assert_equal para("<a href=\"C1.html#method-i-m\"><code>C1#m</code></a>"), result
+
+    result = @to.convert '<tt>C1.m</tt>'
+    assert_equal para("<a href=\"C1.html#method-c-m\"><code>C1.m</code></a>"), result
+  end
+
   def test_convert_CROSSREF_ignored_excluded_words
     @options.autolink_excluded_words = ['C1']
 


### PR DESCRIPTION
## Summary
- Fixes issue where backslashes in `<tt>` tags caused unwanted cross-reference links
- Adds validation to ensure escaped characters don't trigger false positive cross-references
- Preserves normal cross-reference functionality for valid method/class references

## Problem
When text in `<tt>` tags contains backslashes (e.g., `<tt>.bar.hello(\)</tt>`), RDoc was incorrectly creating cross-reference links. This happened because the backslash matched the escaped character pattern in `CROSSREF_REGEXP`, causing the entire string to be processed as a potential cross-reference.

## Solution
Added checks in both `handle_regexp_CROSSREF` and `convert_flow` to detect when a match is solely due to escaped character patterns that don't represent valid method/class references. These strings are now rendered as code without creating links.

## Test plan
- [x] Added new test case `test_convert_CROSSREF_backslash_escapes_in_monofont` to verify the fix
- [x] Confirmed existing tests pass
- [x] Tested with the reproduction case from the issue

Fixes #1390

🤖 Generated with [Claude Code](https://claude.ai/code)