### PR TITLE
Search automatically on ?q= URL query parameter

### DIFF
--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -72,7 +72,15 @@ function hookSearch() {
   }
 
   search.select = function(result) {
-    window.location.href = result.firstChild.firstChild.href;
+    var href = result.firstChild.firstChild.href;
+    var query = this.input.value;
+    if (query) {
+      var url = new URL(href, window.location.origin);
+      url.searchParams.set('q', query);
+      url.searchParams.set('nav', '0');
+      href = url.toString();
+    }
+    window.location.href = href;
   }
 
   search.scrollIntoView = search.scrollInWindow;
@@ -82,8 +90,10 @@ function hookSearch() {
     var urlParams = new URLSearchParams(window.location.search);
     var queryParam = urlParams.get('q');
     if (queryParam) {
+      var navParam = urlParams.get('nav');
+      var autoSelect = navParam !== '0';
       input.value = queryParam;
-      search.search(queryParam, true);
+      search.search(queryParam, autoSelect);
     }
   }
 };

--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -76,6 +76,16 @@ function hookSearch() {
   }
 
   search.scrollIntoView = search.scrollInWindow;
+
+  // Check for ?q= URL parameter and trigger search automatically
+  if (typeof URLSearchParams !== 'undefined') {
+    var urlParams = new URLSearchParams(window.location.search);
+    var queryParam = urlParams.get('q');
+    if (queryParam) {
+      input.value = queryParam;
+      search.search(queryParam, true);
+    }
+  }
 };
 
 function hookFocus() {

--- a/lib/rdoc/generator/template/darkfish/js/search.js
+++ b/lib/rdoc/generator/template/darkfish/js/search.js
@@ -34,6 +34,8 @@ Search.prototype = Object.assign({}, Navigation, new function() {
   }
 
   this.search = function(value, selectFirstMatch) {
+    this.selectFirstMatch = selectFirstMatch;
+
     value = value.trim().toLowerCase();
     if (value) {
       this.setNavigationActive(true);
@@ -76,7 +78,15 @@ Search.prototype = Object.assign({}, Navigation, new function() {
     //TODO: ECMAScript
     //if (jQuery.browser.msie) this.$element[0].className += '';
 
-    if (isLast) this.result.setAttribute('aria-busy', 'false');
+    if (this.selectFirstMatch && this.current) {
+      this.selectFirstMatch = false;
+      this.select(this.current);
+    }
+
+    if (isLast) {
+      this.selectFirstMatch = false;
+      this.result.setAttribute('aria-busy', 'false');
+    }
   }
 
   this.move = function(isDown) {


### PR DESCRIPTION
Fixes https://github.com/ruby/rdoc/issues/1319 (I wanted this for exactly that reason 😅)

Automatically start searching when ?q= parameter is given in the URL, selecting and visiting the first match if available.

If not available, the query will be filled into the search box but we won't navigate away.

This should enable configuring a generated rdoc page as a search engine in one's web browser, or as a bang command in a search engine. For reference Rails' sdoc (which I think rdoc's search is originally based on) does this: https://api.rubyonrails.org/?q=changed%3F