### PR TITLE
searcher.js: Escape characters when building regexps

### DIFF
--- a/lib/rdoc/generator/template/json_index/js/searcher.js
+++ b/lib/rdoc/generator/template/json_index/js/searcher.js
@@ -58,7 +58,12 @@ Searcher.prototype = new function() {
 
   function buildRegexps(queries) {
     return queries.map(function(query) {
-      return new RegExp(query.replace(/(.)/g, '([$1])([^$1]*?)'), 'i');
+      var pattern = [];
+      for (var i = 0; i < query.length; i++) {
+        var char = RegExp.escape(query[i]);
+        pattern.push('([' + char + '])([^' + char + ']*?)');
+      }
+      return new RegExp(pattern.join(''), 'i');
     });
   }
 


### PR DESCRIPTION
Otherwise characters with regexp meaning ~like `.` won't behave as expected~.

Actually `.` when inside `[]` doesn't have a special meaning, however `\` and a few other break the search.