### PR TITLE
Fix incomplete string escaping or encoding

### DIFF
--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -294,7 +294,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
 
   def handle_regexp_SUPPRESSED_CROSSREF(target)
     text = target.text
-    text = text.sub('\\', '') unless in_tt?
+    text = text.gsub('\\', '') unless in_tt?
     text
   end
 


### PR DESCRIPTION
fix the problem, replace `text.sub('\\', '')` with `text.gsub('\\', '')` so that all occurrences of the backslash character are removed from the string, not just the first one. This change should be made only on line 297 in the `handle_regexp_SUPPRESSED_CROSSREF` method in `lib/rdoc/markup/to_rdoc.rb`. No additional imports or method definitions are required, as `gsub` is a standard Ruby `String` method. This change preserves the intended functionality while ensuring that all backslashes are removed, not just the first.

### References
[RailsActiveRecord::Base::sanitize_sql](https://api.rubyonrails.org/classes/ActiveRecord/Sanitization/ClassMethods.html)
