### PR TITLE
Revert "Shorten the description text to get rid of JRuby exception"

### DIFF
--- a/test/rdoc/rdoc_generator_darkfish_test.rb
+++ b/test/rdoc/rdoc_generator_darkfish_test.rb
@@ -469,7 +469,8 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
     top_level.comment = <<~MARKDOWN
       # Distributed Ruby: dRuby
 
-      dRuby is a distributed object system for Ruby.  It allows an object.
+      dRuby is a distributed object system for Ruby.  It allows an object in one
+      Ruby process to invoke methods on an object in another Ruby process.
     MARKDOWN
 
     @g.generate
@@ -480,7 +481,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
       "<meta name=\"description\" content=\"" \
       "README: dRuby " \
       "dRuby is a distributed object system for Ruby. " \
-      "It allows an object."
+      "It allows an object in one Ruby process to invoke methods on an object"
     )
   end
 


### PR DESCRIPTION
This reverts commit 0ed8f0179f38f9e0f01c55401b5045ed24b57f1b. No longer this workaround seems needed (jruby/jruby#8682).