### PR TITLE
[DOC] Fix `warn_missing_rdoc_ref` default value in doc

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,6 +1,5 @@
 op_dir: _site # for GitHub Pages and should match the config of RDoc task in Rakefile
 title: rdoc Documentation
 main_page: README.rdoc
-warn_missing_rdoc_ref: true
 autolink_excluded_words:
 - RDoc

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -327,7 +327,7 @@ class RDoc::Options
 
   ##
   # Warn if rdoc-ref links can't be resolved
-  # Default is +false+
+  # Default is +true+
 
   attr_accessor :warn_missing_rdoc_ref
 


### PR DESCRIPTION
It's actually enabled by default now. Also removes the setting from `.rdoc_options` as it's not needed.