### PR TITLE
Change error message assertion to make it pass in JRuby

### DIFF
--- a/test/rdoc/rdoc_context_test.rb
+++ b/test/rdoc/rdoc_context_test.rb
@@ -237,7 +237,7 @@ class RDocContextTest < XrefTestCase
     expected = 'Duplicate method (unknown)#name in file second.rb, ' \
                'previously in file first.rb'
 
-    assert_equal expected, err.chomp
+    assert_include err, expected
 
     method = @context.method_list.first
 

--- a/test/rdoc/rdoc_encoding_test.rb
+++ b/test/rdoc/rdoc_encoding_test.rb
@@ -60,7 +60,7 @@ class RDocEncodingTest < RDoc::TestCase
 
     assert_nil contents
 
-    assert_match %r%^unable to convert%, err
+    assert_include err, 'unable to convert'
   end
 
   def test_class_read_file_encoding_fancy
@@ -101,7 +101,7 @@ class RDocEncodingTest < RDoc::TestCase
       contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
     end
 
-    assert_equal "unable to convert \"\\xE4\" on US-ASCII for #{@tempfile.path}, skipping\n", err
+    assert_include err, "unable to convert \"\\xE4\" on US-ASCII for #{@tempfile.path}, skipping\n"
 
     assert_nil contents
   end

--- a/test/rdoc/rdoc_options_test.rb
+++ b/test/rdoc/rdoc_options_test.rb
@@ -47,7 +47,7 @@ class RDocOptionsTest < RDoc::TestCase
     end
 
     assert_empty out
-    assert_equal "file 'nonexistent' not found\n", err
+    assert_include err, "file 'nonexistent' not found\n"
     assert_empty @options.files
   end
 
@@ -828,7 +828,7 @@ rdoc_include:
     end
 
     assert_empty out
-    assert_equal "warnings on\n", err
+    assert_include err, "warnings on\n"
   end
 
   def test_write_options

--- a/test/rdoc/rdoc_parser_c_test.rb
+++ b/test/rdoc/rdoc_parser_c_test.rb
@@ -289,8 +289,7 @@ void Init_Blah(void) {
       refute util_get_class(content, 'cDate')
     end
 
-    assert_equal "Enclosing class or module \"cDate\" for alias b a is not known\n",
-                 err
+    assert_include err, "Enclosing class or module \"cDate\" for alias b a is not known\n"
   end
 
   def test_do_classes_class
@@ -827,7 +826,7 @@ void Init_Blah(void) {
     expected = 'Unable to create class Y (y), class Z (z) ' +
                'due to a cyclic class or module creation'
 
-    assert_equal expected, err.chomp
+    assert_include err, expected
 
     assert_equal %w[A A::B A::B::C],
                  @store.all_classes_and_modules.map { |m| m.full_name }.sort

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -146,8 +146,8 @@ class RDocRDocTest < RDoc::TestCase
     assert_empty files
 
     assert_empty out
-    assert_match %r"^rdoc can't parse", err
-    assert_match %r"#{dev}$",           err
+    assert_include err, "rdoc can't parse"
+    assert_match %r"#{dev}$", err
   end
 
   def test_normalized_file_list_with_dot_doc

--- a/test/rdoc/rdoc_task_test.rb
+++ b/test/rdoc/rdoc_task_test.rb
@@ -24,13 +24,13 @@ class RDocTaskTest < RDoc::TestCase
       assert @t.inline_source
     end
 
-    assert_equal "RDoc::Task#inline_source is deprecated\n", err
+    assert_include err, "RDoc::Task#inline_source is deprecated\n"
 
     _, err = verbose_capture_output do
       @t.inline_source = false
     end
 
-    assert_equal "RDoc::Task#inline_source is deprecated\n", err
+    assert_include err, "RDoc::Task#inline_source is deprecated\n"
 
     capture_output do
       assert @t.inline_source

--- a/test/rdoc/rdoc_text_test.rb
+++ b/test/rdoc/rdoc_text_test.rb
@@ -571,7 +571,7 @@ The comments associated with
       assert_equal '<tt>hi', to_html('<tt>hi')
     end
 
-    assert_equal "mismatched <tt> tag\n", err
+    assert_include err, "mismatched <tt> tag\n"
   end
 
   def formatter


### PR DESCRIPTION
Fix JRuby ci failure
```
Failure: test_check_files_warn(RDocOptionsTest)
/home/runner/work/rdoc/rdoc/test/rdoc/rdoc_options_test.rb:50:in 'test_check_files_warn'
     49:     assert_empty out
  => 50:     assert_equal "file 'nonexistent' not found\n", err
     51:     assert_empty @options.files
     52:   end
<"file 'nonexistent' not found\n"> expected but was
<"/home/runner/work/rdoc/rdoc/lib/rdoc/options.rb:1370: warning: file 'nonexistent' not found\n">
```

Related to https://github.com/ruby/prism/pull/3647