### PR TITLE
Rescue RuboCop rake tasks require error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,12 @@ $:.unshift File.expand_path('lib', __dir__) # default template dir
 require_relative 'lib/rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-require 'rubocop/rake_task'
+
+begin
+  require 'rubocop/rake_task'
+rescue LoadError
+  puts "RuboCop is not installed"
+end
 
 task :test    => [:normal_test, :rubygems_test]
 


### PR DESCRIPTION
On Ruby's CI, RuboCop is not installed and not needed. So we should rescue the error to allow it to still run tests with Rake.