### PR TITLE
Fix missing indentation on targeted .method-detail elements

### DIFF
--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -582,6 +582,7 @@ main .method-detail {
 main .method-detail:target {
   margin-left: -10px;
   border-left: 10px solid var(--border-color);
+  padding-inline-start: 1em;
 }
 
 main .method-header {


### PR DESCRIPTION
This patch improves the spacing of highlighted method details in generated RDoc pages.

When a method anchor (for example, #method-i-force) is targeted, a left border is applied to the `.method-detail` element. Previously the border caused the inner content of the selected element to touch the left border, reducing readability.

This change adds a small left padding to the targeted element to maintain consistent spacing between the border and its contents.

<img width="778" height="146" alt="Screenshot 2025-10-19 at 16 05 07" src="https://github.com/user-attachments/assets/dd8813ca-9569-4d8f-b9cc-a140f8d48d8e" />
<img width="785" height="159" alt="Screenshot 2025-10-19 at 16 04 43" src="https://github.com/user-attachments/assets/f95cc2a5-5925-4a74-a198-4599cd4553d3" />


