### PR TITLE
searcher.js: handle missing RegExp.escape

### DIFF
--- a/lib/rdoc/generator/template/json_index/js/searcher.js
+++ b/lib/rdoc/generator/template/json_index/js/searcher.js
@@ -57,10 +57,14 @@ Searcher.prototype = new function() {
   }
 
   function buildRegexps(queries) {
+    // A small minority of older browsers don't have RegExp.escape
+    // but it's not worth including a complex polyfill.
+    var escape = RegExp.escape || function(s) { return s };
+
     return queries.map(function(query) {
       var pattern = [];
       for (var i = 0; i < query.length; i++) {
-        var char = RegExp.escape(query[i]);
+        var char = escape(query[i]);
         pattern.push('([' + char + '])([^' + char + ']*?)');
       }
       return new RegExp(pattern.join(''), 'i');

--- a/test/rdoc/rdoc_generator_json_index_searcher_test.rb
+++ b/test/rdoc/rdoc_generator_json_index_searcher_test.rb
@@ -16,13 +16,6 @@ class RDocGeneratorJsonIndexSearcherTest < Test::Unit::TestCase
   def setup
     @context = MiniRacer::Context.new
 
-    # Add RegExp.escape polyfill to avoid `RegExp.escape is not a function` error
-    @context.eval(<<~JS)
-      RegExp.escape = function(string) {
-        return string.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
-      };
-    JS
-
     searcher_js_path = File.expand_path(
       '../../lib/rdoc/generator/template/json_index/js/searcher.js',
       __dir__


### PR DESCRIPTION
That API is more recent than I expected, so there is still a small minority of browsers that may be missing it.

But this escaping is only needed when the search context special chars, which too is a minority of searches.

Given that, I think it's better to just not escape if support is missing.

cc @st0012 