### PR TITLE
Add tooltip to attribute type

### DIFF
--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -94,10 +94,8 @@
       <%- attributes.each do |attrib| %>
       <div id="<%= attrib.aref %>" class="method-detail anchor-link">
         <div class="method-heading attribute-method-heading">
-          <a href="#<%= attrib.aref %>" title="Link to this attribute">
-            <span class="method-name"><%= h attrib.name %></span>
-            <span class="attribute-access-type">[<%= attrib.rw %>]</span>
-          </a>
+          <a href="#<%= attrib.aref %>" title="Link to this attribute"><span class="method-name"><%= h attrib.name %></span></a>
+          <span class="attribute-access-type" title="<%= attrib.definition %>">[<%= attrib.rw %>]</span>
         </div>
 
         <div class="method-description">


### PR DESCRIPTION
1. Move the `[R]` part outside the underlined and linked `<a>` tag
2. Add a `title` field to explain what `[R]`, `[W]` or `[RW]` mean.

     It's fairly self-explanatory if you see `[RW]`, but on many APIs' docs, you'll only have a bunch of `[R]`s, so you'll be missing that context clue.

    On hover, it shows one of:
    * `attr_reader`
    * `attr_writer`
    * `attr_accessor`

| Before | After |
|--------|-------|
| <img width="190" height="71" alt="Before" src="https://github.com/user-attachments/assets/aa4b62bf-e32f-4820-96c0-50e48bc4443f" /> | <img width="190" height="71" alt="After" src="https://github.com/user-attachments/assets/e273167a-f8bf-42ff-b99b-397e1a58ed03" /> |
