### PR TITLE
[Aliki] Set default overflow wrap behavior to avoid overflow on mobile

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -231,6 +231,7 @@ body {
   color: var(--text-color);
   line-height: var(--line-height-relaxed);
   margin: 0;
+  overflow-wrap: break-word; /* Avoid overflow on mobile */
 
   /* Grid layout with header, sidebar, main, and footer */
   display: grid;
@@ -1292,7 +1293,6 @@ aside.table-of-contents * {
   transition: color var(--transition-fast);
   line-height: var(--line-height-relaxed);
   word-wrap: break-word;
-  overflow-wrap: break-word;
   hyphens: auto;
 }
 


### PR DESCRIPTION
Currently, if the page's text content is long, it'd overflow on mobile and create a bad experience:

<img width="30%" alt="Screenshot 2025-11-16 at 23 53 58" src="https://github.com/user-attachments/assets/c9a101aa-be97-4aa2-95b0-e420b18e68b9" />

This PR fixes the issue by specifying the default overflow wrapping behavior. So long text will break into multiple lines instead of overflowing the page.

<img width="30%" alt="Screenshot 2025-11-16 at 23 56 53" src="https://github.com/user-attachments/assets/d241a91b-f2a4-4fc6-94d8-9ea38b2b387a" />
