### PR TITLE
[Aliki] Set scroll-margin-top to all heading inside <main/>

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -308,7 +308,6 @@ h6:target {
   margin-left: calc(-1 * var(--space-5));
   padding-left: calc(var(--space-5) / 2);
   border-left: calc(var(--space-5) / 2) solid var(--border-color);
-  scroll-margin-top: calc(var(--layout-header-height) + 2rem);
 }
 
 main .anchor-link:target {
@@ -944,6 +943,7 @@ main h5,
 main h6 {
   font-family: var(--font-heading);
   color: var(--highlight-color);
+  scroll-margin-top: calc(var(--layout-header-height) + 2rem);
 }
 
 /* Heading size hierarchy */


### PR DESCRIPTION
Before (header's opacity is set to 0.9 to describe)
<img width="1065" height="675" alt="before" src="https://github.com/user-attachments/assets/dd7ae9af-f624-4a28-bab5-f6743b5650dd" />
After
<img width="1065" height="675" alt="after" src="https://github.com/user-attachments/assets/5e27c63e-1bfa-4bb5-ac93-bb1d0facbabb" />
