### PR TITLE
[Aliki] Remove nav detail's nested padding-right

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -864,11 +864,6 @@ nav a:hover {
   }
 }
 
-nav ul li details {
-  position: relative;
-  padding-right: 1.5em;  /* Add space for the marker on the right */
-}
-
 nav ul li details > summary {
   list-style: none;  /* Remove the default marker */
   position: relative; /* So that the open/close triangle can position itself absolutely inside */


### PR DESCRIPTION
Before:
padding-right is nested.
Nested `<details>` have narrow width.
<img width="247" height="591" alt="before_1" src="https://github.com/user-attachments/assets/f705a976-948c-4c37-9432-ace158bb6184" />
<img width="240" height="591" alt="before_2" src="https://github.com/user-attachments/assets/14e2fb63-5b99-4cbf-b655-f519fa388b09" />
<img width="264" height="591" alt="before_3" src="https://github.com/user-attachments/assets/321505d5-3b49-492f-8d60-d8afba484c0c" />

After:
<img width="245" height="592" alt="after" src="https://github.com/user-attachments/assets/a826f2ad-52df-4b85-9e4e-ac3c1253ff1e" />
