### PR TITLE
[Aliki] Stable calculation of active toc

### DIFF
--- a/lib/rdoc/generator/template/aliki/js/aliki.js
+++ b/lib/rdoc/generator/template/aliki/js/aliki.js
@@ -242,7 +242,6 @@ function hookTocActiveHighlighting() {
 
     // Add active class to current link
     correspondingLink.classList.add('active');
-    activeLink = correspondingLink;
 
     // Scroll link into view if needed
     var tocNav = document.querySelector('#toc-nav');


### PR DESCRIPTION
Fix this unstable active table-of-contents link calculation shown in this video:
Clicking "Plugin types", active toc link will be "Option Parsing" or "File Parsing", depend on previous scroll position.
https://github.com/user-attachments/assets/bfd5c92a-9f11-4c9b-9267-86ae55607541


IntersectionObserver only notifies changed intersections.
We need to track which heading tag currently intersects with viewport. (I use Set in this pull request)
Use the top-most intersecting heading to make user-clicked toc links match with active toc links.
