### PR TITLE
[Aliki] Add classes and modules list to class page's sidebar

### DIFF
--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -9,6 +9,7 @@
   <%= render '_sidebar_includes.rhtml' %>
   <%= render '_sidebar_extends.rhtml' %>
   <%= render '_sidebar_methods.rhtml' %>
+  <%= render '_sidebar_classes.rhtml' %>
 </nav>
 
 <main role="main" aria-labelledby="<%= h klass.aref %>">


### PR DESCRIPTION
It'd be much more convenient if users can jump between classes/modules directly from the current class/module page, without needing to go back to the index page.

Placing it at the bottom so users can access class/module specific info first.