### PR TITLE
Fix rb_define_method(singleton_class_of_module, ...) not to change nested module name

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -1052,10 +1052,13 @@ class RDoc::Parser::C < RDoc::Parser
   # Registers a singleton class +sclass_var+ as a singleton of +class_var+
 
   def handle_singleton(sclass_var, class_var)
-    class_name = @known_classes[class_var]
-
-    @known_classes[sclass_var]     = class_name
-    @singleton_classes[sclass_var] = class_name
+    if (klass = @classes[class_var])
+      @classes[sclass_var] = klass
+    end
+    if (class_name = @known_classes[class_var])
+      @known_classes[sclass_var]     = class_name
+      @singleton_classes[sclass_var] = class_name
+    end
   end
 
   ##


### PR DESCRIPTION
Fixes #1440
Always track class and singleton class stored to a variable to `@classes`.
Otherwise, `find_class var_name, class_name` called from `handle_method` will add a new class.

Before:
<img width="303" height="167" alt="before" src="https://github.com/user-attachments/assets/fb885b6c-40bf-44c5-8f01-095cfdc75c16" />
After:
<img width="303" height="167" alt="after" src="https://github.com/user-attachments/assets/e0aae152-f46e-4954-8b68-23b74dd3bc90" />


Minimal reproduction:
```c
VALUE mFoo = rb_define_module("Foo");
VALUE mBar = rb_define_module_under(mFoo, "Bar");
VALUE mBarS = rb_singleton_class(mBar);
rb_define_method(mBarS, "baz", baz, 0);
```

`RDoc::Parser::C#handle_method` calls `find_class 'mBarS', 'Foo::Bar'`.
`RDoc::Parser::C#find_class` calls `@top_level.add_class RDoc::NormalClass, 'Foo::Bar'`. This will create `::Bar` for some reason and `Foo::Bar` disappears from generated document.
