### PR TITLE
[Aliki] Adjust table of content scrollable area height

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1226,6 +1226,18 @@ aside.table-of-contents * {
   outline: none !important;
 }
 
+aside.table-of-contents .toc-sticky {
+  display: flex;
+  flex-direction: column;
+
+  /* Exclude header height and top/bottom padding of aside.table-of-contents */
+  height: calc(100vh - var(--layout-header-height) - var(--space-8) * 2);
+}
+
+aside.table-of-contents .toc-sticky nav {
+  height: auto;
+}
+
 /* Hide TOC on mobile/tablet */
 @media (max-width: 1279px) {
   aside.table-of-contents {


### PR DESCRIPTION
`aside.table-of-contents .toc-sticky nav` had `height: calc(100vh - var(--layout-header-height))`
but height should exclude padding and height of `<h3>On This Page</h3>` element.
This calculation is hard, so I use display:flex instead.

Left: before, Right: after
<img width="532" height="396" alt="before_after" src="https://github.com/user-attachments/assets/b8203fda-c2ca-4f74-a6be-669573907aeb" />

Scenario: scroll to page bottom
Left: before, Right: after
<img width="1100" height="660" alt="beforeafter_scrollbottom" src="https://github.com/user-attachments/assets/1de803da-d50c-4fef-bc2b-8ffd7b6e32b0" />
