### PR TITLE
[Aliki] Add C syntax highlighting with a custom JS highlighter

### DIFF
--- a/lib/rdoc/generator/template/aliki/_head.rhtml
+++ b/lib/rdoc/generator/template/aliki/_head.rhtml
@@ -82,6 +82,7 @@
 <script src="<%= h asset_rel_prefix %>/js/search.js" defer></script>
 <script src="<%= h asset_rel_prefix %>/js/search_index.js" defer></script>
 <script src="<%= h asset_rel_prefix %>/js/searcher.js" defer></script>
+<script src="<%= h asset_rel_prefix %>/js/c_highlighter.js" defer></script>
 <script src="<%= h asset_rel_prefix %>/js/aliki.js" defer></script>
 
 <link href="<%= h asset_rel_prefix %>/css/rdoc.css" rel="stylesheet">

--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -161,7 +161,7 @@
         <div class="method-description">
           <%- if method.token_stream then %>
           <div class="method-source-code" id="<%= method.html_name %>-source">
-            <pre><%= method.markup_code %></pre>
+            <pre class="<%= method.source_language %>" data-language="<%= method.source_language %>"><%= method.markup_code %></pre>
           </div>
           <%- end %>
           <%- if method.mixin_from then %>

--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -46,6 +46,18 @@
   --code-purple: #7e22ce;
   --code-red: #dc2626;
 
+  /* C syntax highlighting */
+  --c-keyword: #b91c1c;
+  --c-type: #0891b2;
+  --c-macro: #ea580c;
+  --c-function: #7c3aed;
+  --c-identifier: #475569;
+  --c-operator: #059669;
+  --c-preprocessor: #a21caf;
+  --c-value: #92400e;
+  --c-string: #15803d;
+  --c-comment: #78716c;
+
   /* Color Palette - Green (for success states) */
   --color-green-400: #4ade80;
   --color-green-500: #22c55e;
@@ -162,6 +174,18 @@
   --code-orange: #fbbf24;
   --code-purple: #c084fc;
   --code-red: #f87171;
+
+  /* C syntax highlighting */
+  --c-keyword: #f87171;
+  --c-type: #22d3ee;
+  --c-macro: #fb923c;
+  --c-function: #a78bfa;
+  --c-identifier: #94a3b8;
+  --c-operator: #6ee7b7;
+  --c-preprocessor: #e879f9;
+  --c-value: #fcd34d;
+  --c-string: #4ade80;
+  --c-comment: #a8a29e;
 
   /* Semantic Colors - Dark Theme */
   --color-text-primary: var(--color-neutral-50);
@@ -819,6 +843,22 @@ main h6 a:hover {
 [data-theme="dark"] .ruby-regexp     { color: var(--code-purple); }
 [data-theme="dark"] .ruby-value      { color: var(--code-orange); }
 [data-theme="dark"] .ruby-string     { color: var(--code-green); }
+
+/* C Syntax Highlighting */
+.c-keyword { color: var(--c-keyword); }
+.c-type { color: var(--c-type); }
+.c-macro { color: var(--c-macro); }
+.c-function { color: var(--c-function); }
+.c-identifier { color: var(--c-identifier); }
+.c-operator { color: var(--c-operator); }
+.c-preprocessor { color: var(--c-preprocessor); }
+.c-value { color: var(--c-value); }
+.c-string { color: var(--c-string); }
+
+.c-comment {
+  color: var(--c-comment);
+  font-style: italic;
+}
 
 /* Emphasis */
 em {

--- a/lib/rdoc/generator/template/aliki/js/c_highlighter.js
+++ b/lib/rdoc/generator/template/aliki/js/c_highlighter.js
@@ -1,0 +1,299 @@
+/**
+ * Client-side C syntax highlighter for RDoc
+ */
+
+(function() {
+  'use strict';
+
+  // C control flow and storage class keywords
+  const C_KEYWORDS = new Set([
+    'auto', 'break', 'case', 'continue', 'default', 'do', 'else', 'extern',
+    'for', 'goto', 'if', 'inline', 'register', 'return', 'sizeof', 'static',
+    'switch', 'while',
+    '_Alignas', '_Alignof', '_Generic', '_Noreturn', '_Static_assert', '_Thread_local'
+  ]);
+
+  // C type keywords and type qualifiers
+  const C_TYPE_KEYWORDS = new Set([
+    'bool', 'char', 'const', 'double', 'enum', 'float', 'int', 'long',
+    'restrict', 'short', 'signed', 'struct', 'typedef', 'union', 'unsigned',
+    'void', 'volatile', '_Atomic', '_Bool', '_Complex', '_Imaginary'
+  ]);
+
+  // Library-defined types (typedef'd in headers, not language keywords)
+  // Includes: Ruby C API types (VALUE, ID), POSIX types (size_t, ssize_t),
+  // fixed-width integer types (uint32_t, int64_t), and standard I/O types (FILE)
+  const C_TYPES = new Set([
+    'VALUE', 'ID', 'size_t', 'ssize_t', 'ptrdiff_t', 'uintptr_t', 'intptr_t',
+    'uint8_t', 'uint16_t', 'uint32_t', 'uint64_t',
+    'int8_t', 'int16_t', 'int32_t', 'int64_t',
+    'FILE', 'DIR', 'va_list'
+  ]);
+
+  // Common Ruby VALUE macros and boolean literals
+  const RUBY_MACROS = new Set([
+    'Qtrue', 'Qfalse', 'Qnil', 'Qundef', 'NULL', 'TRUE', 'FALSE', 'true', 'false'
+  ]);
+
+  const OPERATORS = new Set([
+    '==', '!=', '<=', '>=', '&&', '||', '<<', '>>', '++', '--',
+    '+=', '-=', '*=', '/=', '%=', '&=', '|=', '^=', '->',
+    '+', '-', '*', '/', '%', '<', '>', '=', '!', '&', '|', '^', '~'
+  ]);
+
+  // Single character that can start an operator
+  const OPERATOR_CHARS = new Set('+-*/%<>=!&|^~');
+
+  function isMacro(word) {
+    return RUBY_MACROS.has(word) || /^[A-Z][A-Z0-9_]*$/.test(word);
+  }
+
+  function isType(word) {
+    return C_TYPE_KEYWORDS.has(word) || C_TYPES.has(word) || /_t$/.test(word);
+  }
+
+  /**
+   * Escape HTML special characters
+   */
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  /**
+   * Check if position is at line start (only whitespace before it)
+   */
+  function isLineStart(code, pos) {
+    if (pos === 0) return true;
+    for (let i = pos - 1; i >= 0; i--) {
+      const ch = code[i];
+      if (ch === '\n') return true;
+      if (ch !== ' ' && ch !== '\t') return false;
+    }
+    return true;
+  }
+
+  /**
+   * Highlight C source code
+   */
+  function highlightC(code) {
+    const tokens = [];
+    let i = 0;
+    const len = code.length;
+
+    while (i < len) {
+      const char = code[i];
+
+      // Multi-line comment
+      if (char === '/' && code[i + 1] === '*') {
+        let end = code.indexOf('*/', i + 2);
+        end = (end === -1) ? len : end + 2;
+        const comment = code.substring(i, end);
+        tokens.push('<span class="c-comment">', escapeHtml(comment), '</span>');
+        i = end;
+        continue;
+      }
+
+      // Single-line comment
+      if (char === '/' && code[i + 1] === '/') {
+        const end = code.indexOf('\n', i);
+        const commentEnd = (end === -1) ? len : end;
+        const comment = code.substring(i, commentEnd);
+        tokens.push('<span class="c-comment">', escapeHtml(comment), '</span>');
+        i = commentEnd;
+        continue;
+      }
+
+      // Preprocessor directive (must be at line start)
+      if (char === '#' && isLineStart(code, i)) {
+        let end = i + 1;
+        while (end < len && code[end] !== '\n') {
+          if (code[end] === '\\' && end + 1 < len && code[end + 1] === '\n') {
+            end += 2; // Handle line continuation
+          } else {
+            end++;
+          }
+        }
+        const preprocessor = code.substring(i, end);
+        tokens.push('<span class="c-preprocessor">', escapeHtml(preprocessor), '</span>');
+        i = end;
+        continue;
+      }
+
+      // String literal
+      if (char === '"') {
+        let end = i + 1;
+        while (end < len && code[end] !== '"') {
+          if (code[end] === '\\' && end + 1 < len) {
+            end += 2; // Skip escaped character
+          } else {
+            end++;
+          }
+        }
+        if (end < len) end++; // Include closing quote
+        const string = code.substring(i, end);
+        tokens.push('<span class="c-string">', escapeHtml(string), '</span>');
+        i = end;
+        continue;
+      }
+
+      // Character literal
+      if (char === "'") {
+        let end = i + 1;
+        // Handle escape sequences like '\n', '\\', '\''
+        if (end < len && code[end] === '\\' && end + 1 < len) {
+          end += 2; // Skip backslash and escaped char
+        } else if (end < len) {
+          end++; // Single character
+        }
+        if (end < len && code[end] === "'") end++; // Closing quote
+        const charLit = code.substring(i, end);
+        tokens.push('<span class="c-value">', escapeHtml(charLit), '</span>');
+        i = end;
+        continue;
+      }
+
+      // Number (integer or float)
+      if (char >= '0' && char <= '9') {
+        let end = i;
+
+        // Hexadecimal
+        if (char === '0' && (code[i + 1] === 'x' || code[i + 1] === 'X')) {
+          end = i + 2;
+          while (end < len) {
+            const ch = code[end];
+            if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')) {
+              end++;
+            } else {
+              break;
+            }
+          }
+        }
+        // Octal
+        else if (char === '0' && code[i + 1] >= '0' && code[i + 1] <= '7') {
+          end = i + 1;
+          while (end < len && code[end] >= '0' && code[end] <= '7') end++;
+        }
+        // Decimal/Float
+        else {
+          while (end < len) {
+            const ch = code[end];
+            if ((ch >= '0' && ch <= '9') || ch === '.') {
+              end++;
+            } else {
+              break;
+            }
+          }
+          // Scientific notation
+          if (end < len && (code[end] === 'e' || code[end] === 'E')) {
+            end++;
+            if (end < len && (code[end] === '+' || code[end] === '-')) end++;
+            while (end < len && code[end] >= '0' && code[end] <= '9') end++;
+          }
+        }
+
+        // Suffix (u, l, f, etc.)
+        while (end < len) {
+          const ch = code[end];
+          if (ch === 'u' || ch === 'U' || ch === 'l' || ch === 'L' || ch === 'f' || ch === 'F') {
+            end++;
+          } else {
+            break;
+          }
+        }
+
+        const number = code.substring(i, end);
+        tokens.push('<span class="c-value">', escapeHtml(number), '</span>');
+        i = end;
+        continue;
+      }
+
+      // Identifier or keyword
+      if ((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || char === '_') {
+        let end = i + 1;
+        while (end < len) {
+          const ch = code[end];
+          if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+              (ch >= '0' && ch <= '9') || ch === '_') {
+            end++;
+          } else {
+            break;
+          }
+        }
+        const word = code.substring(i, end);
+
+        if (C_KEYWORDS.has(word)) {
+          tokens.push('<span class="c-keyword">', escapeHtml(word), '</span>');
+        } else if (isType(word)) {
+          // Check types before macros (VALUE, ID are types, not macros)
+          tokens.push('<span class="c-type">', escapeHtml(word), '</span>');
+        } else if (isMacro(word)) {
+          tokens.push('<span class="c-macro">', escapeHtml(word), '</span>');
+        } else {
+          // Check if followed by '(' -> function name
+          let nextCharIdx = end;
+          while (nextCharIdx < len && (code[nextCharIdx] === ' ' || code[nextCharIdx] === '\t')) {
+            nextCharIdx++;
+          }
+          if (nextCharIdx < len && code[nextCharIdx] === '(') {
+            tokens.push('<span class="c-function">', escapeHtml(word), '</span>');
+          } else {
+            tokens.push('<span class="c-identifier">', escapeHtml(word), '</span>');
+          }
+        }
+        i = end;
+        continue;
+      }
+
+      // Operators
+      if (OPERATOR_CHARS.has(char)) {
+        let op = char;
+        // Check for two-character operators
+        if (i + 1 < len) {
+          const twoChar = char + code[i + 1];
+          if (OPERATORS.has(twoChar)) {
+            op = twoChar;
+          }
+        }
+        tokens.push('<span class="c-operator">', escapeHtml(op), '</span>');
+        i += op.length;
+        continue;
+      }
+
+      // Everything else (punctuation, whitespace)
+      tokens.push(escapeHtml(char));
+      i++;
+    }
+
+    return tokens.join('');
+  }
+
+  /**
+   * Initialize C syntax highlighting on page load
+   */
+  function initHighlighting() {
+    const codeBlocks = document.querySelectorAll('pre[data-language="c"]');
+
+    codeBlocks.forEach(block => {
+      if (block.getAttribute('data-highlighted') === 'true') {
+        return;
+      }
+
+      const code = block.textContent;
+      const highlighted = highlightC(code);
+
+      block.innerHTML = highlighted;
+      block.setAttribute('data-highlighted', 'true');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHighlighting);
+  } else {
+    initHighlighting();
+  }
+})();

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -622,7 +622,7 @@ class RDoc::Parser::C < RDoc::Parser
       find_modifiers comment, meth_obj if comment
 
       #meth_obj.params = params
-      meth_obj.start_collecting_tokens
+      meth_obj.start_collecting_tokens(:c)
       tk = { :line_no => 1, :char_no => 1, :text => body }
       meth_obj.add_token tk
       meth_obj.comment = comment
@@ -638,7 +638,7 @@ class RDoc::Parser::C < RDoc::Parser
 
       find_modifiers comment, meth_obj
 
-      meth_obj.start_collecting_tokens
+      meth_obj.start_collecting_tokens(:c)
       tk = { :line_no => 1, :char_no => 1, :text => body }
       meth_obj.add_token tk
       meth_obj.comment = comment

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -203,7 +203,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
     meth.call_seq = signature
     return unless meth.name
 
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     node = @line_nodes[line_no]
     tokens = node ? visible_tokens_from_location(node.location) : [file_line_comment_token(start_line)]
     tokens.each { |token| meth.token_stream << token }
@@ -554,7 +554,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
     meth.calls_super = calls_super
     meth.block_params ||= block_params if block_params
     record_location(meth)
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     tokens.each do |token|
       meth.token_stream << token
     end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1137,7 +1137,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     meth = RDoc::GhostMethod.new get_tkread, name
     record_location meth
 
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     indent = RDoc::Parser::RipperStateLex::Token.new(1, 1, :on_sp, ' ' * column)
     position_comment = RDoc::Parser::RipperStateLex::Token.new(line_no, 1, :on_comment)
     position_comment[:text] = "# File #{@top_level.relative_name}, line #{line_no}"
@@ -1180,7 +1180,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     record_location meth
     meth.line      = line_no
 
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     indent = RDoc::Parser::RipperStateLex::Token.new(1, 1, :on_sp, ' ' * column)
     position_comment = RDoc::Parser::RipperStateLex::Token.new(line_no, 1, :on_comment)
     position_comment[:text] = "# File #{@top_level.relative_name}, line #{line_no}"
@@ -1344,7 +1344,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     column  = tk[:char_no]
     line_no = tk[:line_no]
 
-    start_collecting_tokens
+    start_collecting_tokens(:ruby)
     add_token tk
     add_token_listener self
 
@@ -1363,7 +1363,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     remove_token_listener self
 
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     indent = RDoc::Parser::RipperStateLex::Token.new(1, 1, :on_sp, ' ' * column)
     position_comment = RDoc::Parser::RipperStateLex::Token.new(line_no, 1, :on_comment)
     position_comment[:text] = "# File #{@top_level.relative_name}, line #{line_no}"
@@ -1448,7 +1448,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     column  = tk[:char_no]
     line_no = tk[:line_no]
 
-    start_collecting_tokens
+    start_collecting_tokens(:ruby)
     add_token tk
 
     token_listener self do
@@ -1471,7 +1471,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     record_location meth
     meth.line   = line_no
 
-    meth.start_collecting_tokens
+    meth.start_collecting_tokens(:ruby)
     indent = RDoc::Parser::RipperStateLex::Token.new(1, 1, :on_sp, ' ' * column)
     token = RDoc::Parser::RipperStateLex::Token.new(line_no, 1, :on_comment)
     token[:text] = "# File #{@top_level.relative_name}, line #{line_no}"

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ##
 # A TokenStream is a list of tokens, gathered during the parse of some entity
 # (say a method). Entities populate these streams by being registered with the
@@ -87,9 +88,11 @@ module RDoc::TokenStream
 
   ##
   # Starts collecting tokens
+  #
 
-  def collect_tokens
+  def collect_tokens(language)
     @token_stream = []
+    @token_stream_language = language
   end
 
   alias start_collecting_tokens collect_tokens
@@ -113,6 +116,15 @@ module RDoc::TokenStream
 
   def tokens_to_s
     (token_stream or return '').compact.map { |token| token[:text] }.join ''
+  end
+
+  ##
+  # Returns the source language of the token stream as a string
+  #
+  # Returns 'c' or 'ruby'
+
+  def source_language
+    @token_stream_language == :c ? 'c' : 'ruby'
   end
 
 end

--- a/test/rdoc/code_object/any_method_test.rb
+++ b/test/rdoc/code_object/any_method_test.rb
@@ -153,7 +153,7 @@ each_line(foo)
       { :line_no => 0, :char_no => 0, :kind => :on_const, :text => 'CONSTANT' },
     ]
 
-    @c2_a.collect_tokens
+    @c2_a.collect_tokens(:ruby)
     @c2_a.add_tokens(tokens)
 
     expected = '<span class="ruby-constant">CONSTANT</span>'
@@ -171,7 +171,7 @@ each_line(foo)
       { :line_no => 3, :char_no => 0, :kind => :on_const, :text => 'B' }
     ]
 
-    @c2_a.collect_tokens
+    @c2_a.collect_tokens(:ruby)
     @c2_a.add_tokens(tokens)
 
     assert_equal <<-EXPECTED.chomp, @c2_a.markup_code

--- a/test/rdoc/generator/aliki/highlight_c_test.rb
+++ b/test/rdoc/generator/aliki/highlight_c_test.rb
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+require_relative '../../helper'
+
+return if RUBY_DESCRIPTION =~ /truffleruby/ || RUBY_DESCRIPTION =~ /jruby/
+
+begin
+  require 'mini_racer'
+rescue LoadError
+  return
+end
+
+class RDocGeneratorAlikiHighlightCTest < Test::Unit::TestCase
+  HIGHLIGHT_C_JS_PATH = File.expand_path(
+    '../../../../lib/rdoc/generator/template/aliki/js/c_highlighter.js',
+    __dir__
+  )
+
+  HIGHLIGHT_C_JS = begin
+    highlight_c_js = File.read(HIGHLIGHT_C_JS_PATH)
+
+    # We need to modify the JS slightly to make it work in the context of a test.
+    highlight_c_js.gsub(
+      /\(function\(\) \{[\s\S]*'use strict';/,
+      "// Test wrapper\n"
+    ).gsub(
+      /if \(document\.readyState[\s\S]*\}\)\(\);/,
+      "// Removed DOM initialization for testing"
+    )
+  end.freeze
+
+  def setup
+    @context = MiniRacer::Context.new
+    @context.eval(HIGHLIGHT_C_JS)
+  end
+
+  def teardown
+    @context.dispose
+  end
+
+  def test_keywords
+    result = highlight('int main() { return 0; }')
+
+    assert_includes result, '<span class="c-type">int</span>'
+    assert_includes result, '<span class="c-keyword">return</span>'
+  end
+
+  def test_identifiers
+    result = highlight('int x = 5; char *name;')
+
+    assert_includes result, '<span class="c-identifier">x</span>'
+    assert_includes result, '<span class="c-identifier">name</span>'
+  end
+
+  def test_operators
+    result = highlight('a == b && c != d')
+
+    assert_includes result, '<span class="c-operator">==</span>'
+    assert_includes result, '<span class="c-operator">&amp;&amp;</span>'
+    assert_includes result, '<span class="c-operator">!=</span>'
+  end
+
+  def test_single_char_operators
+    result = highlight('a + b - c * d / e')
+
+    assert_includes result, '<span class="c-operator">+</span>'
+    assert_includes result, '<span class="c-operator">-</span>'
+    assert_includes result, '<span class="c-operator">*</span>'
+    assert_includes result, '<span class="c-operator">/</span>'
+  end
+
+  def test_preprocessor_directives
+    result = highlight("#include <stdio.h>\n#define MAX 100")
+
+    assert_includes result, '<span class="c-preprocessor">#include &lt;stdio.h&gt;</span>'
+    assert_includes result, '<span class="c-preprocessor">#define MAX 100</span>'
+  end
+
+  def test_preprocessor_with_line_continuation
+    result = highlight("#define LONG_MACRO \\\n    value")
+
+    # Preprocessor should capture everything including the line continuation
+    assert_includes result, '<span class="c-preprocessor">#define LONG_MACRO \\'
+    assert_includes result, '    value</span>'
+  end
+
+  def test_single_line_comment
+    result = highlight('// This is a comment')
+
+    assert_includes result, '<span class="c-comment">// This is a comment</span>'
+  end
+
+  def test_multi_line_comment
+    result = highlight('/* Multi\nline\ncomment */')
+
+    assert_includes result, '<span class="c-comment">/* Multi\nline\ncomment */</span>'
+  end
+
+  def test_string_literals
+    result = highlight('"hello world"')
+
+    assert_includes result, '<span class="c-string">&quot;hello world&quot;</span>'
+  end
+
+  def test_string_with_escapes
+    result = highlight('"hello \"world\""')
+
+    assert_includes result, '<span class="c-string">&quot;hello \&quot;world\&quot;&quot;</span>'
+  end
+
+  def test_character_literals
+    result = highlight("'a'")
+
+    assert_includes result, "<span class=\"c-value\">&#39;a&#39;</span>"
+  end
+
+  def test_character_literals_with_escapes
+    result = highlight("'\\n' '\\\\' '\\''")
+
+    assert_includes result, "<span class=\"c-value\">&#39;\\n&#39;</span>"
+    assert_includes result, "<span class=\"c-value\">&#39;\\\\&#39;</span>"
+    assert_includes result, "<span class=\"c-value\">&#39;\\&#39;&#39;</span>"
+  end
+
+  def test_decimal_numbers
+    result = highlight('42 3.14 2.5e10')
+
+    assert_includes result, '<span class="c-value">42</span>'
+    assert_includes result, '<span class="c-value">3.14</span>'
+    assert_includes result, '<span class="c-value">2.5e10</span>'
+  end
+
+  def test_hexadecimal_numbers
+    result = highlight('0xFF 0xDEADBEEF')
+
+    assert_includes result, '<span class="c-value">0xFF</span>'
+    assert_includes result, '<span class="c-value">0xDEADBEEF</span>'
+  end
+
+  def test_octal_numbers
+    result = highlight('0755')
+
+    assert_includes result, '<span class="c-value">0755</span>'
+  end
+
+  def test_number_suffixes
+    result = highlight('42u 3.14f 100L')
+
+    assert_includes result, '<span class="c-value">42u</span>'
+    assert_includes result, '<span class="c-value">3.14f</span>'
+    assert_includes result, '<span class="c-value">100L</span>'
+  end
+
+  def test_html_escaping
+    result = highlight('if (x < 5 && y > 10) {}')
+
+    assert_includes result, '&lt;'
+    assert_includes result, '&gt;'
+    assert_includes result, '&amp;&amp;'
+  end
+
+  def test_complex_c_code
+    code = <<~C
+      #include <stdio.h>
+
+      /* Main function */
+      int main() {
+          char *str = "Hello, World!";
+          int x = 0xFF;
+
+          // Print the string
+          if (x > 0) {
+              printf("%s\\n", str);
+          }
+          return 0;
+      }
+    C
+
+    result = highlight(code)
+
+    # Verify key components are highlighted
+    assert_includes result, '<span class="c-preprocessor">#include &lt;stdio.h&gt;</span>'
+    assert_includes result, '<span class="c-comment">/* Main function */</span>'
+    assert_includes result, '<span class="c-type">int</span>'
+    assert_includes result, '<span class="c-type">char</span>'
+    assert_includes result, '<span class="c-keyword">return</span>'
+    assert_includes result, '<span class="c-function">main</span>'
+    assert_includes result, '<span class="c-function">printf</span>'
+    assert_includes result, '<span class="c-string">&quot;Hello, World!&quot;</span>'
+    assert_includes result, '<span class="c-value">0xFF</span>'
+    assert_includes result, '<span class="c-value">0</span>'
+    assert_includes result, '<span class="c-comment">// Print the string</span>'
+  end
+
+  def test_empty_code
+    result = highlight('')
+
+    assert_equal '', result
+  end
+
+  def test_only_whitespace
+    result = highlight("   \n\t  \n  ")
+
+    assert_equal "   \n\t  \n  ", result
+  end
+
+  def test_c11_keywords
+    result = highlight('_Atomic _Bool _Complex _Thread_local')
+
+    assert_includes result, '<span class="c-type">_Atomic</span>'
+    assert_includes result, '<span class="c-type">_Bool</span>'
+    assert_includes result, '<span class="c-type">_Complex</span>'
+    assert_includes result, '<span class="c-keyword">_Thread_local</span>'
+  end
+
+  def test_preprocessor_only_at_line_start
+    # # in the middle of code should not be treated as preprocessor
+    result = highlight('int x = 5 # 3;')
+
+    refute_includes result, '<span class="c-preprocessor">'
+    # The # should be treated as regular text
+    assert_includes result, '#'
+  end
+
+  def test_typical_function_definition
+    code = <<~C
+      static VALUE
+      rb_ary_all_p(int argc, VALUE *argv, VALUE ary)
+      {
+          long i;
+
+          for (i = 0; i < RARRAY_LEN(ary); i++) {
+              if (!RTEST(RARRAY_AREF(ary, i))) {
+                  return Qfalse;
+              }
+          }
+          return Qtrue;
+      }
+    C
+
+    result = highlight(code)
+
+    # Verify it highlights correctly without errors
+    assert_includes result, '<span class="c-keyword">static</span>'
+    assert_includes result, '<span class="c-type">VALUE</span>'
+    assert_includes result, '<span class="c-function">rb_ary_all_p</span>'
+    assert_includes result, '<span class="c-type">int</span>'
+    assert_includes result, '<span class="c-type">long</span>'
+    assert_includes result, '<span class="c-keyword">for</span>'
+    assert_includes result, '<span class="c-keyword">return</span>'
+    assert_includes result, '<span class="c-macro">Qtrue</span>'
+    assert_includes result, '<span class="c-macro">Qfalse</span>'
+    assert_includes result, '<span class="c-macro">RARRAY_LEN</span>'
+    assert_includes result, '<span class="c-macro">RTEST</span>'
+    assert_includes result, '<span class="c-macro">RARRAY_AREF</span>'
+  end
+
+  def test_macros_all_caps
+    result = highlight('RARRAY_LEN(ary) ARY_EMBED_P(x) FL_UNSET_EMBED')
+
+    assert_includes result, '<span class="c-macro">RARRAY_LEN</span>'
+    assert_includes result, '<span class="c-macro">ARY_EMBED_P</span>'
+    assert_includes result, '<span class="c-macro">FL_UNSET_EMBED</span>'
+  end
+
+  def test_types_common_ruby_types
+    result = highlight('VALUE obj; ID name; size_t len;')
+
+    assert_includes result, '<span class="c-type">VALUE</span>'
+    assert_includes result, '<span class="c-type">ID</span>'
+    assert_includes result, '<span class="c-type">size_t</span>'
+  end
+
+  def test_types_with_t_suffix
+    result = highlight('uint32_t count; ssize_t result; ptrdiff_t diff;')
+
+    assert_includes result, '<span class="c-type">uint32_t</span>'
+    assert_includes result, '<span class="c-type">ssize_t</span>'
+    assert_includes result, '<span class="c-type">ptrdiff_t</span>'
+  end
+
+  def test_function_names
+    result = highlight('rb_ary_replace(copy, orig); ary_memcpy(dest, src);')
+
+    assert_includes result, '<span class="c-function">rb_ary_replace</span>'
+    assert_includes result, '<span class="c-function">ary_memcpy</span>'
+  end
+
+  def test_function_definition
+    result = highlight('VALUE rb_ary_new(void) {')
+
+    assert_includes result, '<span class="c-type">VALUE</span>'
+    assert_includes result, '<span class="c-function">rb_ary_new</span>'
+    assert_includes result, '<span class="c-type">void</span>'
+  end
+
+  def test_variable_names
+    result = highlight('int count = 5; char *ptr = NULL;')
+
+    assert_includes result, '<span class="c-identifier">count</span>'
+    assert_includes result, '<span class="c-identifier">ptr</span>'
+    assert_includes result, '<span class="c-macro">NULL</span>'
+  end
+
+  def test_mixed_identifiers_in_expression
+    result = highlight('if (ARY_EMBED_P(ary) && len > 0)')
+
+    assert_includes result, '<span class="c-macro">ARY_EMBED_P</span>'
+    assert_includes result, '<span class="c-identifier">ary</span>'
+    assert_includes result, '<span class="c-identifier">len</span>'
+  end
+
+  def test_macro_vs_function_distinction
+    # Macros are ALL_CAPS, functions are not
+    result = highlight('RARRAY_LEN(ary) vs ary_length(ary)')
+
+    assert_includes result, '<span class="c-macro">RARRAY_LEN</span>'
+    assert_includes result, '<span class="c-function">ary_length</span>'
+  end
+
+  private
+
+  def highlight(code)
+    @context.eval("highlightC(#{code.to_json})")
+  end
+end

--- a/test/rdoc/rdoc_token_stream_test.rb
+++ b/test/rdoc/rdoc_token_stream_test.rb
@@ -39,11 +39,29 @@ class RDocTokenStreamTest < RDoc::TestCase
     assert_equal '', RDoc::TokenStream.to_html([])
   end
 
+  def test_source_language_ruby
+    foo = Class.new do
+      include RDoc::TokenStream
+    end.new
+
+    foo.collect_tokens(:ruby)
+    assert_equal 'ruby', foo.source_language
+  end
+
+  def test_source_language_c
+    foo = Class.new do
+      include RDoc::TokenStream
+    end.new
+
+    foo.collect_tokens(:c)
+    assert_equal 'c', foo.source_language
+  end
+
   def test_add_tokens
     foo = Class.new do
       include RDoc::TokenStream
     end.new
-    foo.collect_tokens
+    foo.collect_tokens(:ruby)
     foo.add_tokens([:token])
     assert_equal [:token], foo.token_stream
   end
@@ -52,7 +70,7 @@ class RDocTokenStreamTest < RDoc::TestCase
     foo = Class.new do
       include RDoc::TokenStream
     end.new
-    foo.collect_tokens
+    foo.collect_tokens(:ruby)
     foo.add_token(:token)
     assert_equal [:token], foo.token_stream
   end
@@ -61,7 +79,7 @@ class RDocTokenStreamTest < RDoc::TestCase
     foo = Class.new do
       include RDoc::TokenStream
     end.new
-    foo.collect_tokens
+    foo.collect_tokens(:ruby)
     assert_equal [], foo.token_stream
   end
 
@@ -69,7 +87,7 @@ class RDocTokenStreamTest < RDoc::TestCase
     foo = Class.new do
       include RDoc::TokenStream
     end.new
-    foo.collect_tokens
+    foo.collect_tokens(:ruby)
     foo.add_token(:token)
     foo.pop_token
     assert_equal [], foo.token_stream


### PR DESCRIPTION
Does exactly the same as #1467 but using JS as this way it doesn't slowdown `ruby/ruby`'s doc generation.

<img width="60%" alt="Screenshot 2025-11-25 at 11 16 18" src="https://github.com/user-attachments/assets/7a2cc394-57d8-4d8e-8f5f-43d69109036e" />
