### PR TITLE
Aliki: Make hamburger toggle non-selectable

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     "csstools/value-no-unknown-custom-properties": true,
     "custom-property-no-missing-var-function": true,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "property-no-vendor-prefix": null
   }
 }

--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -664,6 +664,8 @@ nav footer a {
     cursor: pointer;
     transition: color var(--transition-fast);
     line-height: 1;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   #navigation-toggle:hover {


### PR DESCRIPTION
It's implemented via an utf8 character but should not be selected by double-clicking

Ref https://github.com/ruby/rdoc/issues/1479