### PR TITLE
Aliki: Add padding to TOC

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1316,6 +1316,14 @@ aside.table-of-contents .toc-sticky nav {
   height: auto;
 }
 
+aside.table-of-contents .toc-list > .toc-h2 {
+  margin-left: var(--space-4);
+}
+
+aside.table-of-contents .toc-list > .toc-h3 {
+  margin-left: var(--space-8);
+}
+
 /* Hide TOC on mobile/tablet */
 @media (width <= 1279px) {
   aside.table-of-contents {


### PR DESCRIPTION
I'm unsure if rdoc uses this somewhere but here is how it looks like on https://docs.ruby-lang.org/en/master/String.html

<img width="348" height="637" alt="image" src="https://github.com/user-attachments/assets/c60cd491-1dee-448e-b2eb-01cd85c5c6ed" />

In https://github.com/ruby/rdoc/issues/1479 I wrote about it not being formatted. Since the TOC is generated via javascript, that seems a bit difficult to fix.

But I'm unsure if that is even needed. What was bothering me was that there was no connection between the "What's Here" and its subsections. This fixes that in a pretty simple way.