### PR TITLE
Apply markup in table cell

### DIFF
--- a/lib/rdoc/markup/to_ansi.rb
+++ b/lib/rdoc/markup/to_ansi.rb
@@ -81,6 +81,10 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
     end
   end
 
+  def calculate_text_width(text)
+    text.gsub(/\e\[[\d;]*m/, '').size
+  end
+
   ##
   # Starts accepting with a reset screen
 

--- a/lib/rdoc/markup/to_bs.rb
+++ b/lib/rdoc/markup/to_bs.rb
@@ -65,6 +65,10 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
     end
   end
 
+  def calculate_text_width(text)
+    text.gsub(/_\x08/, '').gsub(/\x08./, '').size
+  end
+
   ##
   # Turns on or off regexp handling for +convert_string+
 

--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -250,13 +250,10 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
   # Adds +table+ to the output
 
   def accept_table(header, body, aligns)
-    body = body.map do |row|
-      row.map do |cell|
-        attributes cell
-      end
-    end
+    header = header.map { |h| attributes h }
+    body = body.map { |row| row.map { |t| attributes t } }
     widths = header.zip(*body).map do |cols|
-      cols.map(&:size).max
+      cols.map { |col| calculate_text_width(col) }.max
     end
     aligns = aligns.map do |a|
       case a
@@ -269,14 +266,20 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
       end
     end
     @res << header.zip(widths, aligns).map do |h, w, a|
-      h.__send__(a, w)
+      extra_width = h.size - calculate_text_width(h)
+      h.__send__(a, w + extra_width)
     end.join("|").rstrip << "\n"
     @res << widths.map {|w| "-" * w }.join("|") << "\n"
     body.each do |row|
       @res << row.zip(widths, aligns).map do |t, w, a|
-        t.__send__(a, w)
+        extra_width = t.size - calculate_text_width(t)
+        t.__send__(a, w + extra_width)
       end.join("|").rstrip << "\n"
     end
+  end
+
+  def calculate_text_width(text)
+    text.size
   end
 
   ##

--- a/test/rdoc/markup/to_ansi_test.rb
+++ b/test/rdoc/markup/to_ansi_test.rb
@@ -350,11 +350,11 @@ words words words words
 
   def accept_table_align
     expected = "\e[0m" + <<-EXPECTED
- AA |BB |CCCCC|  DDDDD
-----|---|-----|---------
-    |bbb|    c|
-aaaa|b  |     |   dd
- a  |   |   cc|\e[7mdd\e[m
+ AA |BB |CCCCC|DDDDD
+----|---|-----|-----
+    |bbb|    \e[1mc\e[m|
+aaaa|b  |     | dd
+ a  |   |   cc| \e[7mdd\e[m
     EXPECTED
     assert_equal expected, @to.end_accepting
   end

--- a/test/rdoc/markup/to_bs_test.rb
+++ b/test/rdoc/markup/to_bs_test.rb
@@ -353,7 +353,7 @@ words words words words
     expected = <<-EXPECTED
  AA |BB |CCCCC|DDDDD
 ----|---|-----|-----
-    |bbb|    c|
+    |bbb|    c\bc|
 aaaa|b  |     | dd
  a  |   |   cc| dd
     EXPECTED

--- a/test/rdoc/markup/to_markdown_test.rb
+++ b/test/rdoc/markup/to_markdown_test.rb
@@ -350,7 +350,7 @@ words words words words
     expected = <<-EXPECTED
  AA |BB |CCCCC|DDDDD
 ----|---|-----|-----
-    |bbb|    c|
+    |bbb|**c**|
 aaaa|b  |     | dd
  a  |   |   cc|`dd`
     EXPECTED

--- a/test/rdoc/markup/to_rdoc_test.rb
+++ b/test/rdoc/markup/to_rdoc_test.rb
@@ -348,11 +348,11 @@ words words words words
 
   def accept_table_align
     expected = <<-EXPECTED
- AA |BB |CCCCC|   DDDDD
-----|---|-----|-----------
-    |bbb|    c|
-aaaa|b  |     |    dd
- a  |   |   cc|<tt>dd</tt>
+ AA |BB |   CCCCC|   DDDDD
+----|---|--------|-----------
+    |bbb|<b>c</b>|
+aaaa|b  |        |    dd
+ a  |   |      cc|<tt>dd</tt>
     EXPECTED
     assert_equal expected, @to.end_accepting
   end

--- a/test/rdoc/support/text_formatter_test_case.rb
+++ b/test/rdoc/support/text_formatter_test_case.rb
@@ -105,7 +105,7 @@ class RDoc::Markup::TextFormatterTestCase < RDoc::Markup::FormatterTestCase
       def test_accept_table_align
         header = ['AA', 'BB', 'CCCCC', 'DDDDD']
         body = [
-          ['', 'bbb', 'c', ''],
+          ['', 'bbb', '<b>c</b>', ''],
           ['aaaa', 'b', '', 'dd'],
           ['a', '', 'cc', '<code>dd</code>']
         ]


### PR DESCRIPTION
In the documentation for methods like `test`, backtick are used within table cells.
While each parser handles backquotes within table cells, the generator does not.
As a result, the tags are displayed literally without being processed.

To resolve this, I propose that tag expressions should be properly handled within table cells as well.

### Before
ri --format=bs test

```
 Character  |Test
------------|---------------------------------------------------------------
<tt>'<'</tt>|Whether the `mtime` at `path0` is less than that at `path1`.
<tt>'='</tt>|Whether the `mtime` at `path0` is equal to that at `path1`.
<tt>'>'</tt>|Whether the `mtime` at `path0` is greater than that at `path1`.
```

ri --format=markdown test

```
 Character  |Test
------------|---------------------------------------------------------------
<tt>'<'</tt>|Whether the `mtime` at `path0` is less than that at `path1`.
<tt>'='</tt>|Whether the `mtime` at `path0` is equal to that at `path1`.
<tt>'>'</tt>|Whether the `mtime` at `path0` is greater than that at `path1`.
```

ri --format=ansi

<img width="550" height="92" alt="image" src="https://github.com/user-attachments/assets/1f7f4ac4-7c15-4352-b272-9e8789a3320a" />

### After

ri --format=bs test

```
Character|Test
---------|---------------------------------------------------------------
   '<'   |Whether the `mtime` at `path0` is less than that at `path1`.
   '='   |Whether the `mtime` at `path0` is equal to that at `path1`.
   '>'   |Whether the `mtime` at `path0` is greater than that at `path1`.
```

ri --format=markdown test

```
Character|Test
---------|---------------------------------------------------------------
  `'<'`  |Whether the `mtime` at `path0` is less than that at `path1`.
  `'='`  |Whether the `mtime` at `path0` is equal to that at `path1`.
  `'>'`  |Whether the `mtime` at `path0` is greater than that at `path1`.
```

ri --format=ansi

<img width="522" height="90" alt="image" src="https://github.com/user-attachments/assets/bd1dc32d-fe67-4f95-b819-30454f78af65" />

