### PR TITLE
Add `hide` option to hide generated pages from the sidebar listing

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -11,6 +11,11 @@ exclude:
 - CLAUDE.md
 - lib/rdoc/markdown.kpeg
 
+hide:
+- CVE-2013-0256.rdoc
+- LEGAL.rdoc
+- LICENSE.rdoc
+
 footer_content:
   DOCUMENTATION:
     Home: index.html

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -39,6 +39,11 @@ class RDoc::TopLevel < RDoc::Context
   attr_reader :parser
 
   ##
+  # Is this page hidden from the sidebar listing?
+
+  attr_accessor :hidden
+
+  ##
   # Creates a new TopLevel for the file at +absolute_name+.  If documentation
   # is being generated outside the source dir +relative_name+ is relative to
   # the source directory.
@@ -49,6 +54,7 @@ class RDoc::TopLevel < RDoc::Context
     @absolute_name = absolute_name
     @relative_name = relative_name
     @parser        = nil
+    @hidden        = false
 
     if relative_name
       @base_name = File.basename(relative_name)

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -250,7 +250,7 @@ class RDoc::Generator::JsonIndex
     debug_msg "  generating pages search index"
 
     pages = @files.select do |file|
-      file.text?
+      file.text? && !file.hidden
     end
 
     pages.each do |page|

--- a/lib/rdoc/generator/template/aliki/_sidebar_pages.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_pages.rhtml
@@ -1,4 +1,4 @@
-<%- simple_files = @files.select { |f| f.text? } %>
+<%- simple_files = @files.select { |f| f.text? && !f.hidden } %>
 
 <%- if defined?(current) && current.respond_to?(:page_name) %>
   <%- dir = current.full_name[%r{\A[^/]+(?=/)}] || current.page_name %>

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -169,6 +169,11 @@ class RDoc::Options
   attr_writer :exclude
 
   ##
+  # Pages matching this pattern will be hidden from listings but still generated
+
+  attr_writer :hide
+
+  ##
   # The list of files to be processed
 
   attr_accessor :files
@@ -409,6 +414,7 @@ class RDoc::Options
     @embed_mixins = false
     @exclude = []
     @files = nil
+    @hide = []
     @force_output = false
     @force_update = true
     @generator_name = "darkfish"
@@ -461,6 +467,7 @@ class RDoc::Options
     @charset        = map['charset']
     @embed_mixins   = map['embed_mixins']
     @exclude        = map['exclude']
+    @hide           = map['hide']
     @generator_name = map['generator_name']
     @hyperlink_all  = map['hyperlink_all']
     @line_numbers   = map['line_numbers']
@@ -497,6 +504,7 @@ class RDoc::Options
     @charset        = map['charset']        if map.has_key?('charset')
     @embed_mixins   = map['embed_mixins']   if map.has_key?('embed_mixins')
     @exclude        = map['exclude']        if map.has_key?('exclude')
+    @hide           = map['hide']           if map.has_key?('hide')
     @generator_name = map['generator_name'] if map.has_key?('generator_name')
     @hyperlink_all  = map['hyperlink_all']  if map.has_key?('hyperlink_all')
     @line_numbers   = map['line_numbers']   if map.has_key?('line_numbers')
@@ -629,6 +637,19 @@ class RDoc::Options
   end
 
   ##
+  # Create a regexp for #hide
+
+  def hide
+    if @hide.nil? || @hide.is_a?(Regexp)
+      @hide
+    elsif @hide.empty?
+      nil
+    else
+      Regexp.new(@hide.join("|"))
+    end
+  end
+
+  ##
   # Completes any unfinished option setup business such as filtering for
   # existent files, creating a regexp for #exclude and setting a default
   # #template.
@@ -647,6 +668,7 @@ class RDoc::Options
     end
 
     @exclude = self.exclude
+    @hide = self.hide
 
     finish_page_dir
 
@@ -861,6 +883,15 @@ Usage: #{opt.program_name} [options] [names...]
       opt.on("--[no-]apply-default-exclude",
              "Use default PATTERN to exclude.") do |value|
         @apply_default_exclude = value
+      end
+
+      opt.separator nil
+
+      opt.on("--hide=PATTERN", "-H", Regexp,
+             "Hide pages matching PATTERN from the",
+             "sidebar listing. Pages are still",
+             "generated and linkable.") do |value|
+        @hide << value
       end
 
       opt.separator nil

--- a/test/rdoc/rdoc_options_test.rb
+++ b/test/rdoc/rdoc_options_test.rb
@@ -67,6 +67,7 @@ class RDocOptionsTest < RDoc::TestCase
       'encoding'              => encoding,
       'embed_mixins'          => false,
       'exclude'               => [],
+      'hide'                  => [],
       'hyperlink_all'         => false,
       'line_numbers'          => false,
       'locale_dir'            => 'locale',
@@ -966,6 +967,28 @@ rdoc_include:
     exclude = @options.exclude
     assert_match exclude, "foo.old"
     assert_not_match exclude, "foo~"
+  end
+
+  def test_hide_option
+    @options.parse %w[--hide=doc/internal/.*]
+    hide = @options.hide
+    assert_kind_of Regexp, hide
+    assert_match hide, "doc/internal/foo.md"
+    assert_not_match hide, "doc/public/bar.md"
+  end
+
+  def test_hide_option_multiple
+    @options.parse %w[--hide=doc/internal/.* --hide=doc/fragments/.*]
+    hide = @options.hide
+    assert_kind_of Regexp, hide
+    assert_match hide, "doc/internal/foo.md"
+    assert_match hide, "doc/fragments/bar.md"
+    assert_not_match hide, "doc/public/baz.md"
+  end
+
+  def test_hide_option_empty
+    @options.parse %w[]
+    assert_nil @options.hide
   end
 
   class DummyCoder < Hash

--- a/test/rdoc/rdoc_top_level_test.rb
+++ b/test/rdoc/rdoc_top_level_test.rb
@@ -281,4 +281,17 @@ class RDocTopLevelTest < XrefTestCase
     refute rd.text?
   end
 
+  def test_hidden_default
+    t = RDoc::TopLevel.new 'path/file.rb'
+
+    refute t.hidden
+  end
+
+  def test_hidden_set
+    t = RDoc::TopLevel.new 'path/file.rb'
+    t.hidden = true
+
+    assert t.hidden
+  end
+
 end


### PR DESCRIPTION
Some pages are primarily used as a linked reference but currently still take up space in the sidebar listing. RDoc should provide a way to hide them so we don't waste space on them.