### PR TITLE
Remove align-self from nav that restricted toc-list width

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -542,7 +542,6 @@ nav {
   position: sticky;
   top: var(--layout-header-height);
   height: calc(100vh - var(--layout-header-height));
-  align-self: start;
 }
 
 /* Mobile navigation */


### PR DESCRIPTION
Before
<img width="360" height="600" alt="before" src="https://github.com/user-attachments/assets/8fea0489-f000-4c61-90e1-cc3641b148f3" />
After
<img width="360" height="600" alt="after" src="https://github.com/user-attachments/assets/a4930ca3-d1f5-4bba-8446-89ebc5588564" />
