### PR TITLE
Fix source code styling issues

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1119,6 +1119,8 @@ main .method-source-code {
 
 main .method-source-code pre {
   border-color: var(--color-accent-hover);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 main .method-source-code.active-menu {
@@ -1143,6 +1145,7 @@ main .method-detail:target {
 
 main .method-header {
   display: inline-block;
+  max-width: calc(100% - 6em); /* 6em is the width of the source code toggle */
 }
 
 main .method-heading {


### PR DESCRIPTION
- By setting width to 100%, it ensures the source code container takes up
  the full width of its parent container.
- By setting box-sizing to border-box, it ensures when the source code block
  expands, it doesn't overflow the container.
- By limiting the method header's width, it ensures that the source code toggle
  doesn't get pushed down to a weird position.