### PR TITLE
Avoid linking file paths inside backticks

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -156,7 +156,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
     ref = @cross_reference.resolve name, text if name
 
     case ref
-    when String then
+    when String
       if rdoc_ref && @options.warn_missing_rdoc_ref
         puts "#{@from_path}: `rdoc-ref:#{name}` can't be resolved for `#{text}`"
       end
@@ -164,8 +164,18 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
     else
       path = ref ? ref.as_href(@from_path) : +""
 
-      if code and RDoc::CodeObject === ref and !(RDoc::TopLevel === ref)
-        text = "<code>#{CGI.escapeHTML text}</code>"
+      text = if code && RDoc::TopLevel === ref
+        # Allow explicit rdoc-ref links to files, but don't wrap in code tags
+        if rdoc_ref
+          text
+        else
+          # Don't auto-link file paths in backticks
+          return "<code>#{CGI.escapeHTML text}</code>"
+        end
+      elsif code && RDoc::CodeObject === ref
+        "<code>#{CGI.escapeHTML text}</code>"
+      else
+        text
       end
 
       if label

--- a/test/rdoc/markup/to_html_crossref_test.rb
+++ b/test/rdoc/markup/to_html_crossref_test.rb
@@ -329,6 +329,23 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
                  @to.link('Parent::m', 'Parent::m')
   end
 
+  def test_convert_CROSSREF_file_path_not_linked
+    # Must use hyperlink_all = false for file path pattern to match the right regex
+    @options.hyperlink_all = false
+    @to = RDoc::Markup::ToHtmlCrossref.new @options, 'index.html', @c1
+
+    file = @store.add_file 'lib/foo/bar.rb'
+    file.parser = RDoc::Parser::Ruby
+
+    # Verify the file IS resolvable via rdoc-ref (sanity check)
+    result = @to.convert 'rdoc-ref:lib/foo/bar.rb'
+    assert_equal para('<a href="lib/foo/bar_rb.html">lib/foo/bar.rb</a>'), result
+
+    # But file paths inside backticks should NOT be converted to links
+    result = @to.convert '+lib/foo/bar.rb+'
+    assert_equal para('<code>lib/foo/bar.rb</code>'), result
+  end
+
   def para(text)
     "\n<p>#{text}</p>\n"
   end


### PR DESCRIPTION
Highlighting file paths like `lib/foo/bar.rb` should not be linked to the file automatically. If the writer's intention is to link it, `rdoc-ref` should be used.