### PR TITLE
Reduce sidebar list item padding

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -690,7 +690,6 @@ nav ul li {
 }
 
 nav ul li a {
-  padding: var(--space-1) 0;
   transition:
     color var(--transition-fast),
     transform var(--transition-fast),


### PR DESCRIPTION
While the padding makes the list more aesthetically pleasing, it requires users to scroll more to see the full list. IMO it's better to prioritize utility over aesthetics.

### Before
<img width="20%" alt="Screenshot 2025-12-20 at 15 29 22" src="https://github.com/user-attachments/assets/ab1278f1-85e5-4859-8535-f9cd33919ed8" />


### After


<img width="20%" alt="Screenshot 2025-12-20 at 15 29 17" src="https://github.com/user-attachments/assets/090fddb7-e199-4e2b-ab36-e2bbb69590b7" />

