### PR TITLE
Fix class/module alias document having wrong name

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -807,11 +807,13 @@ class RDoc::ClassModule < RDoc::Context
       cm_alias = cm.dup
       cm_alias.name = const.name
 
-      # Don't move top-level aliases under Object, they look ugly there
-      unless RDoc::TopLevel === cm_alias.parent then
+      if full_name == 'Object'
+        # Don't move top-level aliases under Object, they look ugly there
+        cm_alias.parent = top_level
+      else
         cm_alias.parent = self
-        cm_alias.full_name = nil # force update for new parent
       end
+      cm_alias.full_name = nil # force update for new parent
 
       cm_alias.aliases.clear
       cm_alias.is_alias_for = cm

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -356,7 +356,9 @@ class RDoc::Generator::Darkfish
 
     current = nil
 
-    @classes.each do |klass|
+    # Document files are generated only for non-alias classes/modules
+    @classes.reject(&:is_alias_for).each do |klass|
+
       current = klass
 
       generate_class klass, template_file

--- a/test/rdoc/generator/aliki_test.rb
+++ b/test/rdoc/generator/aliki_test.rb
@@ -34,6 +34,13 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
     @top_level.parser = RDoc::Parser::Ruby
     @klass = @top_level.add_class RDoc::NormalClass, 'Klass'
 
+    @alias_constant = RDoc::Constant.new 'A', nil, ''
+    @alias_constant.record_location @top_level
+
+    @top_level.add_constant @alias_constant
+
+    @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
+
     @meth = RDoc::AnyMethod.new nil, 'method'
     @meth_with_html_tag_yield = RDoc::AnyMethod.new nil, 'method_with_html_tag_yield'
     @meth_with_html_tag_yield.block_params = '%<<script>alert("atui")</script>>, yield_arg'
@@ -55,6 +62,12 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
   def test_inheritance_and_template_dir
     assert_kind_of RDoc::Generator::Darkfish, @g
     assert_match %r{/template/aliki\z}, @g.template_dir.to_s
+  end
+
+  def test_aliased_classes_full_name
+    @g.generate
+
+    assert_equal(%w[Klass Klass::A Object], @g.classes.map(&:full_name).sort)
   end
 
   def test_write_style_sheet_copies_css_and_js_only

--- a/test/rdoc/generator/darkfish_test.rb
+++ b/test/rdoc/generator/darkfish_test.rb
@@ -297,11 +297,13 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
   def test_setup
     @g.setup
 
-    assert_equal [@klass_alias, @ignored, @klass, @object],
+    assert_equal %w[Ignored Klass Klass::A Object],
+                 [@ignored, @klass, @klass_alias, @object].map(&:full_name)
+    assert_equal [@ignored, @klass, @klass_alias, @object],
                  @g.classes.sort_by { |klass| klass.full_name }
     assert_equal [@top_level],                           @g.files
     assert_equal [@meth, @meth, @meth_bang, @meth_bang, @meth_with_html_tag_yield, @meth_with_html_tag_yield], @g.methods
-    assert_equal [@klass_alias, @klass, @object], @g.modsort
+    assert_equal [@klass, @klass_alias, @object], @g.modsort
   end
 
   def test_template_for
@@ -338,7 +340,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
 
     @g.generate
 
-    path = File.join @tmpdir, 'A.html'
+    path = File.join @tmpdir, 'Klass.html'
 
     f = open(path)
     internal_file = f.read


### PR DESCRIPTION
Fixes #1014

Some aliased class/module document had wrong title.
Example: https://docs.ruby-lang.org/en/master/Net/HTTP.html
Title should be `class Net::HTTP`, Not `class Net::HTTPSession`.

```ruby
# Source
module Net
  class HTTP
    ...
  end
  HTTPSession = HTTP
  deprecate_constant :HTTPSession
end
```

RDoc first generates `Net/HTTP.html` with the correct content, and then overwrite the same file with aliased-name content.

Fixes:
- Stop aliased class/module document file overwrite original one.
- Fix aliasing-to-toplevel check (because test failed with the above change).

Documents of `ruby/ruby` that will change:
```
DidYouMean/Formatter.html
  Title change from DidYouMean::VerboseFormatter
Net/HTTP.html
  Title change from Net::HTTPSession
Net/HTTPFound.html
  Title change from Net::HTTPMovedTemporarily
Net/HTTPPayloadTooLarge.html
  Title change from Net::HTTPRequestEntityTooLarge
Net/HTTPRangeNotSatisfiable.html
  Title change from Net::HTTPRequestedRangeNotSatisfiable
Net/HTTPRequestURITooLong.html
  Title was Net::HTTPRequestURITooLarge, file deleted
OpenSSL/PKey/PKeyError.html
  Title change from OpenSSL::PKey::RSAError
Prism/Translation/Parser33.html
  Title change from Prism::Translation::ParserCurrent
```
