### PR TITLE
Standardize HardBreak markup

### DIFF
--- a/lib/rdoc/markup/hard_break.rb
+++ b/lib/rdoc/markup/hard_break.rb
@@ -1,31 +1,34 @@
 # frozen_string_literal: true
-##
-# A hard-break in the middle of a paragraph.
 
-class RDoc::Markup::HardBreak
+module RDoc
+  class Markup
+    # A hard-break in the middle of a paragraph.
+    class HardBreak < Element
+      @instance = new
 
-  @instance = new
+      # RDoc::Markup::HardBreak is a singleton
+      #: () -> HardBreak
+      def self.new
+        @instance
+      end
 
-  ##
-  # RDoc::Markup::HardBreak is a singleton
+      # Calls #accept_hard_break on +visitor+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_hard_break(self)
+      end
 
-  def self.new
-    @instance
+      #: (top) -> bool
+      def ==(other) # :nodoc:
+        self.class === other
+      end
+
+      # @override
+      #: (PP) -> void
+      def pretty_print(q) # :nodoc:
+        q.text("[break]")
+      end
+    end
   end
-
-  ##
-  # Calls #accept_hard_break on +visitor+
-
-  def accept(visitor)
-    visitor.accept_hard_break self
-  end
-
-  def ==(other) # :nodoc:
-    self.class === other
-  end
-
-  def pretty_print(q) # :nodoc:
-    q.text "[break]"
-  end
-
 end


### PR DESCRIPTION
Continuing the work from #1389. This PR standardizes the `HardBreak` element to a consistent style and starts inheriting from `Element`.