### PR TITLE
Standardize BlockQuote markup

### DIFF
--- a/lib/rdoc/markup/block_quote.rb
+++ b/lib/rdoc/markup/block_quote.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
-##
-# A quoted section which contains markup items.
 
-class RDoc::Markup::BlockQuote < RDoc::Markup::Raw
-
-  ##
-  # Calls #accept_block_quote on +visitor+
-
-  def accept(visitor)
-    visitor.accept_block_quote self
+module RDoc
+  class Markup
+    class BlockQuote < Raw
+      # Calls #accept_block_quote on +visitor+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_block_quote(self)
+      end
+    end
   end
-
 end

--- a/lib/rdoc/markup/raw.rb
+++ b/lib/rdoc/markup/raw.rb
@@ -3,7 +3,7 @@
 module RDoc
   class Markup
     # A section of text that is added to the output document as-is
-    class Raw
+    class Raw < Element
       # The component parts of the list
       #: Array[String]
       attr_reader :parts


### PR DESCRIPTION
Continuing the work from #1389. This PR standardizes the `BlockQuote` element to a consistent style and starts inheriting from `Element`.

I also added the missing parent in `Raw`, which I missed on the other PR.