### PR TITLE
Standardize IndentedParagraph markup

### DIFF
--- a/lib/rdoc/markup/indented_paragraph.rb
+++ b/lib/rdoc/markup/indented_paragraph.rb
@@ -1,47 +1,44 @@
 # frozen_string_literal: true
-##
-# An Indented Paragraph of text
 
-class RDoc::Markup::IndentedParagraph < RDoc::Markup::Raw
+module RDoc
+  class Markup
+    # An Indented Paragraph of text
+    class IndentedParagraph < Raw
+      # The indent in number of spaces
+      #: Integer
+      attr_reader :indent
 
-  ##
-  # The indent in number of spaces
+      # Creates a new IndentedParagraph containing +parts+ indented with +indent+ spaces
+      #: (Integer, *String) -> void
+      def initialize(indent, *parts)
+        @indent = indent
 
-  attr_reader :indent
-
-  ##
-  # Creates a new IndentedParagraph containing +parts+ indented with +indent+
-  # spaces
-
-  def initialize indent, *parts
-    @indent = indent
-
-    super(*parts)
-  end
-
-  def ==(other) # :nodoc:
-    super and indent == other.indent
-  end
-
-  ##
-  # Calls #accept_indented_paragraph on +visitor+
-
-  def accept(visitor)
-    visitor.accept_indented_paragraph self
-  end
-
-  ##
-  # Joins the raw paragraph text and converts inline HardBreaks to the
-  # +hard_break+ text followed by the indent.
-
-  def text(hard_break = nil)
-    @parts.map do |part|
-      if RDoc::Markup::HardBreak === part then
-        '%1$s%3$*2$s' % [hard_break, @indent, ' '] if hard_break
-      else
-        part
+        super(*parts)
       end
-    end.join
-  end
 
+      #: (top) -> bool
+      def ==(other) # :nodoc:
+        super && @indent == other.indent
+      end
+
+      # Calls #accept_indented_paragraph on +visitor+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_indented_paragraph(self)
+      end
+
+      # Joins the raw paragraph text and converts inline HardBreaks to the +hard_break+ text followed by the indent.
+      #: (?String) -> String
+      def text(hard_break = nil)
+        @parts.map do |part|
+          if HardBreak === part then
+            '%1$s%3$*2$s' % [hard_break, @indent, ' '] if hard_break
+          else
+            part
+          end
+        end.join
+      end
+    end
+  end
 end


### PR DESCRIPTION
Continuing the work from #1389. This PR standardizes the `IndentedParagraph` element to a consistent style and starts inheriting from `Element`.