### PR TITLE
Standardize Verbatim markup

### DIFF
--- a/test/rdoc/markup/parser_test.rb
+++ b/test/rdoc/markup/parser_test.rb
@@ -1637,21 +1637,6 @@ Example heading:
     assert_equal expected, @RMP.tokenize(str)
   end
 
-  # HACK move to Verbatim test case
-  def test_verbatim_normalize
-    v = @RM::Verbatim.new "foo\n", "\n", "\n", "bar\n"
-
-    v.normalize
-
-    assert_equal ["foo\n", "\n", "bar\n"], v.parts
-
-    v = @RM::Verbatim.new "foo\n", "\n"
-
-    v.normalize
-
-    assert_equal ["foo\n"], v.parts
-  end
-
   def test_unget
     parser = util_parser
 

--- a/test/rdoc/markup/verbatim_test.rb
+++ b/test/rdoc/markup/verbatim_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require_relative '../helper'
+
+require_relative "../helper"
 
 class RDocMarkupVerbatimTest < RDoc::TestCase
-
   def test_equals2
     v1 = verb('1 + 1')
     v2 = verb('1 + 1')
@@ -11,19 +11,25 @@ class RDocMarkupVerbatimTest < RDoc::TestCase
     v4.format = :ruby
 
     assert_equal v1, v2
-
     refute_equal v1, v3
     refute_equal v1, v4
   end
 
   def test_ruby_eh
     verbatim = RDoc::Markup::Verbatim.new
-
     refute verbatim.ruby?
 
     verbatim.format = :ruby
-
     assert verbatim.ruby?
   end
 
+  def test_normalize
+    verbatim = verb("a\n", "  \n", "  \n", "  \n", "  \n", "more text\n")
+    verbatim.normalize
+    assert_equal(["a\n", "  \n", "more text\n"], verbatim.parts)
+
+    verbatim = verb("foo\n", "\n")
+    verbatim.normalize
+    assert_equal(["foo\n"], verbatim.parts)
+  end
 end


### PR DESCRIPTION
Continuing the work from #1389. This PR standardizes the `Verbatim` element to a consistent style and starts inheriting from `Element`.

I noticed that the `normalize` method had incorrect documentation. It said that we normalize 3+ line breaks to 2, but instead it normalizes 2+ to 1. I confirmed that this is the case based on existing tests as well.

I tried to refactor the implementation a little bit to make it more succinct.