### PR TITLE
Fix comment location marshalling in ClassModule

### DIFF
--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -922,12 +922,17 @@ class RDocStoreTest < XrefTestCase
 
     s = RDoc::RI::Store.new(RDoc::Options.new, path: @tmpdir)
 
-    inner = @RM::Document.new @RM::Paragraph.new 'new comment'
-    inner.file = @top_level
+    loaded = s.load_class('Object')
 
-    document = @RM::Document.new inner
+    # After loading, comment_location is an array (not a Document)
+    assert_kind_of Array, loaded.comment_location
+    assert_equal 1, loaded.comment_location.length
 
-    assert_equal document, s.load_class('Object').comment_location
+    # Verify content is preserved
+    comment, location = loaded.comment_location.first
+    assert_kind_of @RM::Document, comment
+    assert_equal 'new comment', comment.parts[0].text
+    assert_equal @top_level.relative_name, location
   end
 
   # This is a functional test


### PR DESCRIPTION
Fixes #1523 

The issue is likely caused by RDoc generating documentation using data from marshal load (used by `ri`), which has different types than if the generation happen directly.

This code can reproduce the same error:

```rb
require 'rdoc'
require 'tmpdir'

# Setup store
options = RDoc::Options.new
store = RDoc::Store.new(options, path: Dir.tmpdir)

# Create a class with a comment
tl = store.add_file 'file.rb'
ns = tl.add_module RDoc::NormalModule, 'Namespace'
cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
cm.add_comment 'This is a class comment', tl

# Before marshalling - works fine
puts "Before marshal: #{cm.search_snippet.inspect}"

# Marshal round-trip (simulates loading from .ri cache)
loaded = Marshal.load(Marshal.dump(cm))
loaded.store = store

# After marshalling - fails with NoMethodError
puts "After marshal: #{loaded.search_snippet.inspect}"
```

Similar to other code objects' marshalling behaviour, `ClassModule#comment_location`'s content type would change before/after marshalling. But it should still be an array of pairs that respond to the same set of methods.

This commit also adds documentation about the marshalling behaviour of `ClassModule#comment_location`.

I don't like the fact that data types & shapes could change before/after marshalling. But changing this design will be a breaking change and require some careful planning. So for now the change it to make sure the type change is less surprising
