### PR TITLE
Prevent style rendering in code blocks

### DIFF
--- a/test/rdoc/markup/attribute_manager_test.rb
+++ b/test/rdoc/markup/attribute_manager_test.rb
@@ -202,6 +202,30 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
     assert_equal 'foo <CODE>__send__</CODE> bar', output('foo <code>__send__</code> bar')
   end
 
+  def test_convert_attrs_ignores_bold_inside_code
+    assert_equal 'foo <CODE>*bold*</CODE> bar', output('foo <code>*bold*</code> bar')
+  end
+
+  def test_convert_attrs_ignores_em_inside_code
+    assert_equal 'foo <CODE>_em_</CODE> bar', output('foo <code>_em_</code> bar')
+  end
+
+  def test_convert_attrs_ignores_tt_inside_code
+    assert_equal 'foo <CODE>+tt+</CODE> bar', output('foo <code>+tt+</code> bar')
+  end
+
+  def test_convert_attrs_ignores_bold_inside_tt
+    assert_equal 'foo <CODE>*bold*</CODE> bar', output('foo <tt>*bold*</tt> bar')
+  end
+
+  def test_convert_attrs_ignores_em_inside_tt
+    assert_equal 'foo <CODE>_em_</CODE> bar', output('foo <tt>_em_</tt> bar')
+  end
+
+  def test_convert_attrs_ignores_tt_inside_tt
+    assert_equal 'foo <CODE>+tt+</CODE> bar', output('foo <tt>+tt+</tt> bar')
+  end
+
   def test_convert_attrs_ignores_tt
     assert_equal 'foo <CODE>__send__</CODE> bar', output('foo <tt>__send__</tt> bar')
   end

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1283,6 +1283,16 @@ and an extra note.[^2]
     assert_includes html, '<a href="https://example.com">Link to <code>Foo</code> and <code>Bar</code> and <code>Baz</code></a>'
   end
 
+  def test_code_span_preserves_inline_formatting_chars
+    # Code spans should display formatting characters literally, not as styling
+    doc = parse "Code: `*bold*` and `_em_` and `+tt+`"
+    html = @to_html.convert doc
+
+    assert_includes html, '<code>*bold*</code>'
+    assert_includes html, '<code>_em_</code>'
+    assert_includes html, '<code>+tt+</code>'
+  end
+
   def parse(text)
     @parser.parse text
   end


### PR DESCRIPTION
### Before

<img width="110" height="38" alt="Screenshot 2025-12-31 at 23 44 19" src="https://github.com/user-attachments/assets/43819b7d-0e87-44f7-9ab8-51ce53e2e50a" />

### After

<img width="121" height="31" alt="Screenshot 2025-12-31 at 23 43 58" src="https://github.com/user-attachments/assets/a08919cb-81b4-4092-bd02-c10fbd2852c8" />
