### PR TITLE
Improve code block language detection

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -226,10 +226,10 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
     klass = nil
 
     # Apply Ruby syntax highlighting if
-    # - explicitly marked as Ruby
+    # - explicitly marked as Ruby (via ruby? which accepts :ruby or :rb)
     # - no format specified but the text is parseable as Ruby
-    # Otherwise, add language class when applicable and skips Ruby highlighting
-    content = if format == :ruby || (format.nil? && parseable?(text))
+    # Otherwise, add language class when applicable and skip Ruby highlighting
+    content = if verbatim.ruby? || (format.nil? && parseable?(text))
                 begin
                   tokens = RDoc::Parser::RipperStateLex.parse text
                   klass  = ' class="ruby"'

--- a/lib/rdoc/markup/verbatim.rb
+++ b/lib/rdoc/markup/verbatim.rb
@@ -70,7 +70,7 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
 
   def ruby?
     @format ||= nil # TODO for older ri data, switch the tree to marshal_dump
-    @format == :ruby
+    @format == :ruby || @format == :rb
   end
 
   ##

--- a/test/rdoc/markup/to_html_test.rb
+++ b/test/rdoc/markup/to_html_test.rb
@@ -603,6 +603,22 @@ end
     assert_equal expected, @to.res.join
   end
 
+  def test_accept_verbatim_rb
+    verb = @RM::Verbatim.new("1 + 1\n")
+    verb.format = :rb
+
+    @to.start_accepting
+    @to.accept_verbatim verb
+
+    expected = <<-EXPECTED
+
+<pre class="ruby"><span class="ruby-value">1</span> <span class="ruby-operator">+</span> <span class="ruby-value">1</span>
+</pre>
+    EXPECTED
+
+    assert_equal expected, @to.res.join
+  end
+
   def test_accept_verbatim_non_ruby_format_without_ruby_highlighting
     verb = @RM::Verbatim.new("1. First item\n", "2. Second item\n")
     verb.format = :markdown


### PR DESCRIPTION
### Fix verbatim blocks with non-Ruby formats getting Ruby highlighting

Code blocks with explicit language identifiers (e.g., ```markdown) were sometimes incorrectly receiving Ruby syntax highlighting when their content happened to be parseable as Ruby.

Now Ruby highlighting is only applied when:
- Format is explicitly `ruby`, or
- No format specified and content is parseable as Ruby

Other formats now get their language class (e.g., `class="markdown"`) for potential frontend-based highlighting support.

### Support `rb` as an alternative markdown code block language