### PR TITLE
Fix Markdown strikethrough (`~~text~~`) not rendering in HTML output

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -89,12 +89,15 @@ class RDoc::Markup::AttributeManager
     add_word_pair "*", "*", :BOLD, true
     add_word_pair "_", "_", :EM, true
     add_word_pair "+", "+", :TT, true
+    add_word_pair "~", "~", :STRIKE, true
 
     add_html "em", :EM, true
     add_html "i",  :EM, true
     add_html "b",  :BOLD, true
     add_html "tt",   :TT, true
     add_html "code", :TT, true
+    add_html "s",   :STRIKE, true
+    add_html "del", :STRIKE, true
 
     @word_pair_chars = @matching_word_pairs.keys.join
 

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -419,9 +419,10 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # Maps attributes to HTML tags
 
   def init_tags
-    add_tag :BOLD, "<strong>", "</strong>"
-    add_tag :TT,   "<code>",   "</code>"
-    add_tag :EM,   "<em>",     "</em>"
+    add_tag :BOLD,   "<strong>", "</strong>"
+    add_tag :TT,     "<code>",   "</code>"
+    add_tag :EM,     "<em>",     "</em>"
+    add_tag :STRIKE, "<del>",    "</del>"
   end
 
   ##

--- a/test/rdoc/markup/attribute_manager_test.rb
+++ b/test/rdoc/markup/attribute_manager_test.rb
@@ -17,6 +17,9 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
     @em_on    = @am.changed_attribute_by_name([], [:EM])
     @em_off   = @am.changed_attribute_by_name([:EM], [])
 
+    @strike_on  = @am.changed_attribute_by_name([], [:STRIKE])
+    @strike_off = @am.changed_attribute_by_name([:STRIKE], [])
+
     @bold_em_on   = @am.changed_attribute_by_name([], [:BOLD] | [:EM])
     @bold_em_off  = @am.changed_attribute_by_name([:BOLD] | [:EM], [])
 
@@ -54,7 +57,7 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
   def test_add_html_tag
     @am.add_html("Test", :TEST)
     tags = @am.html_tags
-    assert_equal(6, tags.size)
+    assert_equal(8, tags.size)
     assert(tags.has_key?("test"))
   end
 
@@ -162,6 +165,40 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
 
   def test_bold_html_escaped
     assert_equal ['cat <b>dog</b>'], @am.flow('cat \<b>dog</b>')
+  end
+
+  def test_strike
+    assert_equal [@strike_on, 'strike', @strike_off],
+                 @am.flow("~strike~")
+
+    assert_equal [@strike_on, 'Strike:', @strike_off],
+                 @am.flow("~Strike:~")
+
+    assert_equal ["cat ", @strike_on, "and", @strike_off, " dog"],
+                 @am.flow("cat ~and~ dog")
+  end
+
+  def test_strike_html_escaped
+    assert_equal ['cat <s>dog</s>'], @am.flow('cat \<s>dog</s>')
+    assert_equal ['cat <del>dog</del>'], @am.flow('cat \<del>dog</del>')
+  end
+
+  def test_html_like_strike
+    assert_equal ["cat ", @strike_on, "dog", @strike_off],
+                  @am.flow("cat <s>dog</s>")
+  end
+
+  def test_html_like_strike_del
+    assert_equal ["cat ", @strike_on, "dog", @strike_off],
+                  @am.flow("cat <del>dog</del>")
+  end
+
+  def test_convert_attrs_ignores_strike_inside_code
+    assert_equal 'foo <CODE>~strike~</CODE> bar', output('foo <code>~strike~</code> bar')
+  end
+
+  def test_convert_attrs_ignores_strike_inside_tt
+    assert_equal 'foo <CODE>~strike~</CODE> bar', output('foo <tt>~strike~</tt> bar')
   end
 
   def test_combined
@@ -331,13 +368,13 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
   def test_initial_html
     html_tags = @am.html_tags
     assert html_tags.is_a?(Hash)
-    assert_equal(5, html_tags.size)
+    assert_equal(7, html_tags.size)
   end
 
   def test_initial_word_pairs
     word_pairs = @am.matching_word_pairs
     assert word_pairs.is_a?(Hash)
-    assert_equal(3, word_pairs.size)
+    assert_equal(4, word_pairs.size)
   end
 
   def test_mask_protected_sequence

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1114,6 +1114,34 @@ and an extra note.[^2]
     assert_equal expected, doc
   end
 
+  def test_strike_to_html_single_word
+    doc = parse "This is ~~strikethrough~~ text.\n"
+    html = @to_html.convert doc
+
+    assert_match %r{<del>strikethrough</del>}, html
+  end
+
+  def test_strike_to_html_multiple_words
+    doc = parse "This is ~~multiple words~~ text.\n"
+    html = @to_html.convert doc
+
+    assert_match %r{<del>multiple words</del>}, html
+  end
+
+  def test_strike_to_html_with_s_tag
+    doc = parse "This has <s>deleted</s> text.\n"
+    html = @to_html.convert doc
+
+    assert_match %r{<del>deleted</del>}, html
+  end
+
+  def test_strike_to_html_with_del_tag
+    doc = parse "This has <del>deleted</del> text.\n"
+    html = @to_html.convert doc
+
+    assert_match %r{<del>deleted</del>}, html
+  end
+
   def test_parse_style
     @parser.css = true
 


### PR DESCRIPTION
The Markdown parser correctly parsed `~~text~~` syntax but the `AttributeManager` did not recognize the resulting formats for HTML conversion:

- Single words: `~~word~~` -> `~word~` (not registered as word pair)
- Multi-word: `~~words here~~` -> `<s>words here</s>` (tag not registered)

Add support for strikethrough formatting:

- Register `~` as word pair for `:STRIKE` attribute
- Register `<s>`, `<del>`, and `<strike>` HTML tags for `:STRIKE`
- Add `:STRIKE` -> `<del>` tag mapping in `ToHtml`

All strikethrough input formats now render as `<del>text</del>` in HTML.