### PR TITLE
Use class for highlight selector

### DIFF
--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -159,7 +159,7 @@
             </details>
           </div>
           <div class="method-source-code" id="<%= method.html_name %>-source">
-            <pre class="<%= method.source_language %>" data-language="<%= method.source_language %>"><%= method.markup_code %></pre>
+            <pre class="<%= method.source_language %>"><%= method.markup_code %></pre>
           </div>
         <%- end %>
 

--- a/lib/rdoc/generator/template/aliki/js/c_highlighter.js
+++ b/lib/rdoc/generator/template/aliki/js/c_highlighter.js
@@ -276,7 +276,7 @@
    * Initialize C syntax highlighting on page load
    */
   function initHighlighting() {
-    const codeBlocks = document.querySelectorAll('pre[data-language="c"]');
+    const codeBlocks = document.querySelectorAll('pre.c');
 
     codeBlocks.forEach(block => {
       if (block.getAttribute('data-highlighted') === 'true') {


### PR DESCRIPTION
After #1538, code blocks with language declaration now have the class as the language name. So we can simply use the class for the highlight selector.