### PR TITLE
Align strikethrough support with GitHub Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ rdoc --markup markdown
 | Cross-references | Automatic | Automatic |
 | Directives (`:nodoc:`, etc.) | Supported | Supported |
 | Tables | Not supported | Supported |
-| Strikethrough | Not supported | Supported |
+| Strikethrough | `<del>text</del>` | `~~text~~` |
 | Footnotes | Not supported | Supported |
 
 For complete syntax documentation, see:

--- a/doc/markup_reference/markdown.md
+++ b/doc/markup_reference/markdown.md
@@ -540,7 +540,7 @@ See [rdoc.rdoc](rdoc.rdoc) for complete directive documentation.
 | Code blocks | Indent beyond margin | Indent 4 spaces or fence |
 | Block quotes | `>>>` | `>` |
 | Tables | Not supported | Supported |
-| Strikethrough | Not supported | `~~text~~` |
+| Strikethrough | `<del>text</del>` | `~~text~~` |
 | Footnotes | Not supported | `[^1]` |
 
 ## Notes and Limitations

--- a/doc/markup_reference/rdoc.rdoc
+++ b/doc/markup_reference/rdoc.rdoc
@@ -664,7 +664,7 @@ For C code, the directive may appear in a stand-alone comment.
 
 Text markup is metatext that affects HTML rendering:
 
-- {Typeface}[rdoc-ref:rdoc@Typeface+Markup]: italic, bold, monofont.
+- {Typeface}[rdoc-ref:rdoc@Typeface+Markup]: italic, bold, monofont, strikethrough.
 - {Character conversions}[rdoc-ref:rdoc@Character+Conversions]: copyright, trademark, certain punctuation.
 - {Links}[rdoc-ref:rdoc@Links].
 - {Escapes}[rdoc-ref:rdoc@Escaping+Text]: marking text as "not markup."
@@ -672,12 +672,13 @@ Text markup is metatext that affects HTML rendering:
 === Typeface Markup
 
 Typeface markup can specify that text is to be rendered
-as italic, bold, or monofont.
+as italic, bold, monofont, or strikethrough.
 
 Typeface markup may contain only one type of nested block:
 
 - More typeface markup:
-  {italic}[rdoc-ref:rdoc@Italic], {bold}[rdoc-ref:rdoc@Bold], {monofont}[rdoc-ref:rdoc@Monofont].
+  {italic}[rdoc-ref:rdoc@Italic], {bold}[rdoc-ref:rdoc@Bold], {monofont}[rdoc-ref:rdoc@Monofont],
+  {strikethrough}[rdoc-ref:rdoc@Strikethrough].
 
 ==== Italic
 
@@ -765,6 +766,23 @@ Rendered HTML:
 
 >>>
   +Monofont+ in a paragraph.
+
+==== Strikethrough
+
+Text may be marked as strikethrough via HTML tag <tt><del></tt> or <tt><s></tt>.
+
+Example input:
+
+  <del>Strikethrough words</del> in a paragraph.
+
+  <del>Deleted passage containing _italics_ and *bold*.</del>
+
+Rendered HTML:
+
+>>>
+  <del>Strikethrough words</del> in a paragraph.
+
+  <del>Deleted passage containing _italics_ and *bold*.</del>
 
 === Character Conversions
 

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -490,11 +490,7 @@
   # Wraps `text` in strike markup for rdoc inline formatting
 
   def strike text
-    if text =~ /\A[a-z\d.\/-]+\z/i then
-      "~#{text}~"
-    else
-      "<s>#{text}</s>"
-    end
+    "<del>#{text}</del>"
   end
 
   ##

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -875,11 +875,7 @@ class RDoc::Markdown
   # Wraps `text` in strike markup for rdoc inline formatting
 
   def strike text
-    if text =~ /\A[a-z\d.\/-]+\z/i then
-      "~#{text}~"
-    else
-      "<s>#{text}</s>"
-    end
+    "<del>#{text}</del>"
   end
 
   ##

--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -89,7 +89,6 @@ class RDoc::Markup::AttributeManager
     add_word_pair "*", "*", :BOLD, true
     add_word_pair "_", "_", :EM, true
     add_word_pair "+", "+", :TT, true
-    add_word_pair "~", "~", :STRIKE, true
 
     add_html "em", :EM, true
     add_html "i",  :EM, true
@@ -263,7 +262,10 @@ class RDoc::Markup::AttributeManager
     @str.gsub!(/<(code|tt)>(.*?)<\/\1>/im) do
       tag = $1
       content = $2
+      # Protect word pair delimiters (*, _, +) from being processed
       escaped = content.gsub(@unprotected_word_pair_regexp, "\\1#{PROTECT_ATTR}")
+      # Protect HTML-like tags from being processed (e.g., <del> inside code)
+      escaped = escaped.gsub(/<(?!#{PROTECT_ATTR})/, "<#{PROTECT_ATTR}")
       "<#{tag}>#{escaped}</#{tag}>"
     end
   end

--- a/test/rdoc/markup/attribute_manager_test.rb
+++ b/test/rdoc/markup/attribute_manager_test.rb
@@ -167,17 +167,6 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
     assert_equal ['cat <b>dog</b>'], @am.flow('cat \<b>dog</b>')
   end
 
-  def test_strike
-    assert_equal [@strike_on, 'strike', @strike_off],
-                 @am.flow("~strike~")
-
-    assert_equal [@strike_on, 'Strike:', @strike_off],
-                 @am.flow("~Strike:~")
-
-    assert_equal ["cat ", @strike_on, "and", @strike_off, " dog"],
-                 @am.flow("cat ~and~ dog")
-  end
-
   def test_strike_html_escaped
     assert_equal ['cat <s>dog</s>'], @am.flow('cat \<s>dog</s>')
     assert_equal ['cat <del>dog</del>'], @am.flow('cat \<del>dog</del>')
@@ -191,14 +180,6 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
   def test_html_like_strike_del
     assert_equal ["cat ", @strike_on, "dog", @strike_off],
                   @am.flow("cat <del>dog</del>")
-  end
-
-  def test_convert_attrs_ignores_strike_inside_code
-    assert_equal 'foo <CODE>~strike~</CODE> bar', output('foo <code>~strike~</code> bar')
-  end
-
-  def test_convert_attrs_ignores_strike_inside_tt
-    assert_equal 'foo <CODE>~strike~</CODE> bar', output('foo <tt>~strike~</tt> bar')
   end
 
   def test_combined
@@ -261,6 +242,18 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
 
   def test_convert_attrs_ignores_tt_inside_tt
     assert_equal 'foo <CODE>+tt+</CODE> bar', output('foo <tt>+tt+</tt> bar')
+  end
+
+  def test_convert_attrs_ignores_del_inside_code
+    assert_equal 'foo <CODE><del>strike</del></CODE> bar', output('foo <code><del>strike</del></code> bar')
+  end
+
+  def test_convert_attrs_ignores_del_inside_tt
+    assert_equal 'foo <CODE><del>strike</del></CODE> bar', output('foo <tt><del>strike</del></tt> bar')
+  end
+
+  def test_convert_attrs_ignores_s_inside_code
+    assert_equal 'foo <CODE><s>strike</s></CODE> bar', output('foo <code><s>strike</s></code> bar')
   end
 
   def test_convert_attrs_ignores_tt
@@ -374,7 +367,7 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
   def test_initial_word_pairs
     word_pairs = @am.matching_word_pairs
     assert word_pairs.is_a?(Hash)
-    assert_equal(4, word_pairs.size)
+    assert_equal(3, word_pairs.size)
   end
 
   def test_mask_protected_sequence

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1089,7 +1089,7 @@ and an extra note.[^2]
     doc = parse "it ~~works~~\n"
 
     expected = @RM::Document.new(
-      @RM::Paragraph.new("it ~works~"))
+      @RM::Paragraph.new("it <del>works</del>"))
 
     assert_equal expected, doc
   end
@@ -1098,7 +1098,7 @@ and an extra note.[^2]
     doc = parse "it ~~works fine~~\n"
 
     expected = @RM::Document.new(
-      @RM::Paragraph.new("it <s>works fine</s>"))
+      @RM::Paragraph.new("it <del>works fine</del>"))
 
     assert_equal expected, doc
   end


### PR DESCRIPTION
1. GitHub doesn't support `~word~` syntax for strikethrough, so we shouldn't either.
2. It's hard to make RDoc markup support `~~word~~` without supporting `~word~` as well due to the way attribute manager works. So instead we rollback the support added in #1541. Users can still use `<del>text</del>` syntax for strikethrough.
3. Fix `<code><del>text</del></code>` not rendering as `<del>text</del>` in HTML output.
4. Update documentation to reflect the new support.