### PR TITLE
Allow using backticks to quote text in RDoc markup too

### DIFF
--- a/doc/markup_reference/rdoc.rdoc
+++ b/doc/markup_reference/rdoc.rdoc
@@ -756,16 +756,31 @@ Rendered HTML:
   <tt>Monofont passage containing _italics_ and *bold*.</tt>
 
 A single word may be made monofont by a shorthand:
-prefixed and suffixed plus-signs.
+prefixed and suffixed plus-signs or backticks.
 
 Example input:
 
   +Monofont+ in a paragraph.
 
+  `Monofont` in a paragraph.
+
 Rendered HTML:
 
 >>>
   +Monofont+ in a paragraph.
+
+  `Monofont` in a paragraph.
+
+Note: The shorthand (<tt>+...+</tt> and <tt>`...`</tt>) only works for simple content
+containing word characters, colons, periods, slashes, brackets, and hyphens.
+Content containing HTML tags or other markup delimiters will not be matched.
+For complex content, use the HTML tags <tt><tt></tt> or <tt><code></tt> instead:
+
+  <tt>+literal_plus+</tt> shows: +literal_plus+
+
+  <tt>`literal_backtick`</tt> shows: `literal_backtick`
+
+  <tt><code>content</code></tt> shows: <code>content</code>
 
 ==== Strikethrough
 

--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -89,6 +89,7 @@ class RDoc::Markup::AttributeManager
     add_word_pair "*", "*", :BOLD, true
     add_word_pair "_", "_", :EM, true
     add_word_pair "+", "+", :TT, true
+    add_word_pair "`", "`", :TT, true
 
     add_html "em", :EM, true
     add_html "i",  :EM, true
@@ -100,7 +101,7 @@ class RDoc::Markup::AttributeManager
 
     @word_pair_chars = @matching_word_pairs.keys.join
 
-    # Matches a word pair delimiter (*, _, +) that is NOT already protected.
+    # Matches a word pair delimiter (*, _, +, `) that is NOT already protected.
     # Used by #protect_code_markup to escape delimiters inside <code>/<tt> tags.
     @unprotected_word_pair_regexp = /([#{@word_pair_chars}])(?!#{PROTECT_ATTR})/
   end

--- a/test/rdoc/markup/attribute_manager_test.rb
+++ b/test/rdoc/markup/attribute_manager_test.rb
@@ -244,6 +244,31 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
     assert_equal 'foo <CODE>+tt+</CODE> bar', output('foo <tt>+tt+</tt> bar')
   end
 
+  def test_backtick_basic
+    assert_equal(["cat ", @tt_on, "and", @tt_off, " dog"],
+                  @am.flow("cat `and` dog"))
+
+    assert_equal(["cat ", @tt_on, "X::Y", @tt_off, " dog"],
+                  @am.flow("cat `X::Y` dog"))
+  end
+
+  def test_backtick_output
+    assert_equal 'cat <CODE>and</CODE> dog', output('cat `and` dog')
+    assert_equal 'cat <CODE>X::Y</CODE> dog', output('cat `X::Y` dog')
+  end
+
+  def test_convert_attrs_ignores_backtick_inside_code
+    assert_equal 'foo <CODE>`text`</CODE> bar', output('foo <code>`text`</code> bar')
+  end
+
+  def test_convert_attrs_ignores_backtick_inside_tt
+    assert_equal 'foo <CODE>`text`</CODE> bar', output('foo <tt>`text`</tt> bar')
+  end
+
+  def test_backtick_escaped
+    assert_equal ['`text`'], @am.flow('\`text`')
+  end
+
   def test_convert_attrs_ignores_del_inside_code
     assert_equal 'foo <CODE><del>strike</del></CODE> bar', output('foo <code><del>strike</del></code> bar')
   end
@@ -367,7 +392,7 @@ class RDocMarkupAttributeManagerTest < RDoc::TestCase
   def test_initial_word_pairs
     word_pairs = @am.matching_word_pairs
     assert word_pairs.is_a?(Hash)
-    assert_equal(3, word_pairs.size)
+    assert_equal(4, word_pairs.size)
   end
 
   def test_mask_protected_sequence


### PR DESCRIPTION
Users can now use both ``` ` ``` and `+` to make simple code blocks in RDoc markup.

Using backticks to quote code has become a natural habit for many users, so it's common to see it being incorrectly used to contribute to Ruby documentation.

But instead of "correcting" users' behaviour, we should just support it. It'll also allow us to partially migrate some RDoc markup to Markdown.