### PR TITLE
Bump version to v7.1.0

### DIFF
--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -5,6 +5,6 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '7.0.3'
+  VERSION = '7.1.0'
 
 end


### PR DESCRIPTION
Bump to v7.1.0 to release the recent fixes and improvements.

Comparison since the last tag:

https://github.com/ruby/rdoc/compare/v7.0.3...master?expand=1