### PR TITLE
Fix broken RDoc Markup Reference link in RDoc::Comment

### DIFF
--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -6,7 +6,7 @@
 # Each comment may have a different markup format set by #format=.  By default
 # 'rdoc' is used.  The :markup: directive tells RDoc which format to use.
 #
-# See RDoc::MarkupReference@Directive+for+Specifying+RDoc+Source+Format.
+# See {RDoc Markup Reference}[rdoc-ref:doc/markup_reference/rdoc.rdoc@Directive+for+Specifying+RDoc+Source+Format].
 
 
 class RDoc::Comment


### PR DESCRIPTION
Fix broken RDoc Markup Reference links in `RDoc::Comment`.

See https://github.com/ruby/rdoc/pull/1542/files.