### PR TITLE
Move html characeter converting mechanism to regexp-handling

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -42,6 +42,86 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
   # :section:
 
+  # Maps an encoding to a Hash of characters properly transcoded for that
+  # encoding.
+  #
+  # See also encode_fallback.
+
+  TO_HTML_CHARACTERS = Hash.new do |h, encoding|
+    h[encoding] = {
+      close_dquote: encode_fallback('”', encoding, '"'),
+      close_squote: encode_fallback('’', encoding, '\''),
+      copyright:    encode_fallback('©', encoding, '(c)'),
+      ellipsis:     encode_fallback('…', encoding, '...'),
+      dot_ellipsis: encode_fallback('.…', encoding, '....'),
+      em_dash:      encode_fallback('—', encoding, '---'),
+      en_dash:      encode_fallback('–', encoding, '--'),
+      open_dquote:  encode_fallback('“', encoding, '"'),
+      open_squote:  encode_fallback('‘', encoding, '\''),
+      trademark:    encode_fallback('®', encoding, '(r)'),
+    }
+  end
+
+  HTML_CHARACTER_ALIASES = {
+    '(c)' => :copyright,
+    '(C)' => :copyright,
+    '(r)' => :trademark,
+    '(R)' => :trademark,
+    '---' => :em_dash,
+    '--'  => :en_dash,
+    '....' => :dot_ellipsis,
+    '...' => :ellipsis,
+    '``' => :open_dquote,
+    "''" => :close_dquote,
+  }
+
+  # Transcodes +character+ to +encoding+ with a +fallback+ character.
+
+  def self.encode_fallback(character, encoding, fallback)
+    character.encode(
+      encoding,
+      fallback: { character => fallback },
+      undef: :replace,
+      replace: fallback
+    )
+  end
+
+  # Converts ascii quote pairs to multibyte quote characters
+  class QuoteConverter
+
+    def initialize
+      @in_dquote = false
+      @in_squote = false
+    end
+
+    def convert(quote, after_word:)
+      case quote
+      when '"'
+        type = @in_dquote ? :close_dquote : :open_dquote
+        @in_dquote = !@in_dquote
+      when "'"
+        if @in_squote
+          type = :close_squote
+          @in_squote = false
+        elsif after_word
+          # Mary's dog, my parents' house: do not start paired quotes
+          type = :close_squote
+        else
+          type = :open_squote
+          @in_squote = true
+        end
+      when '`'
+        # Opening quote of <tt>`quoted sentence'</tt>.
+        # This will conflict with code blocks <tt>`puts('hello')`</tt> in the future.
+        if !@in_squote && !after_word
+          type = :open_squote
+          @in_squote = true
+        end
+      end
+      TO_HTML_CHARACTERS[quote.encoding][type] if type
+    end
+  end
+
   ##
   # Creates a new formatter that will output HTML
 
@@ -55,6 +135,7 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
     @in_list_entry = nil
     @list = nil
     @th = nil
+    @quote_converter = nil
     @in_tidylink_label = false
     @hard_break = "<br>\n"
 
@@ -78,6 +159,11 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
     # suppress crossref: \#method \::method \ClassName \method_with_underscores
     @markup.add_regexp_handling(/\\(?:[#:A-Z]|[a-z]+_[a-z0-9])/, :SUPPRESSED_CROSSREF)
+
+    @markup.add_regexp_handling(Regexp.union(HTML_CHARACTER_ALIASES.keys), :HTML_CHARACTERS)
+
+    @markup.add_regexp_handling(/\b['"`]/, :QUOTE_AFTER_WORD)
+    @markup.add_regexp_handling(/\B['"`]/, :QUOTE_NOT_AFTER_WORD)
 
     init_link_notation_regexp_handlings
   end
@@ -231,10 +317,26 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
   def handle_inline(text) # :nodoc:
     @inline_output = +''
+    @quote_converter = QuoteConverter.new
     super
     out = @inline_output
     @inline_output = nil
+    @quote_converter = nil
     out
+  end
+
+  # Converts <tt>(c), (r), --, --- , ..., ...., ``, ''</tt> to HTML characters.
+  def handle_regexp_HTML_CHARACTERS(text)
+    name = HTML_CHARACTER_ALIASES[text]
+    TO_HTML_CHARACTERS[text.encoding][name] if name
+  end
+
+  def handle_regexp_QUOTE_NOT_AFTER_WORD(text)
+    @quote_converter.convert(text, after_word: false) || convert_string(text)
+  end
+
+  def handle_regexp_QUOTE_AFTER_WORD(text)
+    @quote_converter.convert(text, after_word: true) || convert_string(text)
   end
 
   # Converts suppressed cross-reference +text+ to HTML by removing the leading backslash.
@@ -576,9 +678,6 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # Converts +item+ to HTML using RDoc::Text#to_html
 
   def to_html(item)
-    # Ideally, we should convert html characters at handle_PLAIN_TEXT or somewhere else,
-    # but we need to convert it here for now because to_html_characters converts pair of backticks to ’‘ and pair of double backticks to ”“.
-    # Known bugs: `...` in `<code>def f(...); end</code>` and `(c) in `<a href="(c)">` will be wrongly converted.
-    to_html_characters(handle_inline(item))
+    handle_inline(item)
   end
 end

--- a/lib/rdoc/markup/to_html_snippet.rb
+++ b/lib/rdoc/markup/to_html_snippet.rb
@@ -109,7 +109,7 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
     input = verbatim.text.rstrip
     text = truncate(input, @character_limit - @characters)
     @characters += input.length
-    text << ' ...' unless text == input
+    text << " #{TO_HTML_CHARACTERS[text.encoding][:ellipsis]}" unless text == input
 
     super RDoc::Markup::Verbatim.new text
 
@@ -262,14 +262,14 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
     return ['', 0] if limit <= 0
     @inline_character_limit = limit
     res = super
-    res << ' ...' if @inline_character_limit <= 0
+    res << " #{TO_HTML_CHARACTERS[text.encoding][:ellipsis]}" if @inline_character_limit <= 0
     @characters += limit - @inline_character_limit
     res
   end
 
   def to_html(item)
     throw :done if @characters >= @character_limit
-    to_html_characters(handle_inline(item))
+    handle_inline(item)
   end
 
   ##

--- a/test/rdoc/markup/to_html_crossref_test.rb
+++ b/test/rdoc/markup/to_html_crossref_test.rb
@@ -118,7 +118,7 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
 
   def test_convert_CROSSREF_legacy_label
     result = @to.convert 'C1@What-27s+Here'
-    assert_equal para("<a href=\"C1.html#class-c1-whats-here\">What\u2019s Here at <code>C1</code></a>"), result
+    assert_equal para("<a href=\"C1.html#class-c1-whats-here\">What's Here at <code>C1</code></a>"), result
   end
 
   def test_convert_CROSSREF_legacy_label_colon
@@ -130,7 +130,7 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
     @c1.add_section "What's Here"
 
     result = @to.convert "C1@What-27s+Here"
-    assert_equal para("<a href=\"C1.html#whats-here\">What\u2019s Here at <code>C1</code></a>"), result
+    assert_equal para("<a href=\"C1.html#whats-here\">What's Here at <code>C1</code></a>"), result
   end
 
   def test_convert_CROSSREF_constant

--- a/test/rdoc/markup/to_html_snippet_test.rb
+++ b/test/rdoc/markup/to_html_snippet_test.rb
@@ -543,7 +543,7 @@ This is some text, it *will* be cut off after 100 characters
 <p>Hello There
 <p>This is some text, it <strong>will</strong> be cut off after 100 characters
 
-<pre>This one is cut off in this verbatim ...</pre>
+<pre>This one is cut off in this verbatim …</pre>
     EXPECTED
 
     actual = @to.convert rdoc

--- a/test/rdoc/rdoc_text_test.rb
+++ b/test/rdoc/rdoc_text_test.rb
@@ -16,13 +16,6 @@ class RDocTextTest < RDoc::TestCase
     @language = nil
   end
 
-  def test_self_encode_fallback
-    assert_equal '…',
-                 RDoc::Text::encode_fallback('…', Encoding::UTF_8,    '...')
-    assert_equal '...',
-                 RDoc::Text::encode_fallback('…', Encoding::US_ASCII, '...')
-  end
-
   def test_expand_tabs
     assert_equal("hello\n  dave",
                  expand_tabs("hello\n  dave"), 'spaces')
@@ -476,104 +469,6 @@ The comments associated with
     EXPECTED
 
     assert_equal expected, strip_stars(text)
-  end
-
-  def test_to_html_apostrophe
-    assert_equal '‘a', to_html("'a")
-    assert_equal 'a’', to_html("a'")
-
-    assert_equal '‘a’ ‘', to_html("'a' '")
-  end
-
-  def test_to_html_apostrophe_entity
-    assert_equal '‘a', to_html("&#39;a")
-    assert_equal 'a’', to_html("a&#39;")
-
-    assert_equal '‘a’ ‘', to_html("&#39;a&#39; &#39;")
-  end
-
-  def test_to_html_backslash
-    # Don't handle unescaped crossref. It should be handled in RDoc::Markup::ToHtml, not in RDoc::Text
-    assert_equal '\\S', to_html('\\S')
-  end
-
-  def test_to_html_br
-    assert_equal '<br>', to_html('<br>')
-  end
-
-  def test_to_html_copyright
-    assert_equal '©', to_html('(c)')
-    assert_equal '©', to_html('(C)')
-  end
-
-  def test_to_html_dash
-    assert_equal '-',  to_html('-')
-    assert_equal '–',  to_html('--')
-    assert_equal '—',  to_html('---')
-    assert_equal '—-', to_html('----')
-  end
-
-  def test_to_html_double_backtick
-    assert_equal '“a',  to_html('``a')
-    assert_equal '“a“', to_html('``a``')
-    assert_equal '“a”', to_html("``a''")
-  end
-
-  def test_to_html_double_quote
-    assert_equal '“a',  to_html('"a')
-    assert_equal '“a”', to_html('"a"')
-  end
-
-  def test_to_html_double_quote_quot
-    assert_equal '“a',  to_html('&quot;a')
-    assert_equal '“a”', to_html('&quot;a&quot;')
-  end
-
-  def test_to_html_double_tick
-    assert_equal '”a',        to_html("''a")
-    assert_equal '”a”', to_html("''a''")
-  end
-
-  def test_to_html_ellipsis
-    assert_equal '..', to_html('..')
-    assert_equal '…',  to_html('...')
-    assert_equal '.…', to_html('....')
-  end
-
-  def test_to_html_encoding
-    s = '...(c)'.encode Encoding::Shift_JIS
-
-    html = to_html s
-
-    assert_equal Encoding::Shift_JIS, html.encoding
-
-    expected = '…(c)'.encode Encoding::Shift_JIS
-
-    assert_equal expected, html
-  end
-
-  def test_to_html_html_tag
-    assert_equal '<a href="http://example">hi’s</a>',
-                 to_html('<a href="http://example">hi\'s</a>')
-  end
-
-  def test_to_html_registered_trademark
-    assert_equal '®', to_html('(r)')
-    assert_equal '®', to_html('(R)')
-  end
-
-  def test_to_html_tt_tag
-    # tt tag content is already escaped
-    assert_equal '<tt>hi\'s</tt>',   to_html('<tt>hi\'s</tt>')
-    assert_equal '<tt>hi\\\\\'s</tt>', to_html('<tt>hi\\\\\'s</tt>')
-  end
-
-  def test_to_html_tt_tag_mismatch
-    _, err = verbose_capture_output do
-      assert_equal '<tt>hi', to_html('<tt>hi')
-    end
-
-    assert_include err, "mismatched <tt> tag\n"
   end
 
   def formatter


### PR DESCRIPTION
`Text#to_html_characters` was a postprocess that converts ascii quotes/marks to multibyte characters. Postprocessing HTML to do that is not a good idea. Convert plain text node with regexp-handling is better.