### PR TITLE
Improve scan of regexp handling

### DIFF
--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -85,31 +85,29 @@ class RDoc::Markup::Formatter
   # Applies regexp handling to +text+ and returns an array of [text, converted?] pairs.
 
   def apply_regexp_handling(text)
-    output = []
-    start = 0
-    loop do
-      pos = text.size
-      matched_name = matched_text = nil
-      @markup.regexp_handlings.each do |pattern, name|
-        m = text.match(pattern, start)
-        next unless m
+    matched = []
+    @markup.regexp_handlings.each_with_index do |(pattern, name), priority|
+      text.scan(pattern) do
+        m = Regexp.last_match
         idx = m[1] ? 1 : 0
-        if m.begin(idx) < pos
-          pos = m.begin(idx)
-          matched_text = m[idx]
-          matched_name = name
-        end
+        matched << [m.begin(idx), m.end(idx), m[idx], name, priority]
       end
-      output << [text[start...pos], false] if pos > start
-      if matched_name
-        handled = public_send(:"handle_regexp_#{matched_name}", matched_text)
-        output << [handled, true]
-        start = pos + matched_text.size
-      else
-        start = pos
-      end
-      break if pos == text.size
     end
+    # If the start positions are the same, prefer the one with higher priority (registered earlier one)
+    matched.sort_by! {|beg_pos, _, _, _, priority| [beg_pos, priority] }
+
+    pos = 0
+    output = []
+    matched.each do |beg_pos, end_pos, s, name|
+      next if beg_pos < pos
+
+      output << [text[pos...beg_pos], false] if beg_pos != pos
+      handled = public_send(:"handle_regexp_#{name}", s)
+      output << [handled, true]
+      pos = end_pos
+    end
+
+    output << [text[pos..], false] if pos < text.size
     output
   end
 

--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -93,7 +93,8 @@ class RDoc::Markup::Formatter
         matched << [m.begin(idx), m.end(idx), m[idx], name, priority]
       end
     end
-    # If the start positions are the same, prefer the one with higher priority (registered earlier one)
+    # If the start positions are the same, prefer the earlier-registered one
+    # (lower numeric priority from each_with_index).
     matched.sort_by! {|beg_pos, _, _, _, priority| [beg_pos, priority] }
 
     pos = 0


### PR DESCRIPTION
Scanning regexp handling that I implemented in #1559 was not performant.

1. Run `string.scan` for each regexp handling once
2. Collect matched locations
3. Scan collected location from the beginning