### PR TITLE
Implement escapes in Markdown to RDoc conversion

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -303,6 +303,20 @@
     end
   end
 
+  # Escape character that has special meaning in RDoc format.
+  # To allow rdoc-styled link used in markdown format for now, bracket and brace are not escaped.
+
+  def rdoc_escape(text)
+    text.gsub(/[*+<\\_]/) {|s| "\\#{s}" }
+  end
+
+  # Escape link url that contains brackets.
+  # Brackets needs escape because link url will be surrounded by `[]` in RDoc format.
+
+  def rdoc_link_url_escape(text)
+    text.gsub(/[\[\]\\]/) {|s| "\\#{s}" }
+  end
+
   ##
   # :category: Extensions
   #
@@ -969,11 +983,11 @@ Space = @Spacechar+ { " " }
 
 Str = @StartList:a
       < @NormalChar+ > { a = text }
-      ( StrChunk:c { a << c } )* { a }
+      ( StrChunk:c { a << c } )* { rdoc_escape(a) }
 
 StrChunk = < (@NormalChar | /_+/ &Alphanumeric)+ > { text }
 
-EscapedChar =   "\\" !@Newline < /[:\\`|*_{}\[\]()#+.!><-]/ > { text }
+EscapedChar =   "\\" !@Newline < /[:\\`|*_{}\[\]()#+.!><-]/ > { rdoc_escape(text) }
 
 Entity =    ( HexEntity | DecEntity | CharEntity ):a { a }
 
@@ -988,7 +1002,7 @@ TerminalEndline = @Sp @Newline @Eof
 LineBreak = "  " @NormalEndline { RDoc::Markup::HardBreak.new }
 
 Symbol = < @SpecialChar >
-         { text }
+         { rdoc_escape(text) }
 
 # This keeps the parser from getting bogged down on long strings of '*' or '_',
 # or strings of '*' or '_' with space on each side:
@@ -1053,7 +1067,7 @@ ReferenceLinkSingle = Label:content < (Spnl "[]")? >
                       { link_to content, content, text }
 
 ExplicitLink = ExplicitLinkWithLabel:a
-               { "{#{a[:label]}}[#{a[:link]}]" }
+               { "{#{a[:label]}}[#{rdoc_link_url_escape(a[:link])}]" }
 
 ExplicitLinkWithLabel = Label:label "(" @Sp Source:link Spnl Title @Sp ")"
                         { { label: label, link: link } }
@@ -1163,12 +1177,12 @@ Newline           = %literals.Newline
 Spacechar         = %literals.Spacechar
 
 HexEntity  = /&#x/i < /[0-9a-fA-F]+/ > ";"
-             { [text.to_i(16)].pack 'U' }
+             { rdoc_escape([text.to_i(16)].pack('U')) }
 DecEntity  = "&#"   < /[0-9]+/       > ";"
-             { [text.to_i].pack 'U' }
+             { rdoc_escape([text.to_i].pack('U')) }
 CharEntity = "&"    </[A-Za-z0-9]+/  > ";"
              { if entity = HTML_ENTITIES[text] then
-                 entity.pack 'U*'
+                 rdoc_escape(entity.pack('U*'))
                else
                  "&#{text};"
                end

--- a/lib/rdoc/markup/inline_parser.rb
+++ b/lib/rdoc/markup/inline_parser.rb
@@ -303,9 +303,10 @@ class RDoc::Markup::InlineParser
   # Returns nil if no valid URL part is found.
   # URL part is enclosed in square brackets and may contain escaped brackets.
   # Example: <tt>[http://example.com/?q=\[\]]</tt> represents <tt>http://example.com/?q=[]</tt>.
+  # If we're accepting rdoc-style links in markdown, url may include <tt>*+<_</tt> with backslash escape.
 
   def read_tidylink_url
-    bracketed_url = strscan(/\[([^\s\[\]\\]|\\[\[\]\\])+\]/)
+    bracketed_url = strscan(/\[([^\s\[\]\\]|\\[\[\]\\*+<_])+\]/)
     bracketed_url[1...-1].gsub(/\\(.)/, '\1') if bracketed_url
   end
 end

--- a/test/rdoc/markup/to_html_test.rb
+++ b/test/rdoc/markup/to_html_test.rb
@@ -736,6 +736,22 @@ EXPECTED
     assert_equal expected, result
   end
 
+  def test_convert_TIDYLINK_url_unescape
+    # markdown: [{label}](http://example.com/foo?q=bar+baz[])
+    result = @to.convert '{\{label\}}[http://example.com/_foo?q=bar+baz\[\]]'
+    expected = "\n<p><a href=\"http://example.com/_foo?q=bar+baz[]\">{label}</a></p>\n"
+    assert_equal expected, result
+  end
+
+  def test_convert_TIDYLINK_rdoc_in_markdown_url_unescape
+    # markdown: {label}[http://example.com/?q=<+_*]
+    # The ubove text is a plain text in markdown, so <+_* are escaped in HTML.
+    # If we're accepting rdoc-style link in markdown, these escape should be allowed in [url] part.
+    result = @to.convert '{label}[http://example.com/?q=\<\+\_\*]'
+    expected = "\n<p><a href=\"http://example.com/?q=&lt;+_*\">label</a></p>\n"
+    assert_equal expected, result
+  end
+
   def test_convert_TIDYLINK_with_code_label
     result = @to.convert '{Link to +Foo+}[https://example.com]'
 

--- a/test/rdoc/rdoc_markdown_test_test.rb
+++ b/test/rdoc/rdoc_markdown_test_test.rb
@@ -25,7 +25,7 @@ class RDocMarkdownTestTest < RDoc::TestCase
         para("AT&T has an ampersand in their name."),
         para("AT&T is another way to write it."),
         para("This & that."),
-        para("4 < 5."),
+        para("4 \\< 5."),
         para("6 > 5."),
         para("Here's a {link}[http://example.com/?foo=1&bar=2] with " +
              "an ampersand in the URL."),
@@ -69,10 +69,10 @@ class RDocMarkdownTestTest < RDoc::TestCase
       doc(
         para("These should all get escaped:"),
 
-        para("Backslash: \\"),
+        para("Backslash: \\\\"),
         para("Backtick: `"),
-        para("Asterisk: *"),
-        para("Underscore: _"),
+        para("Asterisk: \\*"),
+        para("Underscore: \\_"),
         para("Left brace: {"),
         para("Right brace: }"),
         para("Left bracket: ["),
@@ -83,7 +83,7 @@ class RDocMarkdownTestTest < RDoc::TestCase
         para("Hash: #"),
         para("Period: ."),
         para("Bang: !"),
-        para("Plus: +"),
+        para("Plus: \\+"),
         para("Minus: -"),
 
         para("These should not, because they occur within a code block:"),
@@ -142,8 +142,8 @@ class RDocMarkdownTestTest < RDoc::TestCase
         para("These should get escaped, even though they're matching pairs for\n" +
              "other Markdown constructs:"),
 
-        para("\*asterisks\*"),
-        para("\_underscores\_"),
+        para("\\*asterisks\\*"),
+        para("\\_underscores\\_"),
         para("`backticks`"),
 
         para("This is a code span with a literal backslash-backtick " +
@@ -227,7 +227,7 @@ class RDocMarkdownTestTest < RDoc::TestCase
              "middle of a paragraph looked like a\n"    +
              "list item."),
         para("Here's one with a bullet.\n" +
-             "* criminey."))
+             "\\* criminey."))
 
     assert_equal expected, doc
   end
@@ -866,7 +866,7 @@ foo
         para("To this end, Markdown's syntax is comprised entirely of punctuation\n" +
              "characters, which punctuation characters have been carefully chosen so\n" +
              "as to look like what they mean. E.g., asterisks around a word actually\n" +
-             "look like \*emphasis\*. Markdown lists look like, well, lists. Even\n" +
+             "look like \\*emphasis\\*. Markdown lists look like, well, lists. Even\n" +
              "blockquotes look like quoted passages of text, assuming you've ever\n" +
              "used email."),
 


### PR DESCRIPTION
Fixes #919

Plain text part of parsed markdown may contain special characters (example: `+_*<`).
URL in tidy link may contain `[]`.
These characters need escape.

`{}[]` also needs escape, but not escaped in this pull request. RDoc-style tidylink in markdown is still available for now.
