### PR TITLE
Warn when :nodoc: appears on standalone line

### DIFF
--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -223,6 +223,10 @@ class RDoc::Markup::PreProcess
       blankline
     when 'nodoc' then
       return blankline unless code_object
+      if prefix.strip.empty? || prefix.strip == '#'
+        warn ":nodoc: on a standalone line may not work as intended. " \
+             "Append it to the line defining the class, method, or constant."
+      end
       code_object.document_self = nil # notify nodoc
       code_object.document_children = param !~ /all/i
 

--- a/test/rdoc/markup/pre_process_test.rb
+++ b/test/rdoc/markup/pre_process_test.rb
@@ -313,6 +313,28 @@ contents of a string.
     assert_equal "\n", result
   end
 
+  def test_handle_directive_nodoc_standalone_warns
+    code_object = RDoc::CodeObject.new
+
+    _, err = capture_output do
+      @pp.handle_directive '', 'nodoc', nil, code_object
+    end
+
+    assert_match(/standalone/, err,
+      ':nodoc: on a standalone line should emit a warning')
+  end
+
+  def test_handle_directive_nodoc_with_code_prefix_no_warning
+    code_object = RDoc::CodeObject.new
+
+    _, err = capture_output do
+      @pp.handle_directive 'def foo ', 'nodoc', nil, code_object
+    end
+
+    refute_match(/standalone/, err,
+      ':nodoc: with code prefix should NOT emit a warning')
+  end
+
   def test_handle_directive_registered
     RDoc::Markup::PreProcess.register 'x'
 


### PR DESCRIPTION
I misused `:nodoc:` and spent time debugging before finding my error. This patch adds a warning for others who might do the same.

The problem:

```ruby
class Foo
  VISIBLE_CONST = :hello

  # :nodoc:
  HIDDEN_CONST = :bar

  def visible_method
  end
end
```

I expected only the constant to be hidden. Instead, `visible_method` also disappeared from my documentation.

The documentation says `:nodoc:` should be appended inline. This works correctly:

```ruby
HIDDEN_CONST = :bar # :nodoc:
```

Since the standalone form is accepted silently but produces surprising results, this patch emits a warning when the pattern is detected.

I am glad to adjust the implementation or wording. If this does not fit RDoc's direction, please close it.

---

[This issue includes creative contributions from Claude (Anthropic).](https://declare-ai.org/1.0.0/creative.html)