### PR TITLE
Change PrismRuby not to depend on hack that stores module nesting information to context.parent

### DIFF
--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -785,7 +785,10 @@ class RDoc::Context < RDoc::CodeObject
   end
 
   ##
-  # Find a module at a higher scope
+  # Tries to find a module at a higher scope.
+  # But parent is not always a higher module nesting scope, so the result is not correct.
+  # Parent chain can only represent last-opened nesting, and may be broken in some cases.
+  # PrismRuby parser stopped representing module nesting with parent chain at all.
 
   def find_enclosing_module_named(name)
     parent && parent.find_module_named(name)
@@ -860,13 +863,21 @@ class RDoc::Context < RDoc::CodeObject
   end
 
   ##
-  # Find a module with +name+ using ruby's scoping rules
+  # Find a module with +name+ trying to using ruby's scoping rules.
+  # find_enclosing_module_named cannot use ruby's scoping so the result is not correct.
 
   def find_module_named(name)
-    res = @modules[name] || @classes[name]
+    res = get_module_named(name)
     return res if res
     return self if self.name == name
     find_enclosing_module_named name
+  end
+
+  # Get a module named +name+ in this context
+  # Don't look up for higher module nesting scopes. RDoc::Context doesn't have that information.
+
+  def get_module_named(name)
+    @modules[name] || @classes[name]
   end
 
   ##

--- a/lib/rdoc/code_object/mixin.rb
+++ b/lib/rdoc/code_object/mixin.rb
@@ -71,6 +71,9 @@ class RDoc::Mixin < RDoc::CodeObject
   # lookup behavior.
   #
   # As of the beginning of October, 2011, no gem includes nonexistent modules.
+  #
+  # When mixin is created from RDoc::Parser::PrismRuby, module name is already a resolved full-path name.
+  #
 
   def module
     return @module if @module

--- a/lib/rdoc/code_object/top_level.rb
+++ b/lib/rdoc/code_object/top_level.rb
@@ -149,6 +149,8 @@ class RDoc::TopLevel < RDoc::Context
     find_class_or_module(name)
   end
 
+  alias get_module_named find_module_named
+
   ##
   # Returns the relative name of this file
 

--- a/test/rdoc/parser/prism_ruby_test.rb
+++ b/test/rdoc/parser/prism_ruby_test.rb
@@ -1746,6 +1746,7 @@ module RDocParserPrismTestCases
   end
 
   def test_include_with_module_nesting
+    omit 'not implemented' if accept_legacy_bug?
     util_parser <<~RUBY
       module A
         module M; end
@@ -1765,15 +1766,16 @@ module RDocParserPrismTestCases
           include M
         end
       end
-      # TODO: make test pass with the following code appended
-      # module A::B::C
-      #   class D::Foo
-      #     include M
-      #   end
-      # end
+
+      module A::B::C
+        class D::Foo
+          include M
+        end
+      end
     RUBY
     klass = @store.find_class_named 'A::B::C::D::Foo'
-    assert_equal 'A::B::M', klass.includes.first.module.full_name
+    assert_equal 'A::B::M', klass.includes[0].module.full_name
+    assert_equal 'A::B::C::M', klass.includes[1].module.full_name
   end
 
   def test_various_argument_include


### PR DESCRIPTION
Closes #1291

All constant/module/class paths are resolved by PrismRuby parser itself.
Resolves include/extend module name before adding it because `Context#parent` will not have an information for delayed full-path name resolve.