### PR TITLE
Fix not scrolling in search results when `ArrowUp` or `ArrowDown` for `Aliki`

### DIFF
--- a/lib/rdoc/generator/template/aliki/js/aliki.js
+++ b/lib/rdoc/generator/template/aliki/js/aliki.js
@@ -70,8 +70,6 @@ function createSearchInstance(input, result) {
     window.location.href = result.firstChild.firstChild.href;
   }
 
-  search.scrollIntoView = search.scrollInWindow;
-
   return search;
 }
 

--- a/lib/rdoc/generator/template/aliki/js/search_controller.js
+++ b/lib/rdoc/generator/template/aliki/js/search_controller.js
@@ -96,7 +96,7 @@ SearchController.prototype = Object.assign({}, SearchNavigation, new function() 
       this.current.classList.remove('search-selected');
       next.classList.add('search-selected');
       this.input.setAttribute('aria-activedescendant', next.getAttribute('id'));
-      this.scrollIntoView(next, this.view);
+      this.scrollInElement(next, this.result);
       this.current = next;
       this.input.value = next.firstChild.firstChild.text;
       this.input.select();


### PR DESCRIPTION
If we use Up arrow key or Down arrow key in search results, the scroll bar doesn't scroll, instead, the scroll bar of the whole page scroll. 

This PR fixes it. 