### PR TITLE
Add example of :method: directive getting ignored.

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -131,8 +131,8 @@ require_relative 'ripper_state_lex'
 #
 # == Hidden methods and attributes
 #
-# You can provide documentation for methods that don't appear using
-# the :method:, :singleton-method: and :attr: directives:
+# You can provide documentation for methods that don't appear in the code
+# using the :method:, :singleton-method: and :attr: directives:
 #
 #   ##
 #   # :attr_writer: ghost_writer
@@ -148,8 +148,13 @@ require_relative 'ripper_state_lex'
 #   def regular_method() end
 #
 # Note that by default, the :method: directive will be ignored if there is a
-# standard rdocable item following it.
-
+# standard rdocable item following it:
+#
+#   ##
+#   # :method: ghost_method
+#   # ghost_method will be ignored.
+#
+#   def standard_rdocable_method() end
 class RDoc::Parser::Ruby < RDoc::Parser
 
   parse_files_matching(/\.rbw?$/)


### PR DESCRIPTION
Also make the comment about hidden methods slightly clearer — these
methods don't appear in the code, but they appear in the generated
documentation.