### PR TITLE
Fix accept_table with incomplete rows

### DIFF
--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -243,7 +243,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
     header = header.map { |h| attributes h }
     body = body.map { |row| row.map { |t| attributes t } }
     widths = header.zip(*body).map do |cols|
-      cols.map { |col| calculate_text_width(col) }.max
+      cols.compact.map { |col| calculate_text_width(col) }.max
     end
     aligns = aligns.map do |a|
       case a
@@ -261,7 +261,8 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
     end.join("|").rstrip << "\n"
     @res << widths.map {|w| "-" * w }.join("|") << "\n"
     body.each do |row|
-      @res << row.zip(widths, aligns).map do |t, w, a|
+      @res << widths.zip(aligns).each_with_index.map do |(w, a), i|
+        t = row[i] || ""
         extra_width = t.size - calculate_text_width(t)
         t.__send__(a, w + extra_width)
       end.join("|").rstrip << "\n"

--- a/test/rdoc/markup/to_ansi_test.rb
+++ b/test/rdoc/markup/to_ansi_test.rb
@@ -348,6 +348,16 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_ragged_rows
+    expected = "\e[0m" + <<-EXPECTED
+Name|Description
+----|---------------
+foo |Foo description
+bar |
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   def accept_table_align
     expected = "\e[0m" + <<-EXPECTED
  AA |BB |CCCCC|DDDDD

--- a/test/rdoc/markup/to_bs_test.rb
+++ b/test/rdoc/markup/to_bs_test.rb
@@ -349,6 +349,16 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_ragged_rows
+    expected = <<-EXPECTED
+Name|Description
+----|---------------
+foo |Foo description
+bar |
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   def accept_table_align
     expected = <<-EXPECTED
  AA |BB |CCCCC|DDDDD

--- a/test/rdoc/markup/to_markdown_test.rb
+++ b/test/rdoc/markup/to_markdown_test.rb
@@ -346,6 +346,16 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_ragged_rows
+    expected = <<-EXPECTED
+Name|Description
+----|---------------
+foo |Foo description
+bar |
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   def accept_table_align
     expected = <<-EXPECTED
  AA |BB |CCCCC|DDDDD

--- a/test/rdoc/markup/to_rdoc_test.rb
+++ b/test/rdoc/markup/to_rdoc_test.rb
@@ -375,6 +375,16 @@ words words words words
     assert_equal expected, @to.end_accepting
   end
 
+  def accept_table_ragged_rows
+    expected = <<-EXPECTED
+Name|Description
+----|---------------
+foo |Foo description
+bar |
+    EXPECTED
+    assert_equal expected, @to.end_accepting
+  end
+
   def accept_table_align
     expected = <<-EXPECTED
  AA |BB |   CCCCC|   DDDDD

--- a/test/rdoc/support/text_formatter_test_case.rb
+++ b/test/rdoc/support/text_formatter_test_case.rb
@@ -117,6 +117,23 @@ class RDoc::Markup::TextFormatterTestCase < RDoc::Markup::FormatterTestCase
       end
 
       ##
+      # Test case that calls <tt>@to.accept_table</tt> with body rows
+      # that have fewer columns than the header
+
+      def test_accept_table_ragged_rows
+        header = ['Name', 'Description']
+        body = [
+          ['foo', 'Foo description'],
+          ['bar'],
+        ]
+        aligns = [:left, :left]
+        @to.start_accepting
+        @to.accept_table header, body, aligns
+
+        accept_table_ragged_rows
+      end
+
+      ##
       # Test case that calls <tt>@to.attributes</tt> with an escaped
       # cross-reference.  If this test doesn't pass something may be very
       # wrong.


### PR DESCRIPTION
`header.zip(*body)` pads shorter rows with nil, causing NoMethodError in column width calculation. Also fix body rendering to output the correct number of columns for short rows instead of silently dropping them.