### PR TITLE
Fix sections not displaying their text

### DIFF
--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -587,7 +587,7 @@ class RDoc::Context < RDoc::CodeObject
     if section = @sections[title] then
       section.add_comment comment if comment
     else
-      section = Section.new self, title, comment
+      section = Section.new self, title, comment, @store
       @sections[title] = section
     end
 

--- a/lib/rdoc/code_object/context/section.rb
+++ b/lib/rdoc/code_object/context/section.rb
@@ -18,11 +18,6 @@ class RDoc::Context::Section
   MARSHAL_VERSION = 0 # :nodoc:
 
   ##
-  # Section comment
-
-  attr_reader :comment
-
-  ##
   # Section comments
 
   attr_reader :comments
@@ -38,11 +33,17 @@ class RDoc::Context::Section
   attr_reader :title
 
   ##
+  # The RDoc::Store for this object.
+
+  attr_reader :store
+
+  ##
   # Creates a new section with +title+ and +comment+
 
-  def initialize(parent, title, comment)
+  def initialize(parent, title, comment, store = nil)
     @parent = parent
     @title = title ? title.strip : title
+    @store = store
 
     @comments = []
 
@@ -151,7 +152,7 @@ class RDoc::Context::Section
     [
       MARSHAL_VERSION,
       @title,
-      parse,
+      to_document,
     ]
   end
 
@@ -169,7 +170,7 @@ class RDoc::Context::Section
   # Parses +comment_location+ into an RDoc::Markup::Document composed of
   # multiple RDoc::Markup::Documents with their file set.
 
-  def parse
+  def to_document
     RDoc::Markup::Document.new(*@comments.map(&:parse))
   end
 
@@ -180,6 +181,23 @@ class RDoc::Context::Section
 
   def plain_html
     @title || 'Top Section'
+  end
+
+  ##
+  # Section comment
+
+  def comment
+    return nil if @comments.empty?
+    RDoc::Comment.from_document(to_document)
+  end
+
+  def description
+    return '' if @comments.empty?
+    markup comment
+  end
+
+  def language
+    @comments.first&.language
   end
 
   ##

--- a/test/rdoc/rdoc_context_section_test.rb
+++ b/test/rdoc/rdoc_context_section_test.rb
@@ -40,6 +40,25 @@ class RDocContextSectionTest < RDoc::TestCase
     assert_equal [c2, c3], s.comments
   end
 
+  def test_description
+    file1 = @store.add_file 'file1.rb'
+    klass = file1.add_class RDoc::NormalClass, 'Klass'
+
+
+    c1 = comment "# :section: section\n", file1, :ruby
+    c2 = comment "# hello\n",             file1, :ruby
+    c3 = comment "# <tt>world</tt>\n",    file1, :ruby
+
+    s = @S.new klass, 'section', c1, @store
+    assert_equal '', s.description
+
+    s.add_comment c2
+    assert_equal "\n<p>hello</p>\n", s.description
+
+    s.add_comment c3
+    assert_equal "\n<p>hello</p>\n\n<p><code>world</code></p>\n", s.description
+  end
+
   def test_aref
     assert_equal 'section', @s.aref
 
@@ -86,7 +105,7 @@ class RDocContextSectionTest < RDoc::TestCase
     expected = doc RDoc::Comment.new('comment', @top_level).parse
 
     assert_equal 'section', loaded.title
-    assert_equal expected,  loaded.parse
+    assert_equal expected,  loaded.to_document
     assert_nil              loaded.parent, 'parent is set manually'
   end
 
@@ -112,7 +131,7 @@ class RDocContextSectionTest < RDoc::TestCase
     expected = doc RDoc::Comment.new('comment', @top_level).parse
 
     assert_equal 'section', loaded.title
-    assert_equal expected,  loaded.parse
+    assert_equal expected,  loaded.to_document
     assert_nil              loaded.parent, 'parent is set manually'
   end
 
@@ -139,7 +158,7 @@ class RDocContextSectionTest < RDoc::TestCase
 
     loaded.remove_comment comment('bogus', @top_level)
 
-    assert_equal doc(other_comment.parse), loaded.parse
+    assert_equal doc(other_comment.parse), loaded.to_document
   end
 
 end


### PR DESCRIPTION
I'm currently trying to group methods in the prism docs by topic like "location related", " flag related", etc. so that methods not related to these conceps show up more prominently (not mixed in with potentially many other methods). But I noticed that sections do not currently show their comment.

There were a few things wrong that made this not work:
* Formatting expects `@comment` but there is only `@comments`
* The parse method used for marshaling overwrote the markdown parse method
* `@store` was not present, which the formatter requires

Comments can be added/removed, so there still needs to be the array to make it possible to properly modify the section.

Fixes #345, Closes #936

On https://docs.ruby-lang.org/en/master/Prism/Node.html#node-interface there is actually already a comment but it gets swallowed. With this change, it gets properly rendered:

<img width="772" height="143" alt="image" src="https://github.com/user-attachments/assets/70885890-8ebc-48a8-9fde-f2fc8526cee1" />
