### PR TITLE
Add unique IDs to section headings in Aliki template

### DIFF
--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -40,10 +40,10 @@
 
   <%- klass.each_section do |section, constants, attributes| %>
   <span id="<%= section.legacy_aref %>" class="legacy-anchor"></span>
-  <section id="<%= section.aref %>" class="documentation-section anchor-link">
+  <section class="documentation-section anchor-link">
     <%- if section.title then %>
     <header class="documentation-section-title">
-      <h2>
+      <h2 id="<%= section.aref %>">
         <a href="#<%= section.aref %>"><%= section.title %></a>
       </h2>
     </header>
@@ -58,7 +58,7 @@
     <%- unless constants.empty? then %>
     <section class="constants-list">
       <header>
-        <h3 id="constants"><a href="#constants">Constants</a></h3>
+        <h3 id="<%= section.aref %>-constants"><a href="#<%= section.aref %>-constants">Constants</a></h3>
       </header>
       <dl>
       <%- constants.each do |const| %>
@@ -83,7 +83,7 @@
     <%- unless attributes.empty? then %>
     <section class="attribute-method-details method-section">
       <header>
-        <h3 id="attributes"><a href="#attributes">Attributes</a></h3>
+        <h3 id="<%= section.aref %>-attributes"><a href="#<%= section.aref %>-attributes">Attributes</a></h3>
       </header>
 
       <%- attributes.each do |attrib| %>
@@ -118,7 +118,7 @@
     <%- next if methods.empty? %>
      <section id="<%= visibility %>-<%= type %>-<%= section.aref %>-method-details" class="method-section anchor-link">
        <header>
-         <h3 id="<%= visibility %>-<%= type %>-methods"><a href="#<%= visibility %>-<%= type %>-methods"><%= visibility.to_s.capitalize %> <%= type.capitalize %> Methods</a></h3>
+         <h3 id="<%= visibility %>-<%= type %>-<%= section.aref %>-methods"><a href="#<%= visibility %>-<%= type %>-<%= section.aref %>-methods"><%= visibility.to_s.capitalize %> <%= type.capitalize %> Methods</a></h3>
        </header>
 
     <%- methods.each do |method| %>


### PR DESCRIPTION
The Aliki TOC is generated by JavaScript that scans h1/h2/h3 elements with IDs. Section title h2 elements had no ID, so they were invisible to the TOC. Meanwhile, h3 IDs like "constants" and "public-instance-methods" were duplicated across sections.

Prefix all heading IDs with the section's aref to make them unique. Move the section ID from the `<section>` element to the `<h2>` so the TOC picks it up naturally.

<img width="250" height="291" alt="Screenshot 2026-02-08 at 10 20 30" src="https://github.com/user-attachments/assets/b399fb90-ff1a-46b9-838c-61576c6acc2c" />


Fixes #1598