### PR TITLE
Fix RDoc::Attr#add_alias handling of aliased attribute accessor

### DIFF
--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -43,7 +43,8 @@ class RDoc::Attr < RDoc::MethodAttr
   # Add +an_alias+ as an attribute in +context+.
 
   def add_alias(an_alias, context)
-    new_attr = self.class.new(text, an_alias.new_name, rw, comment, singleton: singleton)
+    access_type = an_alias.new_name.end_with?('=') ? 'W' : 'R'
+    new_attr = self.class.new(text, an_alias.new_name, access_type, comment, singleton: singleton)
     new_attr.record_location an_alias.file
     new_attr.visibility = self.visibility
     new_attr.is_alias_for = self

--- a/test/rdoc/code_object/attr_test.rb
+++ b/test/rdoc/code_object/attr_test.rb
@@ -187,4 +187,18 @@ class RDocAttrTest < RDoc::TestCase
     assert_equal 'class', @a.type
   end
 
+  [
+    ['bar', 'baz', 'R'],
+    ['bar=', 'baz=', 'W']
+  ].each do |original_name, new_name, expected_rw|
+    define_method("test_add_alias_#{new_name}_for_an_attribute_accessor") do
+      context = RDoc::Context.new
+      attr = RDoc::Attr.new nil, 'bar', 'RW', ''
+      an_alias = RDoc::Alias.new nil, original_name, new_name, ''
+
+      new_attr = attr.add_alias an_alias, context
+
+      assert_equal expected_rw, new_attr.rw
+    end
+  end
 end


### PR DESCRIPTION
Ensure aliased attr_accessor attributes have the correct access type ('R' or 'W') instead of always being 'RW'.

For more details on the issue being addressed, see https://github.com/ruby/rdoc/issues/1286#issuecomment-3794521252.