### PR TITLE
rubocop --autocorrect

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -173,7 +173,7 @@ class RDoc::Generator::Darkfish
   ##
   # Output progress information if debugging is enabled
 
-  def debug_msg *msg
+  def debug_msg(*msg)
     return unless $DEBUG_RDOC
     $stderr.puts(*msg)
   end

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -118,7 +118,7 @@ class RDoc::Generator::JsonIndex
   ##
   # Output progress information if debugging is enabled
 
-  def debug_msg *msg
+  def debug_msg(*msg)
     return unless $DEBUG_RDOC
     $stderr.puts(*msg)
   end

--- a/lib/rdoc/markup/document.rb
+++ b/lib/rdoc/markup/document.rb
@@ -26,7 +26,7 @@ class RDoc::Markup::Document
   ##
   # Creates a new Document with +parts+
 
-  def initialize *parts
+  def initialize(*parts)
     @parts = []
     @parts.concat parts
 
@@ -148,7 +148,7 @@ class RDoc::Markup::Document
   ##
   # Appends +parts+ to the document
 
-  def push *parts
+  def push(*parts)
     self.parts.concat parts
   end
 

--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -252,7 +252,7 @@ class RDoc::Markup::Formatter
   #
   #   alias accept_raw ignore
 
-  def ignore *node
+  def ignore(*node)
   end
 
   ##

--- a/lib/rdoc/markup/indented_paragraph.rb
+++ b/lib/rdoc/markup/indented_paragraph.rb
@@ -13,7 +13,7 @@ class RDoc::Markup::IndentedParagraph < RDoc::Markup::Raw
   # Creates a new IndentedParagraph containing +parts+ indented with +indent+
   # spaces
 
-  def initialize indent, *parts
+  def initialize(indent, *parts)
     @indent = indent
 
     super(*parts)

--- a/lib/rdoc/markup/list.rb
+++ b/lib/rdoc/markup/list.rb
@@ -37,7 +37,7 @@ class RDoc::Markup::List
   # Creates a new list of +type+ with +items+.  Valid list types are:
   # +:BULLET+, +:LABEL+, +:LALPHA+, +:NOTE+, +:NUMBER+, +:UALPHA+
 
-  def initialize type = nil, *items
+  def initialize(type = nil, *items)
     @type = type
     @items = []
     @items.concat items
@@ -94,7 +94,7 @@ class RDoc::Markup::List
   ##
   # Appends +items+ to the list
 
-  def push *items
+  def push(*items)
     @items.concat items
   end
 

--- a/lib/rdoc/markup/list_item.rb
+++ b/lib/rdoc/markup/list_item.rb
@@ -24,7 +24,7 @@ class RDoc::Markup::ListItem
   ##
   # Creates a new ListItem with an optional +label+ containing +parts+
 
-  def initialize label = nil, *parts
+  def initialize(label = nil, *parts)
     @label = label
     @parts = []
     @parts.concat parts
@@ -92,7 +92,7 @@ class RDoc::Markup::ListItem
   ##
   # Adds +parts+ to the ListItem
 
-  def push *parts
+  def push(*parts)
     @parts.concat parts
   end
 

--- a/lib/rdoc/markup/verbatim.rb
+++ b/lib/rdoc/markup/verbatim.rb
@@ -9,7 +9,7 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
 
   attr_accessor :format
 
-  def initialize *parts # :nodoc:
+  def initialize(*parts) # :nodoc:
     super
 
     @format = nil

--- a/lib/rdoc/ri/paths.rb
+++ b/lib/rdoc/ri/paths.rb
@@ -30,7 +30,7 @@ module RDoc::RI::Paths
   # :extra:: ri data directory from the command line.  Yielded for each
   #          entry in +extra_dirs+
 
-  def self.each system = true, site = true, home = true, gems = :latest, *extra_dirs # :yields: directory, type
+  def self.each(system = true, site = true, home = true, gems = :latest, *extra_dirs) # :yields: directory, type
     return enum_for __method__, system, site, home, gems, *extra_dirs unless
       block_given?
 

--- a/lib/rdoc/servlet.rb
+++ b/lib/rdoc/servlet.rb
@@ -50,7 +50,7 @@ class RDoc::Servlet < WEBrick::HTTPServlet::AbstractServlet
   # Creates an instance of this servlet that shares cached data between
   # requests.
 
-  def self.get_instance server, *options # :nodoc:
+  def self.get_instance(server, *options) # :nodoc:
     stores = @server_stores[server]
 
     new server, stores, @cache, *options

--- a/test/rdoc/support/test_case.rb
+++ b/test/rdoc/support/test_case.rb
@@ -103,7 +103,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::BlockQuote.new with +contents+
 
-  def block *contents
+  def block(*contents)
     @RM::BlockQuote.new(*contents)
   end
 
@@ -119,7 +119,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Document.new with +contents+
 
-  def doc *contents
+  def doc(*contents)
     @RM::Document.new(*contents)
   end
 
@@ -140,14 +140,14 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::ListItem.new with +label+ and +parts+
 
-  def item label = nil, *parts
+  def item(label = nil, *parts)
     @RM::ListItem.new label, *parts
   end
 
   ##
   # Shortcut for RDoc::Markup::List.new with +type+ and +items+
 
-  def list type = nil, *items
+  def list(type = nil, *items)
     @RM::List.new type, *items
   end
 
@@ -163,7 +163,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Paragraph.new with +contents+
 
-  def para *a
+  def para(*a)
     @RM::Paragraph.new(*a)
   end
 
@@ -177,7 +177,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Raw.new with +contents+
 
-  def raw *contents
+  def raw(*contents)
     @RM::Raw.new(*contents)
   end
 
@@ -198,7 +198,7 @@ class RDoc::TestCase < Test::Unit::TestCase
   ##
   # Shortcut for RDoc::Markup::Verbatim.new with +parts+
 
-  def verb *parts
+  def verb(*parts)
     @RM::Verbatim.new(*parts)
   end
 


### PR DESCRIPTION
Apply autocorrect with the latest rubocop.
Old rubocop missed some "Style/MethodDefParentheses" offences that has splat or kwarg splat.

The following code didn't get `Style/MethodDefParentheses` offences in `rubocop <= 1.84.1`, fixed in `v1.84.2`
```ruby
def f a, b:, **c, &d
end

def g a, *b, c, d:, &e
end
```