### PR TITLE
Bump required ruby version to 2.7

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -63,7 +63,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files += s.files.grep(%r[\A[^\/]+\.(?:rdoc|md)\z])
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
   s.add_dependency 'psych', '>= 4.0.0'


### PR DESCRIPTION
Prism itself requires 2.7. No changes to CI, you only run tests against 3.0