### PR TITLE
Support constant assign parsed before class/module definition

### DIFF
--- a/lib/rdoc/code_object/constant.rb
+++ b/lib/rdoc/code_object/constant.rb
@@ -92,8 +92,16 @@ class RDoc::Constant < RDoc::CodeObject
       @is_alias_for = found if found
       @is_alias_for
     else
-      @is_alias_for
+      @is_alias_for ||= find_alias_for
     end
+  end
+
+  # Find alias constant for a value.
+  # This is used when the constant is parsed before the class or module defined in another file.
+  # Note that module nesting information is lost, so constant lookup is inaccurate.
+
+  def find_alias_for
+    parent.find_module_named(value) if value&.match?(/\A(::)?([A-Z][A-Za-z0-9_]*)(::[A-Z][A-Za-z0-9_]*)*\z/)
   end
 
   def inspect # :nodoc:

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -439,6 +439,7 @@ class RDoc::Context < RDoc::CodeObject
       known.value = constant.value if
         known.value.nil? or known.value.strip.empty?
 
+      constant.parent = self
       known.is_alias_for ||= constant.is_alias_for
     else
       @constants_hash[constant.name] = constant


### PR DESCRIPTION
Support `Const = RHS` parsed before `class RHS;end` defined in another file.

This will fix one document-coverage check failure in https://github.com/ruby/ruby/pull/16194
