### PR TITLE
Decouple Store internals from CodeObject classes

### DIFF
--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -291,19 +291,7 @@ class RDoc::CodeObject
     return @parent if @parent
     return nil unless @parent_name
 
-    if @parent_class == RDoc::TopLevel then
-      @parent = @store.add_file @parent_name
-    else
-      @parent = @store.find_class_or_module @parent_name
-
-      return @parent if @parent
-
-      begin
-        @parent = @store.load_class @parent_name
-      rescue RDoc::Store::MissingFileError
-        nil
-      end
-    end
+    @parent = @store&.resolve_parent(@parent_name, @parent_class)
   end
 
   ##
@@ -360,6 +348,10 @@ class RDoc::CodeObject
 
   def store=(store)
     @store = store
+
+    # When a CodeObject is loaded from Marshal data, its @file is a standalone
+    # TopLevel that needs to be replaced with the canonical one from the store.
+    @file = @store.add_file @file.full_name if @file && @store
 
     return unless @track_visibility
 

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -307,15 +307,6 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   end
 
   ##
-  # Sets the store for this method and its referenced code objects.
-
-  def store=(store)
-    super
-
-    @file = @store.add_file @file.full_name if @file
-  end
-
-  ##
   # For methods that +super+, find the superclass method that would be called.
 
   def superclass_method

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -702,12 +702,12 @@ class RDoc::ClassModule < RDoc::Context
 
     modules_hash.each_key do |name|
       full_name = prefix + name
-      modules_hash.delete name unless @store.modules_hash[full_name]
+      modules_hash.delete name unless @store.find_module_named(full_name)
     end
 
     classes_hash.each_key do |name|
       full_name = prefix + name
-      classes_hash.delete name unless @store.classes_hash[full_name]
+      classes_hash.delete name unless @store.find_class_named(full_name)
     end
   end
 
@@ -875,7 +875,7 @@ class RDoc::ClassModule < RDoc::Context
   def update_includes
     includes.reject! do |include|
       mod = include.module
-      !(String === mod) && @store.modules_hash[mod.full_name].nil?
+      !(String === mod) && @store.find_module_named(mod.full_name).nil?
     end
 
     includes.uniq!
@@ -891,7 +891,7 @@ class RDoc::ClassModule < RDoc::Context
     extends.reject! do |ext|
       mod = ext.module
 
-      !(String === mod) && @store.modules_hash[mod.full_name].nil?
+      !(String === mod) && @store.find_module_named(mod.full_name).nil?
     end
 
     extends.uniq!

--- a/lib/rdoc/code_object/constant.rb
+++ b/lib/rdoc/code_object/constant.rb
@@ -174,15 +174,6 @@ class RDoc::Constant < RDoc::CodeObject
     end
   end
 
-  ##
-  # Sets the store for this class or module and its contained code objects.
-
-  def store=(store)
-    super
-
-    @file = @store.add_file @file.full_name if @file
-  end
-
   def to_s # :nodoc:
     parent_name = parent ? parent.full_name : '(unknown)'
     if is_alias_for

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -147,15 +147,6 @@ class RDoc::MethodAttr < RDoc::CodeObject
     @see
   end
 
-  ##
-  # Sets the store for this class or module and its contained code objects.
-
-  def store=(store)
-    super
-
-    @file = @store.add_file @file.full_name if @file
-  end
-
   def find_see # :nodoc:
     return nil if singleton || is_alias_for
 
@@ -172,7 +163,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
     return nil unless parent.respond_to? :ancestors
 
     searched = parent.ancestors
-    kernel = @store.modules_hash['Kernel']
+    kernel = @store.find_module_named('Kernel')
 
     searched << kernel if kernel &&
       parent != kernel && !searched.include?(kernel)

--- a/lib/rdoc/code_object/mixin.rb
+++ b/lib/rdoc/code_object/mixin.rb
@@ -77,43 +77,9 @@ class RDoc::Mixin < RDoc::CodeObject
 
   def module
     return @module if @module
-
-    # search the current context
     return @name unless parent
-    full_name = parent.child_name(@name)
-    @module = @store.modules_hash[full_name]
-    return @module if @module
-    return @name if @name =~ /^::/
 
-    # search the includes before this one, in reverse order
-    searched = parent.includes.take_while { |i| i != self }.reverse
-    searched.each do |i|
-      inc = i.module
-      next if String === inc
-      full_name = inc.child_name(@name)
-      @module = @store.modules_hash[full_name]
-      return @module if @module
-    end
-
-    # go up the hierarchy of names
-    up = parent.parent
-    while up
-      full_name = up.child_name(@name)
-      @module = @store.modules_hash[full_name]
-      return @module if @module
-      up = up.parent
-    end
-
-    @name
-  end
-
-  ##
-  # Sets the store for this class or module and its contained code objects.
-
-  def store=(store)
-    super
-
-    @file = @store.add_file @file.full_name if @file
+    @module = @store&.resolve_mixin(@name, parent, self) || @name
   end
 
   def to_s # :nodoc:

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2016,8 +2016,8 @@ end
 
     @parser.parse_method m, RDoc::Parser::Ruby::NORMAL, tk, @comment
 
-    assert_empty @store.modules_hash.keys
-    assert_equal %w[M], @store.classes_hash.keys
+    assert_equal %w[M], @store.modules_hash.keys
+    assert_empty @store.classes_hash.keys
   end
 
   def test_parse_method_false


### PR DESCRIPTION
Move resolution logic out of CodeObjects into Store:
- Add `Store#resolve_parent` to encapsulate lazy parent loading (previously `CodeObject#parent` called `load_class` for disk I/O)
- Add `Store#resolve_mixin` to encapsulate namespace-walking (previously 30 lines of scoping logic lived in `Mixin#module`)

Consolidate file normalization in base `CodeObject#store=`:
- Remove redundant `store=` overrides from `MethodAttr`, `AnyMethod`, `Mixin`, and `Constant` that all did identical `add_file` calls
- Fix pre-existing bug where `AnyMethod` called `add_file` twice

Replace direct hash reads with existing finder methods:
- Use `find_class_or_module`, `find_class_named`, `find_module_named` instead of `@store.classes_hash[]` / `@store.modules_hash[]`

Simplify `add_class_or_module` signature:
- Drop the `all_hash` parameter that passed Store's internal hash by reference; method now registers directly via the hash accessors