### PR TITLE
Fix Markdown blockquote parsing

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -617,8 +617,8 @@ BlockQuote = BlockQuoteRaw:a
 
 BlockQuoteRaw =  @StartList:a
                  (( ">" " "? Line:l { a << l } )
-                  ( !">" !@BlankLine Line:c { a << c } )*
-                  ( @BlankLine:n { a << n } )*
+                  ( !">" !@BlankLine !(AtxStart @Spacechar) !Bullet !Enumerator !( &{ github? } Ticks3 ) Line:c { a << c } )*
+                  ( ">" @BlankLine:n { a << n } )*
                  )+
                  { inner_parse a.join }
 

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -1656,7 +1656,7 @@ class RDoc::Markdown
     return _tmp
   end
 
-  # BlockQuoteRaw = @StartList:a (">" " "? Line:l { a << l } (!">" !@BlankLine Line:c { a << c })* (@BlankLine:n { a << n })*)+ { inner_parse a.join }
+  # BlockQuoteRaw = @StartList:a (">" " "? Line:l { a << l } (!">" !@BlankLine !(AtxStart @Spacechar) !Bullet !Enumerator !(&{ github? } Ticks3) Line:c { a << c })* (">" @BlankLine:n { a << n })*)+ { inner_parse a.join }
   def _BlockQuoteRaw
 
     _save = self.pos
@@ -1718,6 +1718,68 @@ class RDoc::Markdown
               self.pos = _save5
               break
             end
+            _save8 = self.pos
+
+            _save9 = self.pos
+            while true # sequence
+              _tmp = apply(:_AtxStart)
+              unless _tmp
+                self.pos = _save9
+                break
+              end
+              _tmp = _Spacechar()
+              unless _tmp
+                self.pos = _save9
+              end
+              break
+            end # end sequence
+
+            _tmp = _tmp ? nil : true
+            self.pos = _save8
+            unless _tmp
+              self.pos = _save5
+              break
+            end
+            _save10 = self.pos
+            _tmp = apply(:_Bullet)
+            _tmp = _tmp ? nil : true
+            self.pos = _save10
+            unless _tmp
+              self.pos = _save5
+              break
+            end
+            _save11 = self.pos
+            _tmp = apply(:_Enumerator)
+            _tmp = _tmp ? nil : true
+            self.pos = _save11
+            unless _tmp
+              self.pos = _save5
+              break
+            end
+            _save12 = self.pos
+
+            _save13 = self.pos
+            while true # sequence
+              _save14 = self.pos
+              _tmp = begin;  github? ; end
+              self.pos = _save14
+              unless _tmp
+                self.pos = _save13
+                break
+              end
+              _tmp = apply(:_Ticks3)
+              unless _tmp
+                self.pos = _save13
+              end
+              break
+            end # end sequence
+
+            _tmp = _tmp ? nil : true
+            self.pos = _save12
+            unless _tmp
+              self.pos = _save5
+              break
+            end
             _tmp = apply(:_Line)
             c = @result
             unless _tmp
@@ -1741,18 +1803,23 @@ class RDoc::Markdown
         end
         while true
 
-          _save9 = self.pos
+          _save16 = self.pos
           while true # sequence
+            _tmp = match_string(">")
+            unless _tmp
+              self.pos = _save16
+              break
+            end
             _tmp = _BlankLine()
             n = @result
             unless _tmp
-              self.pos = _save9
+              self.pos = _save16
               break
             end
             @result = begin;  a << n ; end
             _tmp = true
             unless _tmp
-              self.pos = _save9
+              self.pos = _save16
             end
             break
           end # end sequence
@@ -1769,65 +1836,127 @@ class RDoc::Markdown
       if _tmp
         while true
 
-          _save10 = self.pos
+          _save17 = self.pos
           while true # sequence
             _tmp = match_string(">")
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
               break
             end
-            _save11 = self.pos
+            _save18 = self.pos
             _tmp = match_string(" ")
             unless _tmp
               _tmp = true
-              self.pos = _save11
+              self.pos = _save18
             end
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
               break
             end
             _tmp = apply(:_Line)
             l = @result
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
               break
             end
             @result = begin;  a << l ; end
             _tmp = true
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
               break
             end
             while true
 
-              _save13 = self.pos
+              _save20 = self.pos
               while true # sequence
-                _save14 = self.pos
+                _save21 = self.pos
                 _tmp = match_string(">")
                 _tmp = _tmp ? nil : true
-                self.pos = _save14
+                self.pos = _save21
                 unless _tmp
-                  self.pos = _save13
+                  self.pos = _save20
                   break
                 end
-                _save15 = self.pos
+                _save22 = self.pos
                 _tmp = _BlankLine()
                 _tmp = _tmp ? nil : true
-                self.pos = _save15
+                self.pos = _save22
                 unless _tmp
-                  self.pos = _save13
+                  self.pos = _save20
+                  break
+                end
+                _save23 = self.pos
+
+                _save24 = self.pos
+                while true # sequence
+                  _tmp = apply(:_AtxStart)
+                  unless _tmp
+                    self.pos = _save24
+                    break
+                  end
+                  _tmp = _Spacechar()
+                  unless _tmp
+                    self.pos = _save24
+                  end
+                  break
+                end # end sequence
+
+                _tmp = _tmp ? nil : true
+                self.pos = _save23
+                unless _tmp
+                  self.pos = _save20
+                  break
+                end
+                _save25 = self.pos
+                _tmp = apply(:_Bullet)
+                _tmp = _tmp ? nil : true
+                self.pos = _save25
+                unless _tmp
+                  self.pos = _save20
+                  break
+                end
+                _save26 = self.pos
+                _tmp = apply(:_Enumerator)
+                _tmp = _tmp ? nil : true
+                self.pos = _save26
+                unless _tmp
+                  self.pos = _save20
+                  break
+                end
+                _save27 = self.pos
+
+                _save28 = self.pos
+                while true # sequence
+                  _save29 = self.pos
+                  _tmp = begin;  github? ; end
+                  self.pos = _save29
+                  unless _tmp
+                    self.pos = _save28
+                    break
+                  end
+                  _tmp = apply(:_Ticks3)
+                  unless _tmp
+                    self.pos = _save28
+                  end
+                  break
+                end # end sequence
+
+                _tmp = _tmp ? nil : true
+                self.pos = _save27
+                unless _tmp
+                  self.pos = _save20
                   break
                 end
                 _tmp = apply(:_Line)
                 c = @result
                 unless _tmp
-                  self.pos = _save13
+                  self.pos = _save20
                   break
                 end
                 @result = begin;  a << c ; end
                 _tmp = true
                 unless _tmp
-                  self.pos = _save13
+                  self.pos = _save20
                 end
                 break
               end # end sequence
@@ -1836,23 +1965,28 @@ class RDoc::Markdown
             end
             _tmp = true
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
               break
             end
             while true
 
-              _save17 = self.pos
+              _save31 = self.pos
               while true # sequence
+                _tmp = match_string(">")
+                unless _tmp
+                  self.pos = _save31
+                  break
+                end
                 _tmp = _BlankLine()
                 n = @result
                 unless _tmp
-                  self.pos = _save17
+                  self.pos = _save31
                   break
                 end
                 @result = begin;  a << n ; end
                 _tmp = true
                 unless _tmp
-                  self.pos = _save17
+                  self.pos = _save31
                 end
                 break
               end # end sequence
@@ -1861,7 +1995,7 @@ class RDoc::Markdown
             end
             _tmp = true
             unless _tmp
-              self.pos = _save10
+              self.pos = _save17
             end
             break
           end # end sequence
@@ -16467,7 +16601,7 @@ class RDoc::Markdown
   Rules[:_SetextHeading2] = rule_info("SetextHeading2", "&(@RawLine SetextBottom2) @StartList:a (!@Endline Inline:b { a << b })+ @Sp @Newline SetextBottom2 { RDoc::Markup::Heading.new(2, a.join) }")
   Rules[:_Heading] = rule_info("Heading", "(SetextHeading | AtxHeading)")
   Rules[:_BlockQuote] = rule_info("BlockQuote", "BlockQuoteRaw:a { RDoc::Markup::BlockQuote.new(*a) }")
-  Rules[:_BlockQuoteRaw] = rule_info("BlockQuoteRaw", "@StartList:a (\">\" \" \"? Line:l { a << l } (!\">\" !@BlankLine Line:c { a << c })* (@BlankLine:n { a << n })*)+ { inner_parse a.join }")
+  Rules[:_BlockQuoteRaw] = rule_info("BlockQuoteRaw", "@StartList:a (\">\" \" \"? Line:l { a << l } (!\">\" !@BlankLine !(AtxStart @Spacechar) !Bullet !Enumerator !(&{ github? } Ticks3) Line:c { a << c })* (\">\" @BlankLine:n { a << n })*)+ { inner_parse a.join }")
   Rules[:_NonblankIndentedLine] = rule_info("NonblankIndentedLine", "!@BlankLine IndentedLine")
   Rules[:_VerbatimChunk] = rule_info("VerbatimChunk", "@BlankLine*:a NonblankIndentedLine+:b { a.concat b }")
   Rules[:_Verbatim] = rule_info("Verbatim", "VerbatimChunk+:a { RDoc::Markup::Verbatim.new(*a.flatten) }")

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -120,8 +120,91 @@ a block quote
     expected =
       doc(
         block(
-          para("this is\na block quote"),
+          para("this is\na block quote")),
+        block(
           para("that continues")))
+
+    assert_equal expected, doc
+  end
+
+  def test_parse_block_quote_no_lazy_continuation_for_heading
+    doc = parse <<~BLOCK_QUOTE
+      > foo
+      # bar
+    BLOCK_QUOTE
+
+    expected =
+      doc(
+        block(
+          para("foo")),
+        head(1, "bar"))
+
+    assert_equal expected, doc
+  end
+
+  def test_parse_block_quote_no_lazy_continuation_for_list
+    doc = parse <<~BLOCK_QUOTE
+      > foo
+      - bar
+    BLOCK_QUOTE
+
+    expected =
+      doc(
+        block(
+          para("foo")),
+        list(:BULLET,
+          item(nil, para("bar"))))
+
+    assert_equal expected, doc
+  end
+
+  def test_parse_block_quote_no_lazy_continuation_for_ordered_list
+    doc = parse <<~BLOCK_QUOTE
+      > foo
+      1. bar
+    BLOCK_QUOTE
+
+    expected =
+      doc(
+        block(
+          para("foo")),
+        list(:NUMBER,
+          item(nil, para("bar"))))
+
+    assert_equal expected, doc
+  end
+
+  def test_parse_block_quote_no_lazy_continuation_for_code_fence
+    doc = parse <<~BLOCK_QUOTE
+      > foo
+      ```
+      code
+      ```
+    BLOCK_QUOTE
+
+    expected =
+      doc(
+        block(
+          para("foo")),
+        verb("code\n"))
+
+    assert_equal expected, doc
+  end
+
+  def test_parse_block_quote_lazy_continuation_for_code_fence_non_github
+    @parser.github = false
+
+    doc = parse <<~BLOCK_QUOTE
+      > foo
+      ```
+      code
+      ```
+    BLOCK_QUOTE
+
+    expected =
+      doc(
+        block(
+          para("foo\n<code>\ncode\n</code>")))
 
     assert_equal expected, doc
   end


### PR DESCRIPTION
## Summary

Two fixes to the `BlockQuoteRaw` rule in the PEG grammar:

- Separate blockquotes (separated by an unquoted blank line) were merged into one. Now only blank lines prefixed with `>` continue the blockquote, so an unquoted blank line ends it.
- Lazy continuation was consuming block-level elements (headings, list markers, code fences) that should break out of the blockquote. Added negative lookaheads for these elements.

Ref: https://github.com/ruby/rdoc/pull/1550#discussion_r2665504990