### PR TITLE
Re-add truffleruby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     with:
       # 2.7 breaks `test_parse_statements_nodoc_identifier_alias_method`
       min_version: 3.0
-      engine: cruby-jruby
       versions: '["mswin"]'
 
   test:
@@ -27,6 +26,10 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
+          - os: windows-latest
+            ruby: truffleruby
+          - os: windows-latest
+            ruby: truffleruby-head
           - os: windows-latest
             ruby: jruby
           - os: windows-latest


### PR DESCRIPTION
* This reverts commit 776d04352917fd92d4a100b2a3e69c50739af836.
* See https://github.com/ruby/rdoc/pull/1586

> No one fix failure jobs over one month.

The CI failure was reported in https://github.com/truffleruby/truffleruby/issues/4094 and I did a lot of work to replace Ripper with `Prism::Translation::Ripper` in TruffleRuby and [improved `Prism::Translation::Ripper` to be compatible enough](https://github.com/ruby/prism/issues/3838).
There were only 6 days between report & fix.

It seems there was another failure after that, I found [this failing run](https://github.com/ruby/rdoc/actions/runs/21367549712/job/61503325741)
```
/home/runner/work/rdoc/rdoc/lib/rdoc/parser/ripper_state_lex.rb:17:in 'Module#const_missing': uninitialized constant Prism::Translation::Ripper::Filter (NameError)
```

This has been fixed since then (`ruby -rripper -e 'p Prism::Translation::Ripper::Filter'` works on truffleruby-head), given the CI now passes.