### PR TITLE
Fix section comments with the prism parser

### DIFF
--- a/lib/rdoc/code_object/context/section.rb
+++ b/lib/rdoc/code_object/context/section.rb
@@ -106,6 +106,9 @@ class RDoc::Context::Section
   #
   #   # :section: The title
   #   # The body
+  #
+  #--
+  # TODO Remove when the ripper parser has been removed
 
   def extract_comment(comment)
     case comment

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -473,13 +473,26 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
     comment.line = start_line
     markup, = directives['markup']
     comment.format = markup&.downcase || @markup
-    if (section, = directives['section'])
+    if (section, directive_line = directives['section'])
       # If comment has :section:, it is not a documentable comment for a code object
-      @container.set_current_section(section, comment.dup)
+      comment.text = extract_section_comment(comment_text, directive_line - start_line)
+      @container.set_current_section(section, comment)
       return
     end
     @preprocess.run_post_processes(comment, @container)
     [comment, directives]
+  end
+
+  # Extracts the comment for this section from the normalized comment block.
+  # Removes all lines before the line that contains :section:
+  # If the comment also ends with the same content, remove it as well
+
+  def extract_section_comment(comment_text, prefix_line_count) # :nodoc:
+    prefix = comment_text.lines[0...prefix_line_count].join
+    comment_text.delete_prefix!(prefix)
+    # Comment is already normalized and doesn't end with a newline
+    comment_text.delete_suffix!(prefix.chomp)
+    comment_text
   end
 
   def slice_tokens(start_pos, end_pos) # :nodoc:

--- a/test/rdoc/parser/prism_ruby_test.rb
+++ b/test/rdoc/parser/prism_ruby_test.rb
@@ -36,6 +36,41 @@ module RDocParserPrismTestCases
     assert_equal 'new section', section.title
   end
 
+  def test_section_with_divider
+    util_parser <<~RUBY
+      # DIVIDER
+      # :section: section 1
+      # foo
+      # DIVIDER
+
+      # DIVIDER 1
+      # DIVIDER 2
+      # :section: section 2
+      # foo
+      # DIVIDER 1
+      # DIVIDER 2
+
+      # DIVIDER TOP ONLY
+      # :section: section 3
+      # foo
+
+      # DIVIDER TOP ONLY
+      # :section: section 4
+    RUBY
+
+    section = @top_level.sections_hash['section 1']
+    assert_equal "\n<p>foo</p>\n", section.description
+
+    section = @top_level.sections_hash['section 2']
+    assert_equal "\n<p>foo</p>\n", section.description
+
+    section = @top_level.sections_hash['section 3']
+    assert_equal "\n<p>foo</p>\n", section.description
+
+    section = @top_level.sections_hash['section 4']
+    assert_equal '', section.description
+  end
+
   def test_look_for_directives_in_commented
     util_parser <<~RUBY
       # how to make a section:


### PR DESCRIPTION
The section expects a non-formatted comment.
Closes https://github.com/ruby/rdoc/issues/1638

Can be simplified once the ripper parser is removed. It currently passes the comment text as is and transforms it in the section class itself.
The prism parser now does it outside of that class.