### PR TITLE
Fix herb linter offenses in ERB templates

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,21 @@
+version: 0.9.0
+
+linter:
+  enabled: true
+
+  rules:
+    # RDoc templates are not Rails partials — instance variables are the
+    # standard way to pass data from the generator to templates.
+    erb-no-instance-variables-in-partials:
+      enabled: false
+
+    # Template output is generated from trusted RDoc data, not user input.
+    erb-no-unsafe-script-interpolation:
+      enabled: false
+
+    # Same: attribute values come from trusted RDoc data.
+    erb-no-output-in-attribute-position:
+      enabled: false
+
+formatter:
+  enabled: false

--- a/lib/rdoc/generator/template/aliki/_head.rhtml
+++ b/lib/rdoc/generator/template/aliki/_head.rhtml
@@ -28,7 +28,7 @@
 <%- elsif @title %>
   <meta name="keywords" content="ruby,documentation,<%= h @title %>">
   <%- if @options.main_page and
-      main_page = @files.find { |f| f.full_name == @options.main_page } then %>
+      main_page = @files.find { |f| f.full_name == @options.main_page } %>
     <meta
       name="description"
       content="<%= h "#{@title}: #{excerpt(main_page.comment)}" %>"

--- a/lib/rdoc/generator/template/aliki/_sidebar_extends.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_extends.rhtml
@@ -1,4 +1,4 @@
-<%- unless klass.extends.empty? then %>
+<%- unless klass.extends.empty? %>
 <div id="extends-section" class="nav-section">
   <details class="nav-section-collapsible" open>
     <summary class="nav-section-header">
@@ -13,11 +13,13 @@
 
     <ul class="nav-list">
       <%- klass.extends.each do |ext| %>
-    <%- unless String === ext.module then %>
-      <li><a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a></li>
-    <%- else %>
-      <li><span class="extend"><%= ext.name %></span></li>
-    <%- end %>
+      <li>
+      <%- unless String === ext.module %>
+        <a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a>
+      <%- else %>
+        <span class="extend"><%= ext.name %></span>
+      <%- end %>
+      </li>
     <%- end %>
     </ul>
   </details>

--- a/lib/rdoc/generator/template/aliki/_sidebar_includes.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_includes.rhtml
@@ -1,4 +1,4 @@
-<%- unless klass.includes.empty? then %>
+<%- unless klass.includes.empty? %>
 <div id="includes-section" class="nav-section">
   <details class="nav-section-collapsible" open>
     <summary class="nav-section-header">
@@ -13,11 +13,13 @@
 
     <ul class="nav-list">
     <%- klass.includes.each do |inc| %>
-    <%- unless String === inc.module then %>
-      <li><a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a></li>
-    <%- else %>
-      <li><span class="include"><%= inc.name %></span></li>
-    <%- end %>
+      <li>
+      <%- unless String === inc.module %>
+        <a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a>
+      <%- else %>
+        <span class="include"><%= inc.name %></span>
+      <%- end %>
+      </li>
     <%- end %>
     </ul>
   </details>

--- a/lib/rdoc/generator/template/aliki/_sidebar_installed.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_installed.rhtml
@@ -5,7 +5,7 @@
   <%- installed.each do |name, href, exists, type, _| %>
     <%- next if type == :extra %>
     <li class="folder">
-    <%- if exists then %>
+    <%- if exists %>
       <a href="<%= href %>"><%= h name %></a>
     <%- else %>
       <%= h name %>

--- a/lib/rdoc/generator/template/aliki/_sidebar_pages.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_pages.rhtml
@@ -4,7 +4,7 @@
   <%- dir = current.full_name[%r{\A[^/]+(?=/)}] || current.page_name %>
 <%- end %>
 
-<%- unless simple_files.empty? then %>
+<%- unless simple_files.empty? %>
   <div id="fileindex-section" class="nav-section">
     <details class="nav-section-collapsible" <%= 'open' unless @inside_class_file %>>
       <summary class="nav-section-header">

--- a/lib/rdoc/generator/template/aliki/_sidebar_sections.rhtml
+++ b/lib/rdoc/generator/template/aliki/_sidebar_sections.rhtml
@@ -1,4 +1,4 @@
-<%- unless klass.sections.length == 1 then %>
+<%- unless klass.sections.length == 1 %>
 <div id="sections-section" class="nav-section">
   <details class="nav-section-collapsible" open>
     <summary class="nav-section-header">

--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -22,7 +22,7 @@
         <% if namespace[:self] %>
         <span><%= namespace[:name] %></span>
         <% else %>
-        <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span>::</span>
+        <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span class="separator">::</span>
         <% end %>
       </li>
       <% end %>
@@ -41,7 +41,7 @@
   <%- klass.each_section do |section, constants, attributes| %>
   <span id="<%= section.legacy_aref %>" class="legacy-anchor"></span>
   <section class="documentation-section anchor-link">
-    <%- if section.title then %>
+    <%- if section.title %>
     <header class="documentation-section-title">
       <h2 id="<%= section.aref %>">
         <a href="#<%= section.aref %>"><%= section.title %></a>
@@ -49,13 +49,13 @@
     </header>
     <%- end %>
 
-    <%- if section.comment then %>
+    <%- if section.comment %>
     <div>
       <%= section.description %>
     </div>
     <%- end %>
 
-    <%- unless constants.empty? then %>
+    <%- unless constants.empty? %>
     <section class="constants-list">
       <header>
         <h3 id="<%= section.aref %>-constants"><a href="#<%= section.aref %>-constants">Constants</a></h3>
@@ -63,9 +63,9 @@
       <dl>
       <%- constants.each do |const| %>
         <dt id="<%= const.name %>"><%= const.name %></dt>
-        <%- if const.comment then %>
+        <%- if const.comment %>
         <dd>
-          <%- if const.mixin_from then %>
+          <%- if const.mixin_from %>
             <div class="mixin-from">
               Included from <a href="<%= klass.aref_to(const.mixin_from.path) %>"><%= const.mixin_from.full_name %></a>
             </div>
@@ -80,7 +80,7 @@
     </section>
     <%- end %>
 
-    <%- unless attributes.empty? then %>
+    <%- unless attributes.empty? %>
     <section class="attribute-method-details method-section">
       <header>
         <h3 id="<%= section.aref %>-attributes"><a href="#<%= section.aref %>-attributes">Attributes</a></h3>
@@ -96,12 +96,12 @@
         </div>
 
         <div class="method-description">
-        <%- if attrib.mixin_from then %>
+        <%- if attrib.mixin_from %>
           <div class="mixin-from">
             <%= attrib.singleton ? "Extended" : "Included" %> from <a href="<%= klass.aref_to(attrib.mixin_from.path) %>"><%= attrib.mixin_from.full_name %></a>
           </div>
         <%- end %>
-        <%- if attrib.comment then %>
+        <%- if attrib.comment %>
         <%= attrib.description.strip %>
         <%- else %>
         <p class="missing-docs">(Not documented)</p>
@@ -124,7 +124,7 @@
     <%- methods.each do |method| %>
       <div id="<%= method.aref %>" class="method-detail anchor-link <%= method.is_alias_for ? "method-alias" : '' %>">
         <div class="method-header">
-          <%- if (call_seq = method.call_seq) then %>
+          <%- if (call_seq = method.call_seq) %>
             <%- call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
               <div class="method-heading">
                 <a href="#<%= method.aref %>" title="Link to this method">
@@ -136,7 +136,7 @@
                 </a>
               </div>
             <%- end %>
-          <%- elsif method.has_call_seq? then %>
+          <%- elsif method.has_call_seq? %>
             <div class="method-heading">
               <a href="#<%= method.aref %>" title="Link to this method">
                 <span class="method-name"><%= h method.name %></span>
@@ -163,19 +163,19 @@
           </div>
         <%- end %>
 
-        <%- unless method.skip_description? then %>
+        <%- unless method.skip_description? %>
         <div class="method-description">
-          <%- if method.mixin_from then %>
+          <%- if method.mixin_from %>
             <div class="mixin-from">
               <%= method.singleton ? "Extended" : "Included" %> from <a href="<%= klass.aref_to(method.mixin_from.path) %>"><%= method.mixin_from.full_name %></a>
             </div>
           <%- end %>
-          <%- if method.comment then %>
+          <%- if method.comment %>
           <%= method.description.strip %>
           <%- else %>
           <p class="missing-docs">(Not documented)</p>
           <%- end %>
-          <%- if method.calls_super then %>
+          <%- if method.calls_super %>
             <div class="method-calls-super">
               Calls superclass method
               <%=
@@ -187,7 +187,7 @@
         </div>
         <%- end %>
 
-        <%- unless method.aliases.empty? then %>
+        <%- unless method.aliases.empty? %>
         <div class="aliases">
           Also aliased as: <%= method.aliases.map do |aka|
             if aka.parent then # HACK lib/rexml/encodings
@@ -199,7 +199,7 @@
         </div>
         <%- end %>
 
-        <%- if method.is_alias_for then %>
+        <%- if method.is_alias_for %>
         <div class="aliases">
           Alias for: <a href="<%= klass.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
         </div>

--- a/lib/rdoc/generator/template/aliki/servlet_root.rhtml
+++ b/lib/rdoc/generator/template/aliki/servlet_root.rhtml
@@ -42,7 +42,7 @@
 
 <%- gems = installed.select { |_, _, _, type,| type == :gem } %>
 <%- missing = gems.reject { |_, _, exists,| exists } %>
-<%- unless missing.empty? then %>
+<%- unless missing.empty? %>
   <h2>Missing Gem Documentation</h2>
 
   <p>You are missing documentation for some of your installed gems.

--- a/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_extends.rhtml
@@ -1,14 +1,16 @@
-<%- unless klass.extends.empty? then %>
+<%- unless klass.extends.empty? %>
 <div id="extends-section" class="nav-section">
   <h3>Extended With Modules</h3>
 
   <ul class="link-list">
   <%- klass.extends.each do |ext| %>
-  <%- unless String === ext.module then %>
-    <li><a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a></li>
-  <%- else %>
-    <li><span class="extend"><%= ext.name %></span></li>
-  <%- end %>
+    <li>
+    <%- unless String === ext.module %>
+      <a class="extend" href="<%= klass.aref_to ext.module.path %>"><%= ext.module.full_name %></a>
+    <%- else %>
+      <span class="extend"><%= ext.name %></span>
+    <%- end %>
+    </li>
   <%- end %>
   </ul>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_includes.rhtml
@@ -1,14 +1,16 @@
-<%- unless klass.includes.empty? then %>
+<%- unless klass.includes.empty? %>
 <div id="includes-section" class="nav-section">
   <h3>Included Modules</h3>
 
   <ul class="link-list">
   <%- klass.includes.each do |inc| %>
-  <%- unless String === inc.module then %>
-    <li><a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a></li>
-  <%- else %>
-    <li><span class="include"><%= inc.name %></span></li>
-  <%- end %>
+    <li>
+    <%- unless String === inc.module %>
+      <a class="include" href="<%= klass.aref_to inc.module.path %>"><%= inc.module.full_name %></a>
+    <%- else %>
+      <span class="include"><%= inc.name %></span>
+    <%- end %>
+    </li>
   <%- end %>
   </ul>
 </div>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_installed.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_installed.rhtml
@@ -5,7 +5,7 @@
   <%- installed.each do |name, href, exists, type, _| %>
     <%- next if type == :extra %>
     <li class="folder">
-    <%- if exists then %>
+    <%- if exists %>
       <a href="<%= href %>"><%= h name %></a>
     <%- else %>
       <%= h name %>

--- a/lib/rdoc/generator/template/darkfish/_sidebar_pages.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_pages.rhtml
@@ -2,7 +2,7 @@
 <%- if defined?(current) %>
   <%- dir = current.full_name[%r{\A[^/]+(?=/)}] || current.page_name %>
 <%- end %>
-<%- unless simple_files.empty? then %>
+<%- unless simple_files.empty? %>
 <div id="fileindex-section" class="nav-section">
   <h3>Pages</h3>
 

--- a/lib/rdoc/generator/template/darkfish/_sidebar_sections.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_sections.rhtml
@@ -1,4 +1,4 @@
-<%- unless klass.sections.length == 1 then %>
+<%- unless klass.sections.length == 1 %>
 <div id="sections-section" class="nav-section">
   <h3>Sections</h3>
 

--- a/lib/rdoc/generator/template/darkfish/_sidebar_table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/darkfish/_sidebar_table_of_contents.rhtml
@@ -1,11 +1,11 @@
-<%- comment = if current.respond_to? :comment_location then
+<%- comment = if current.respond_to? :comment_location
                current.comment_location
              else
                current.comment
              end
    table = current.parse(comment).table_of_contents.dup
 
-   if table.length > 1 then %>
+   if table.length > 1 %>
 <div class="nav-section">
   <h3>Table of Contents</h3>
 
@@ -17,18 +17,18 @@
       <%- level = table.first&.level %>
       <%- while table.first && table.first.level >= level %>
         <%- heading = table.shift %>
+        <li>
         <%- if table.first.nil? || table.first.level <= heading.level %>
-          <li><% display_link.call heading %></li>
+          <% display_link.call heading %>
         <%- else %>
-          <li>
             <details open>
               <summary><%- display_link.call heading %></summary>
               <ul class="link-list" role="directory">
                 <% list_siblings.call %>
               </ul>
             </details>
-          </li>
         <%- end %>
+        </li>
       <%- end %>
     <%- end %>
 

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -26,7 +26,7 @@
         <% if namespace[:self] %>
         <span><%= namespace[:name] %></span>
         <% else %>
-        <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span>::</span>
+        <a href="<%= namespace[:path] %>"><%= namespace[:name] %></a><span class="separator">::</span>
         <% end %>
       </li>
       <% end %>
@@ -45,7 +45,7 @@
   <%- klass.each_section do |section, constants, attributes| %>
   <span id="<%= section.legacy_aref %>" class="legacy-anchor"></span>
   <section id="<%= section.aref %>" class="documentation-section anchor-link">
-    <%- if section.title then %>
+    <%- if section.title %>
     <header class="documentation-section-title">
       <h2>
         <%= section.title %>
@@ -56,13 +56,13 @@
     </header>
     <%- end %>
 
-    <%- if section.comment then %>
+    <%- if section.comment %>
     <div>
       <%= section.description %>
     </div>
     <%- end %>
 
-    <%- unless constants.empty? then %>
+    <%- unless constants.empty? %>
     <section class="constants-list">
       <header>
         <h3>Constants</h3>
@@ -70,9 +70,9 @@
       <dl>
       <%- constants.each do |const| %>
         <dt id="<%= const.name %>"><%= const.name %></dt>
-        <%- if const.comment then %>
+        <%- if const.comment %>
         <dd>
-          <%- if const.mixin_from then %>
+          <%- if const.mixin_from %>
             <div class="mixin-from">
               Included from <a href="<%= klass.aref_to(const.mixin_from.path) %>"><%= const.mixin_from.full_name %></a>
             </div>
@@ -87,7 +87,7 @@
     </section>
     <%- end %>
 
-    <%- unless attributes.empty? then %>
+    <%- unless attributes.empty? %>
     <section class="attribute-method-details method-section">
       <header>
         <h3>Attributes</h3>
@@ -103,12 +103,12 @@
         </div>
 
         <div class="method-description">
-        <%- if attrib.mixin_from then %>
+        <%- if attrib.mixin_from %>
           <div class="mixin-from">
             <%= attrib.singleton ? "Extended" : "Included" %> from <a href="<%= klass.aref_to(attrib.mixin_from.path) %>"><%= attrib.mixin_from.full_name %></a>
           </div>
         <%- end %>
-        <%- if attrib.comment then %>
+        <%- if attrib.comment %>
         <%= attrib.description.strip %>
         <%- else %>
         <p class="missing-docs">(Not documented)</p>
@@ -131,7 +131,7 @@
     <%- methods.each do |method| %>
       <div id="<%= method.aref %>" class="method-detail anchor-link <%= method.is_alias_for ? "method-alias" : '' %>">
         <div class="method-header">
-          <%- if (call_seq = method.call_seq) then %>
+          <%- if (call_seq = method.call_seq) %>
             <%- call_seq.strip.split("\n").each_with_index do |call_seq, i| %>
               <div class="method-heading">
                 <a href="#<%= method.aref %>" title="Link to this method">
@@ -143,7 +143,7 @@
                 </a>
               </div>
             <%- end %>
-          <%- elsif method.has_call_seq? then %>
+          <%- elsif method.has_call_seq? %>
             <div class="method-heading">
               <a href="#<%= method.aref %>" title="Link to this method">
                 <span class="method-name"><%= h method.name %></span>
@@ -170,19 +170,19 @@
           </div>
         <%- end %>
 
-        <%- unless method.skip_description? then %>
+        <%- unless method.skip_description? %>
         <div class="method-description">
-          <%- if method.mixin_from then %>
+          <%- if method.mixin_from %>
             <div class="mixin-from">
               <%= method.singleton ? "Extended" : "Included" %> from <a href="<%= klass.aref_to(method.mixin_from.path) %>"><%= method.mixin_from.full_name %></a>
             </div>
           <%- end %>
-          <%- if method.comment then %>
+          <%- if method.comment %>
           <%= method.description.strip %>
           <%- else %>
           <p class="missing-docs">(Not documented)</p>
           <%- end %>
-          <%- if method.calls_super then %>
+          <%- if method.calls_super %>
             <div class="method-calls-super">
               Calls superclass method
               <%=
@@ -194,7 +194,7 @@
         </div>
         <%- end %>
 
-        <%- unless method.aliases.empty? then %>
+        <%- unless method.aliases.empty? %>
         <div class="aliases">
           Also aliased as: <%= method.aliases.map do |aka|
             if aka.parent then # HACK lib/rexml/encodings
@@ -206,7 +206,7 @@
         </div>
         <%- end %>
 
-        <%- if method.is_alias_for then %>
+        <%- if method.is_alias_for %>
         <div class="aliases">
           Alias for: <a href="<%= klass.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
         </div>

--- a/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/darkfish/table_of_contents.rhtml
@@ -14,7 +14,7 @@
 <h1 class="class"><%= h @title %></h1>
 
 <%- simple_files = @files.select { |f| f.text? } %>
-<%- unless simple_files.empty? then %>
+<%- unless simple_files.empty? %>
 <h2 id="pages">Pages</h2>
 <ul>
 <%- simple_files.sort.each do |file| %>
@@ -23,7 +23,7 @@
 <%
    # HACK table_of_contents should not exist on Document
    table = file.parse(file.comment).table_of_contents
-   unless table.empty? then %>
+   unless table.empty? %>
     <ul>
     <%- table.each do |heading| %>
       <li><a href="<%= h file.path %>#<%= heading.aref %>"><%= heading.plain_html %></a></li>
@@ -44,7 +44,7 @@
    table.concat klass.parse(klass.comment_location).table_of_contents
    table.concat klass.section_contents
 
-   unless table.empty? then %>
+   unless table.empty? %>
     <ul>
 <%- table.each do |item| %>
   <%- label = item.respond_to?(:label) ? item.label(klass) : item.aref %>


### PR DESCRIPTION
## Summary
- Remove `then` keyword from all ERB control flow tags (52 offenses)
- Move duplicated HTML elements outside conditional branches (14 offenses)
- Add `.herb.yml` config to disable rules not applicable to RDoc:
  - `erb-no-instance-variables-in-partials` — RDoc templates aren't Rails partials
  - `erb-no-unsafe-script-interpolation` — templates render trusted RDoc data
  - `erb-no-output-in-attribute-position` — same reason

Fixes CI failure caused by `@herb-tools/linter` 0.9.0 introducing new rules.