### PR TITLE
Don't auto-link to non-text source files in cross-references

### DIFF
--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -159,6 +159,12 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
 
     ref = @cross_reference.resolve name, text if name
 
+    # Non-text source files (C, Ruby, etc.) don't get HTML pages generated,
+    # so don't auto-link to them. Explicit rdoc-ref: links are still allowed.
+    if !rdoc_ref && RDoc::TopLevel === ref && !ref.text?
+      return text
+    end
+
     case ref
     when String then
       if rdoc_ref && @warn_missing_rdoc_ref

--- a/test/rdoc/markup/to_html_crossref_test.rb
+++ b/test/rdoc/markup/to_html_crossref_test.rb
@@ -387,6 +387,25 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
     assert_equal 'first.last@example.com', result
   end
 
+  def test_convert_CROSSREF_c_file_not_autolinked
+    # C files are not text files, so they don't get HTML pages generated.
+    # Auto cross-references to them should not produce links.
+    c_file = @store.add_file 'array.c'
+    c_file.parser = RDoc::Parser::C
+
+    result = @to.convert 'array.c'
+    assert_equal para("array.c"), result
+  end
+
+  def test_convert_RDOCLINK_rdoc_ref_c_file_linked
+    # Explicit rdoc-ref: links to non-text files should still work.
+    c_file = @store.add_file 'array.c'
+    c_file.parser = RDoc::Parser::C
+
+    result = @to.convert 'rdoc-ref:array.c'
+    assert_equal para("<a href=\"array_c.html\">array.c</a>"), result
+  end
+
   def test_link
     assert_equal 'n', @to.link('n', 'n')
 


### PR DESCRIPTION
## Summary
- RDoc's cross-reference system auto-links filenames like `array.c` when encountered in documentation text, but non-text source files are not meant to have their own documentation pages, so these links are always broken (e.g. https://docs.ruby-lang.org/en/master/extension_rdoc.html#class-library)
- Only suppress auto-linking in `ToHtmlCrossref#link`. Explicit `rdoc-ref:` links to non-text files (enabled by #1376) continue to work