### PR TITLE
Fix deadlock on Ctrl+C in server mode

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -546,10 +546,6 @@ The internal error was:
 
   def start_server
     server = RDoc::Server.new(self, @options.server_port)
-
-    trap('INT')  { server.shutdown }
-    trap('TERM') { server.shutdown }
-
     server.start
   end
 

--- a/lib/rdoc/server.rb
+++ b/lib/rdoc/server.rb
@@ -91,15 +91,10 @@ class RDoc::Server
     loop do
       client = @tcp_server.accept
       Thread.new(client) { |c| handle_client(c) }
-    rescue IOError
-      break
     end
-  end
-
-  ##
-  # Shuts down the server.
-
-  def shutdown
+  rescue Interrupt
+    # Ctrl+C
+  ensure
     @running = false
     @tcp_server&.close
     @watcher_thread&.join(2)


### PR DESCRIPTION
## Summary

- Pressing Ctrl+C in `rdoc --server` raised `ThreadError: deadlock; recursive locking` because the `INT` trap called `shutdown`, which closed the TCP server socket from the same thread blocked on `accept`
- Replace trap-based shutdown with `rescue Interrupt` around the accept loop, and move cleanup into an `ensure` block