### PR TITLE
Add `contents: write` permission for preview of PR from ruby/rdoc

### DIFF
--- a/.github/workflows/pr-preview-check.yml
+++ b/.github/workflows/pr-preview-check.yml
@@ -9,6 +9,8 @@ jobs:
     name: Trigger Preview Build and Deploy (Main Repo)
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: write
     steps:
       - name: Trigger preview deployment
         uses: actions/github-script@v8


### PR DESCRIPTION
For example, Dependabot uses this style.

Currently, it's failing with "Resource not accessible by integration" error:

https://github.com/ruby/rdoc/actions/runs/23154409178/job/67265027124?pr=1651#step:2:23

> RequestError [HttpError]: Resource not accessible by integration


I haven't tested this but It seems `contents: write` is needed for repository dispatch:

https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents

> POST /repos/{owner}/{repo}/dispatches	write
