### PR TITLE
Fix :stopdoc: directive being undone for C-defined classes

### DIFF
--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -125,6 +125,7 @@ class RDoc::CodeObject
     @received_nodoc      = false
     @ignored             = false
     @suppressed          = false
+    @stopped_doc         = false
     @track_visibility    = true
   end
 
@@ -205,8 +206,10 @@ class RDoc::CodeObject
   def done_documenting=(value)
     return unless @track_visibility
     @done_documenting  = value
-    @document_self     = !value
-    @document_children = @document_self
+    unless @stopped_doc
+      @document_self     = !value
+      @document_children = @document_self
+    end
   end
 
   ##
@@ -343,16 +346,18 @@ class RDoc::CodeObject
     @document_children = true
     @ignored    = false
     @suppressed = false
+    @stopped_doc = false
   end
 
   ##
   # Disable capture of documentation
 
-  def stop_doc
+  def stop_doc(from_directive: false)
     return unless @track_visibility
 
     @document_self = false
     @document_children = false
+    @stopped_doc = true if from_directive
   end
 
   ##

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -231,7 +231,7 @@ class RDoc::Markup::PreProcess
     when 'stopdoc' then
       return blankline unless code_object
 
-      code_object.stop_doc
+      code_object.stop_doc(from_directive: true)
 
       blankline
     when 'yield', 'yields' then

--- a/test/rdoc/parser/c_test.rb
+++ b/test/rdoc/parser/c_test.rb
@@ -2328,6 +2328,32 @@ void Init_Blah(void) {
     File.delete source_path if source_path && File.exist?(source_path)
   end
 
+  def test_stopdoc_class_display
+    content = <<~C
+      /* Document-class: Parent
+       * This is the Parent class
+       */
+      VALUE rb_cParent = rb_define_class("Parent", rb_cObject);
+
+      /* :stopdoc: */
+      VALUE cInternal = rb_define_class_under(rb_cParent, "Internal", rb_cObject);
+      /* :startdoc: */
+    C
+
+    util_get_class content, 'cInternal'
+
+    # Simulate parse_file's done_documenting reset
+    @top_level.classes_or_modules.each do |cm|
+      cm.done_documenting = false
+    end
+
+    parent = @store.find_class_named 'Parent'
+    internal = @store.find_class_named 'Parent::Internal'
+
+    assert parent.display?, 'Parent should be displayed'
+    refute internal.display?, 'stopdoc class should not be displayed'
+  end
+
   def util_get_class(content, name = nil)
     @parser = util_parser content
     @parser.scan


### PR DESCRIPTION
## Summary

- After parsing a C file, `parse_file` resets `done_documenting = false` on all classes in `top_level.classes_or_modules`
- Since `done_documenting=` also sets `@document_self = !value`, this inadvertently resets `document_self` to `true` for classes that had `:stopdoc:` applied during parsing
- This became an issue after `add_to_classes_or_modules` was added to the C parser's `handle_class_module`, which caused C-defined classes to appear in `top_level.classes_or_modules` for the first time
- The fix tracks `:stopdoc:` directives with a `@stopped_doc` flag so `done_documenting=` preserves the stopdoc state

## Reproduction

Run `rdoc -C` against a C extension that uses `:stopdoc:` around class definitions, such as [io-console](https://github.com/ruby/io-console):

```
$ rdoc -C
The following items are not documented:

  class IO::ConsoleMode
  end

  module IO::generic_readable
  end
```

These classes are intentionally wrapped in `/* :stopdoc: */` / `/* :startdoc: */` and should not appear in coverage.