### PR TITLE
Add RDoc coverage check for C extensions in ruby-core CI

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,12 +66,17 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
+      - name: Generate rbconfig.rb
+        run: make update-rbconfig
+        working-directory: ruby/ruby
       - name: Core docs coverage
         # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk.
-        # Use -I to load the locally checked out RDoc, matching how
-        # tool/rdoc-srcdir overrides the load path in ruby/ruby.
+        # Use -I to load the locally checked out RDoc and bypass exe/rdoc's
+        # gem activation which could override the load path.
         run: >
-          ruby -I../rdoc/lib ../rdoc/exe/rdoc --quiet -C
+          ruby -I../rdoc/lib -r rdoc/rdoc
+          -e 'RDoc::RDoc.new.document ARGV' --
+          --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych
           -x ^lib/bundler -x ^lib/rubygems
           -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -67,7 +67,12 @@ jobs:
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Core docs coverage
-        run: make XRUBY=ruby RDOC_DEPENDS= RBCONFIG=update-rbconfig rdoc-coverage
+        run: >
+          BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
+          -x ^ext/json -x ^ext/openssl -x ^ext/psych
+          -x ^lib/bundler -x ^lib/rubygems
+          -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest
+          .
         working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,14 +66,21 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
-      - name: Core docs coverage
-        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk
+      - name: Core docs coverage (excluding io-console)
+        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk,
+        # plus ext/io/console which is checked separately below.
         run: >
           BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych
           -x ^lib/bundler -x ^lib/rubygems
           -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest
+          -x ^ext/io/console
           .
+        working-directory: ruby/ruby
+      - name: Core docs coverage (io-console)
+        run: >
+          BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
+          ext/io/console
         working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,17 +66,12 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
-      - name: Generate rbconfig.rb
-        run: make update-rbconfig
-        working-directory: ruby/ruby
       - name: Core docs coverage
         # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk.
-        # Use -I to load the locally checked out RDoc and bypass exe/rdoc's
-        # gem activation which could override the load path.
+        # Use -I to load the locally checked out RDoc and -S to find the
+        # rdoc executable, matching how tool/rdoc-srcdir works in ruby/ruby.
         run: >
-          ruby -I../rdoc/lib -r rdoc/rdoc
-          -e 'RDoc::RDoc.new.document ARGV' --
-          --quiet -C
+          ruby -I../rdoc/lib -S rdoc --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych
           -x ^lib/bundler -x ^lib/rubygems
           -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -67,9 +67,11 @@ jobs:
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Core docs coverage
-        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk
+        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk.
+        # Use -I to load the locally checked out RDoc, matching how
+        # tool/rdoc-srcdir overrides the load path in ruby/ruby.
         run: >
-          BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
+          ruby -I../rdoc/lib ../rdoc/exe/rdoc --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych
           -x ^lib/bundler -x ^lib/rubygems
           -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,9 +66,9 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
-      - name: Run RDoc coverage check on C extensions
-        run: bundle exec rdoc -C -q ../ruby/ext/io/console
-        working-directory: ruby/rdoc
+      - name: Core docs coverage
+        run: make XRUBY=ruby RDOC_DEPENDS= RBCONFIG=update-rbconfig rdoc-coverage
+        working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html
         working-directory: ruby/ruby

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,19 +66,16 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
-      - name: Core docs coverage
-        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk.
-        # Use -I to load the locally checked out RDoc and -S to find the
-        # rdoc executable, matching how tool/rdoc-srcdir works in ruby/ruby.
-        run: >
-          ruby -I../rdoc/lib -S rdoc --quiet -C
-          -x ^ext/json -x ^ext/openssl -x ^ext/psych
-          -x ^lib/bundler -x ^lib/rubygems
-          -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest
-          .
-        working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html
+        working-directory: ruby/ruby
+      - name: Core docs coverage
+        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk.
+        # Run after make html so the build environment is fully set up
+        # (rbconfig.rb, generated files, etc.), matching ruby/ruby's CI.
+        run: >
+          make XRUBY=ruby RDOC_DEPENDS= RBCONFIG=update-rbconfig
+          rdoc-coverage
         working-directory: ruby/ruby
       # We need to clear the generated documentation to generate them again
       # with the Ripper parser.

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,6 +66,9 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
+      - name: Run RDoc coverage check on C extensions
+        run: ruby -I../rdoc/lib ../rdoc/exe/rdoc -C -q ext/io/console
+        working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html
         working-directory: ruby/ruby

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -67,8 +67,8 @@ jobs:
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Run RDoc coverage check on C extensions
-        run: ruby -I../rdoc/lib ../rdoc/exe/rdoc -C -q ext/io/console
-        working-directory: ruby/ruby
+        run: bundle exec rdoc -C -q ../ruby/ext/io/console
+        working-directory: ruby/rdoc
       - name: Generate Documentation with RDoc
         run: make html
         working-directory: ruby/ruby

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -67,6 +67,7 @@ jobs:
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
       - name: Core docs coverage
+        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk
         run: >
           BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -66,21 +66,14 @@ jobs:
           gem install rdoc-*.gem
           bundle exec rake build:local_ruby
         working-directory: ruby/rdoc
-      - name: Core docs coverage (excluding io-console)
-        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk,
-        # plus ext/io/console which is checked separately below.
+      - name: Core docs coverage
+        # Exclusions match RDOC_COVERAGE_EXCLUDES in ruby/ruby's common.mk
         run: >
           BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
           -x ^ext/json -x ^ext/openssl -x ^ext/psych
           -x ^lib/bundler -x ^lib/rubygems
           -x ^lib/did_you_mean -x ^lib/error_highlight -x ^lib/syntax_suggest
-          -x ^ext/io/console
           .
-        working-directory: ruby/ruby
-      - name: Core docs coverage (io-console)
-        run: >
-          BUNDLE_GEMFILE=../rdoc/Gemfile bundle exec rdoc --quiet -C
-          ext/io/console
         working-directory: ruby/ruby
       - name: Generate Documentation with RDoc
         run: make html

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -204,6 +204,7 @@ class RDoc::CodeObject
 
   def done_documenting=(value)
     return unless @track_visibility
+    return if @done_documenting == value
     @done_documenting  = value
     @document_self     = !value
     @document_children = @document_self

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -355,7 +355,6 @@ class RDoc::CodeObject
 
     @document_self = false
     @document_children = false
-    @stopped_doc = true
   end
 
   ##

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -125,6 +125,7 @@ class RDoc::CodeObject
     @received_nodoc      = false
     @ignored             = false
     @suppressed          = false
+    @stopped_doc         = false
     @track_visibility    = true
   end
 
@@ -204,9 +205,8 @@ class RDoc::CodeObject
 
   def done_documenting=(value)
     return unless @track_visibility
-    return if @done_documenting == value
     @done_documenting  = value
-    @document_self     = !value
+    @document_self     = !value unless @stopped_doc
     @document_children = @document_self
   end
 
@@ -344,6 +344,7 @@ class RDoc::CodeObject
     @document_children = true
     @ignored    = false
     @suppressed = false
+    @stopped_doc = false
   end
 
   ##
@@ -354,6 +355,7 @@ class RDoc::CodeObject
 
     @document_self = false
     @document_children = false
+    @stopped_doc = true
   end
 
   ##

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -232,6 +232,7 @@ class RDoc::Markup::PreProcess
       return blankline unless code_object
 
       code_object.stop_doc
+      code_object.instance_variable_set(:@stopped_doc, true)
 
       blankline
     when 'yield', 'yields' then

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -340,7 +340,8 @@ option)
 
     parser.scan
 
-    # restart documentation for the classes & modules found
+    # restart documentation for the classes & modules found,
+    # but preserve explicit :stopdoc: directives
     top_level.classes_or_modules.each do |cm|
       cm.done_documenting = false if cm.document_self
     end

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -342,7 +342,7 @@ option)
 
     # restart documentation for the classes & modules found
     top_level.classes_or_modules.each do |cm|
-      cm.done_documenting = false
+      cm.done_documenting = false if cm.document_self
     end
 
     top_level

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -340,10 +340,9 @@ option)
 
     parser.scan
 
-    # restart documentation for the classes & modules found,
-    # but preserve explicit :stopdoc: directives
+    # restart documentation for the classes & modules found
     top_level.classes_or_modules.each do |cm|
-      cm.done_documenting = false if cm.document_self
+      cm.done_documenting = false
     end
 
     top_level

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -358,6 +358,30 @@ class RDocRDocTest < RDoc::TestCase
     tf.close!
   end
 
+  def test_parse_file_stopdoc_in_c
+    @rdoc.store = RDoc::Store.new(@options)
+
+    temp_dir do |dir|
+      @rdoc.options.root = Pathname(Dir.pwd)
+
+      File.write 'test.c', <<~C
+        void Init_test(void) {
+            VALUE rb_cParent = rb_define_class("Parent", rb_cObject);
+
+            /* :stopdoc: */
+            VALUE cInternal = rb_define_class_under(rb_cParent, "Internal", rb_cObject);
+            /* :startdoc: */
+        }
+      C
+
+      top_level = @rdoc.parse_file 'test.c'
+
+      internal = @rdoc.store.find_class_named 'Parent::Internal'
+      assert internal, 'Parent::Internal should exist'
+      refute internal.document_self, 'Parent::Internal should have document_self=false after :stopdoc:'
+    end
+  end
+
   def test_parse_file_forbidden
     omit 'chmod not supported' if Gem.win_platform?
     omit "assumes that euid is not root" if Process.euid == 0


### PR DESCRIPTION
## Summary

- Adds an `rdoc -C` coverage check step against `ext/io/console` in the ruby-core CI workflow
- This catches regressions where `:stopdoc:` directives in C extensions are incorrectly reported as undocumented

## Context

This is expected to **fail** on the current `master` branch due to a bug where `done_documenting = false` resets `document_self` for classes that had `:stopdoc:` applied. See #1658 for the fix.

Once verified, the fix from #1658 can be cherry-picked here to confirm it resolves the CI failure.

## Test plan

- [x] Expected to fail without the fix (demonstrates the bug)
- [ ] Should pass after cherry-picking the fix from #1658