### PR TITLE
Overhaul coverage report

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -497,7 +497,7 @@ The internal error was:
     if @options.coverage_report then
       puts
 
-      puts @stats.report.accept RDoc::Markup::ToRdoc.new
+      puts @stats.report
     elsif file_info.empty? then
       $stderr.puts "\nNo newer files." unless @options.quiet
     else
@@ -510,7 +510,7 @@ The internal error was:
 
     if @stats and (@options.coverage_report or not @options.quiet) then
       puts
-      puts @stats.summary.accept RDoc::Markup::ToRdoc.new
+      puts @stats.summary
     end
 
     exit @stats.fully_documented? if @options.coverage_report

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -8,6 +8,19 @@ class RDoc::Stats
   include RDoc::Text
 
   ##
+  # Display order for item types in the coverage report
+
+  TYPE_ORDER = %w[Class Module Constant Attribute Method].freeze
+
+  ##
+  # Message displayed when all items are documented
+
+  GREAT_JOB_MESSAGE = <<~MSG
+    100% documentation!
+    Great Job!
+  MSG
+
+  ##
   # Output level for the coverage report
 
   attr_reader :coverage_level
@@ -194,18 +207,6 @@ class RDoc::Stats
   end
 
   ##
-  # A report that says you did a great job!
-
-  def great_job
-    report = RDoc::Markup::Document.new
-
-    report << RDoc::Markup::Paragraph.new('100% documentation!')
-    report << RDoc::Markup::Paragraph.new('Great Job!')
-
-    report
-  end
-
-  ##
   # Calculates the percentage of items documented.
 
   def percent_doc
@@ -230,164 +231,184 @@ class RDoc::Stats
     if @coverage_level.zero? then
       calculate
 
-      return great_job if @num_items == @doc_items
+      return GREAT_JOB_MESSAGE if @num_items == @doc_items
     end
 
-    ucm = @store.unique_classes_and_modules
-
-    report = RDoc::Markup::Document.new
-    report << RDoc::Markup::Paragraph.new('The following items are not documented:')
-    report << RDoc::Markup::BlankLine.new
-
-    ucm.sort.each do |cm|
-      body = report_class_module(cm) {
-        [
-          report_constants(cm),
-          report_attributes(cm),
-          report_methods(cm),
-        ].compact
-      }
-
-      report << body if body
-    end
+    items, empty_classes = collect_undocumented_items
 
     if @coverage_level > 0 then
       calculate
 
-      return great_job if @num_items == @doc_items
+      return GREAT_JOB_MESSAGE if @num_items == @doc_items
     end
 
-    report
-  end
+    report = +""
+    report << "The following items are not documented:\n\n"
 
-  ##
-  # Returns a report on undocumented attributes in ClassModule +cm+
-
-  def report_attributes(cm)
-    return if cm.attributes.empty?
-
-    report = []
-
-    cm.attributes.each do |attr|
-      next if attr.documented?
-      line = attr.line ? ":#{attr.line}" : nil
-      report << "  #{attr.definition} :#{attr.name} # in file #{attr.file.full_name}#{line}\n"
-      report << "\n"
+    # Referenced-but-empty classes
+    empty_classes.each do |cm|
+      report << "#{cm.full_name} is referenced but empty.\n"
+      report << "It probably came from another project.  I'm sorry I'm holding it against you.\n\n"
     end
 
-    report
-  end
+    # Group items by file, then by type
+    by_file = items.group_by { |item| item[:file] }
 
-  ##
-  # Returns a report on undocumented items in ClassModule +cm+
+    by_file.sort_by { |file, _| file }.each do |file, file_items|
+      report << "#{file}:\n"
 
-  def report_class_module(cm)
-    return if cm.fully_documented? and @coverage_level.zero?
-    return unless cm.display?
+      by_type = file_items.group_by { |item| item[:type] }
 
-    report = RDoc::Markup::Document.new
+      TYPE_ORDER.each do |type|
+        next unless by_type[type]
 
-    if cm.in_files.empty? then
-      report << RDoc::Markup::Paragraph.new("#{cm.definition} is referenced but empty.")
-      report << RDoc::Markup::Paragraph.new("It probably came from another project.  I'm sorry I'm holding it against you.")
+        report << "  #{type}:\n"
 
-      return report
-    elsif cm.documented? then
-      documented = true
-      klass = RDoc::Markup::Verbatim.new("#{cm.definition} # is documented\n")
-    else
-      report << RDoc::Markup::Paragraph.new('In files:')
+        sorted = by_type[type].sort_by { |item| [item[:line] || 0, item[:name]] }
+        name_width = sorted.reduce(0) { |max, item| item[:line] && item[:name].length > max ? item[:name].length : max }
 
-      list = RDoc::Markup::List.new :BULLET
+        sorted.each do |item|
+          if item[:line]
+            report << "    %-*s %s:%d\n" % [name_width, item[:name], item[:file], item[:line]]
+          else
+            report << "    #{item[:name]}\n"
+          end
 
-      cm.in_files.each do |file|
-        para = RDoc::Markup::Paragraph.new file.full_name
-        list << RDoc::Markup::ListItem.new(nil, para)
-      end
-
-      report << list
-      report << RDoc::Markup::BlankLine.new
-
-      klass = RDoc::Markup::Verbatim.new("#{cm.definition}\n")
-    end
-
-    klass << "\n"
-
-    body = yield.flatten # HACK remove #flatten
-
-    if body.empty? then
-      return if documented
-
-      klass.parts.pop
-    else
-      klass.parts.concat body
-    end
-
-    klass << "end\n"
-
-    report << klass
-
-    report
-  end
-
-  ##
-  # Returns a report on undocumented constants in ClassModule +cm+
-
-  def report_constants(cm)
-    return if cm.constants.empty?
-
-    report = []
-
-    cm.constants.each do |constant|
-      # TODO constant aliases are listed in the summary but not reported
-      # figure out what to do here
-      next if constant.documented? || constant.is_alias_for
-
-      line = constant.line ? ":#{constant.line}" : line
-      report << "  # in file #{constant.file.full_name}#{line}\n"
-      report << "  #{constant.name} = nil\n"
-      report << "\n"
-    end
-
-    report
-  end
-
-  ##
-  # Returns a report on undocumented methods in ClassModule +cm+
-
-  def report_methods(cm)
-    return if cm.method_list.empty?
-
-    report = []
-
-    cm.each_method do |method|
-      next if method.documented? and @coverage_level.zero?
-
-      if @coverage_level > 0 then
-        params, undoc = undoc_params method
-
-        @num_params += params
-
-        unless undoc.empty? then
-          @undoc_params += undoc.length
-
-          undoc = undoc.map do |param| "+#{param}+" end
-          param_report = "  # #{undoc.join ', '} is not documented\n"
+          if item[:undoc_params]
+            report << "      Undocumented params: #{item[:undoc_params].join(', ')}\n"
+          end
         end
       end
 
-      next if method.documented? and not param_report
-
-      line = method.line ? ":#{method.line}" : nil
-      scope = method.singleton ? 'self.' : nil
-
-      report << "  # in file #{method.file.full_name}#{line}\n"
-      report << param_report if param_report
-      report << "  def #{scope}#{method.name}#{method.params}; end\n"
       report << "\n"
     end
 
     report
+  end
+
+  ##
+  # Collects all undocumented items across all classes and modules.
+  # Returns [items, empty_classes] where items is an Array of Hashes
+  # with keys :type, :name, :file, :line, and empty_classes is an
+  # Array of ClassModule objects that are referenced but have no files.
+
+  def collect_undocumented_items
+    empty_classes = []
+    items = []
+
+    @store.unique_classes_and_modules.each do |class_module|
+      next unless class_module.display?
+
+      if class_module.in_files.empty?
+        empty_classes << class_module
+        next
+      end
+
+      unless class_module.documented? || class_module.full_name == 'Object'
+        collect_undocumented_class_module(class_module, items)
+      end
+
+      collect_undocumented_constants(class_module, items)
+      collect_undocumented_attributes(class_module, items)
+      collect_undocumented_methods(class_module, items)
+    end
+
+    [items, empty_classes]
+  end
+
+  ##
+  # Collects undocumented classes or modules from +class_module+ into +items+.
+  # Reopened classes/modules are reported in every file they appear in.
+
+  def collect_undocumented_class_module(class_module, items)
+    class_module.in_files.map(&:full_name).uniq.each do |file|
+      items << {
+        type: class_module.type.capitalize,
+        name: class_module.full_name,
+        file: file,
+        line: nil,
+      }
+    end
+  end
+
+  ##
+  # Collects undocumented constants from +class_module+ into +items+.
+
+  def collect_undocumented_constants(class_module, items)
+    class_module.constants.each do |constant|
+      next unless constant.display?
+      next if constant.documented? || constant.is_alias_for
+
+      file = constant.file&.full_name
+      next unless file
+
+      items << {
+        type: "Constant",
+        name: constant.full_name,
+        file: file,
+        line: constant.line,
+      }
+    end
+  end
+
+  ##
+  # Collects undocumented attributes from +class_module+ into +items+.
+
+  def collect_undocumented_attributes(class_module, items)
+    class_module.attributes.each do |attr|
+      next unless attr.display?
+      next if attr.documented?
+
+      file = attr.file&.full_name
+      next unless file
+
+      scope = attr.singleton ? "." : "#"
+      items << {
+        type: "Attribute",
+        name: "#{class_module.full_name}#{scope}#{attr.name}",
+        file: file,
+        line: attr.line,
+      }
+    end
+  end
+
+  ##
+  # Collects undocumented methods from +class_module+ into +items+.
+  # At coverage level > 0, also counts undocumented parameters.
+
+  def collect_undocumented_methods(class_module, items)
+    class_module.each_method do |method|
+      next unless method.display?
+      next if method.documented? && @coverage_level.zero?
+
+      undoc_param_names = nil
+
+      if @coverage_level > 0
+        params, undoc = undoc_params method
+        @num_params += params
+
+        unless undoc.empty?
+          @undoc_params += undoc.length
+          undoc_param_names = undoc
+        end
+      end
+
+      next if method.documented? && !undoc_param_names
+
+      file = method.file&.full_name
+      next unless file
+
+      scope = method.singleton ? "." : "#"
+      item = {
+        type: "Method",
+        name: "#{class_module.full_name}#{scope}#{method.name}",
+        file: file,
+        line: method.line,
+      }
+      item[:undoc_params] = undoc_param_names if undoc_param_names
+
+      items << item
+    end
   end
 
   ##
@@ -407,12 +428,10 @@ class RDoc::Stats
       @undoc_params,
     ].max.to_s.length
 
-    report = RDoc::Markup::Verbatim.new
+    report = +""
 
     report << "Files:      %*d\n" % [num_width, @num_files]
-
     report << "\n"
-
     report << "Classes:    %*d (%*d undocumented)\n" % [
       num_width, @num_classes, undoc_width, @undoc_classes]
     report << "Modules:    %*d (%*d undocumented)\n" % [
@@ -426,17 +445,14 @@ class RDoc::Stats
     report << "Parameters: %*d (%*d undocumented)\n" % [
       num_width, @num_params, undoc_width, @undoc_params] if
         @coverage_level > 0
-
     report << "\n"
-
     report << "Total:      %*d (%*d undocumented)\n" % [
       num_width, @num_items, undoc_width, @undoc_items]
-
     report << "%6.2f%% documented\n" % percent_doc
     report << "\n"
     report << "Elapsed: %0.1fs\n" % (Time.now - @start)
 
-    RDoc::Markup::Document.new report
+    report
   end
 
   ##

--- a/test/rdoc/rdoc_stats_test.rb
+++ b/test/rdoc/rdoc_stats_test.rb
@@ -39,25 +39,15 @@ class RDocStatsTest < RDoc::TestCase
 
     a = RDoc::Attr.new nil, 'a', 'RW', nil
     a.record_location @tl
+    a.line = 3
     c.add_attribute a
 
     @store.complete :public
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(
-          "class C # is documented\n",
-          "\n",
-          "  attr_accessor :a # in file file.rb\n",
-          "\n",
-          "end\n"),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Attribute:\n    C#a file.rb:3\n", report
   end
 
   def test_report_attr_documented
@@ -71,24 +61,7 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    report = @s.report
-
-    assert_equal @s.great_job, report
-  end
-
-  def test_report_attr_line
-    c = @tl.add_class RDoc::NormalClass, 'C'
-    c.record_location @tl
-    c.add_comment 'C', @tl
-
-    a = RDoc::Attr.new nil, 'a', 'RW', nil
-    a.record_location @tl
-    a.line = 3
-    c.add_attribute a
-
-    @store.complete :public
-
-    assert_match '# in file file.rb:3', @s.report.accept(to_rdoc)
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_constant
@@ -98,26 +71,15 @@ class RDocStatsTest < RDoc::TestCase
 
     c = RDoc::Constant.new 'C', nil, nil
     c.record_location @tl
+    c.line = 7
     m.add_constant c
 
     @store.complete :public
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(
-          "module M # is documented\n",
-          "\n",
-          "  # in file file.rb\n",
-          "  C = nil\n",
-          "\n",
-          "end\n"),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Constant:\n    M::C file.rb:7\n", report
   end
 
   def test_report_constant_alias
@@ -133,11 +95,8 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    report = @s.report
-
-    # TODO change this to refute match, aliases should be ignored as they are
-    # programmer convenience constructs
-    assert_match 'class Object', report.accept(to_rdoc)
+    # Constant aliases are skipped in the report
+    refute_match 'CA', @s.report
   end
 
   def test_report_constant_documented
@@ -151,24 +110,7 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    report = @s.report
-
-    assert_equal @s.great_job, report
-  end
-
-  def test_report_constant_line
-    m = @tl.add_module RDoc::NormalModule, 'M'
-    m.record_location @tl
-    m.add_comment 'M', @tl
-
-    c = RDoc::Constant.new 'C', nil, nil
-    c.record_location @tl
-    c.line = 5
-    m.add_constant c
-
-    @store.complete :public
-
-    assert_match '# in file file.rb:5', @s.report.accept(to_rdoc)
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_class
@@ -184,18 +126,8 @@ class RDocStatsTest < RDoc::TestCase
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        para('In files:'),
-        list(:BULLET, *[
-          item(nil, para('file.rb'))]),
-        blank_line,
-        verb("class C\n", "end\n"),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Class:\n    C\n", report
   end
 
   def test_report_skip_object
@@ -209,7 +141,7 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    refute_match %r%^class Object$%, @s.report.accept(to_rdoc)
+    refute_match(/^\s+Object$/, @s.report)
   end
 
   def test_report_class_documented
@@ -224,9 +156,7 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    report = @s.report
-
-    assert_equal @s.great_job, report
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_class_documented_level_1
@@ -253,18 +183,8 @@ class RDocStatsTest < RDoc::TestCase
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        para('In files:'),
-        list(:BULLET, *[
-          item(nil, para('file.rb'))]),
-        blank_line,
-        verb("class C2\n", "end\n"),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Class:\n    C2\n", report
   end
 
   def test_report_class_empty
@@ -274,15 +194,9 @@ class RDocStatsTest < RDoc::TestCase
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        para('class C is referenced but empty.'),
-        para("It probably came from another project.  I'm sorry I'm holding it against you."),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "C is referenced but empty.\n", report
+    assert_match "It probably came from another project.", report
   end
 
   def test_report_class_empty_2
@@ -296,66 +210,26 @@ class RDocStatsTest < RDoc::TestCase
     @store.complete :public
 
     @s.coverage_level = 1
-    report = @s.report
-
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        para('In files:'),
-        list(:BULLET, *[
-          item(nil, para('file.rb'))]),
-        blank_line,
-        verb("class C1\n", "end\n"),
-        blank_line)
-
-    assert_equal expected, report
-  end
-
-  def test_report_class_method_documented
-    c = @tl.add_class RDoc::NormalClass, 'C'
-    c.record_location @tl
-
-    m = RDoc::AnyMethod.new nil, 'm'
-    m.record_location @tl
-    c.add_method m
-    m.comment = 'm'
-
-    @store.complete :public
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        para('In files:'),
-        list(:BULLET, *[
-          item(nil, para('file.rb'))]),
-        blank_line,
-        verb("class C\n", "end\n"),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Class:\n    C1\n", report
   end
 
-  def test_report_class_module_ignore
+  def test_report_ignored_class_excluded
     c = @tl.add_class RDoc::NormalClass, 'C'
     c.ignore
 
     @store.complete :public
 
-    report = @s.report_class_module c
-
-    assert_nil report
+    refute_match(/^\s+C$/, @s.report)
   end
 
   def test_report_empty
     @store.complete :public
 
-    report = @s.report
-
-    assert_equal @s.great_job, report
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_method
@@ -365,6 +239,7 @@ class RDocStatsTest < RDoc::TestCase
 
     m1 = RDoc::AnyMethod.new nil, 'm1'
     m1.record_location @tl
+    m1.line = 5
     c.add_method m1
 
     m2 = RDoc::AnyMethod.new nil, 'm2'
@@ -376,20 +251,8 @@ class RDocStatsTest < RDoc::TestCase
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(*[
-          "class C # is documented\n",
-          "\n",
-          "  # in file file.rb\n",
-          "  def m1; end\n",
-          "\n",
-          "end\n"]),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Method:\n    C#m1 file.rb:5\n", report
   end
 
   def test_report_method_class
@@ -399,6 +262,7 @@ class RDocStatsTest < RDoc::TestCase
 
     m1 = RDoc::AnyMethod.new nil, 'm1', singleton: true
     m1.record_location @tl
+    m1.line = 8
     c.add_method m1
 
     m2 = RDoc::AnyMethod.new nil, 'm2', singleton: true
@@ -410,20 +274,8 @@ class RDocStatsTest < RDoc::TestCase
 
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(*[
-          "class C # is documented\n",
-          "\n",
-          "  # in file file.rb\n",
-          "  def self.m1; end\n",
-          "\n",
-          "end\n"]),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Method:\n    C.m1 file.rb:8\n", report
   end
 
   def test_report_method_documented
@@ -438,24 +290,7 @@ class RDocStatsTest < RDoc::TestCase
 
     @store.complete :public
 
-    report = @s.report
-
-    assert_equal @s.great_job, report
-  end
-
-  def test_report_method_line
-    c = @tl.add_class RDoc::NormalClass, 'C'
-    c.record_location @tl
-    c.add_comment 'C', @tl
-
-    m1 = RDoc::AnyMethod.new nil, 'm1'
-    m1.record_location @tl
-    m1.line = 4
-    c.add_method m1
-
-    @store.complete :public
-
-    assert_match '# in file file.rb:4', @s.report.accept(to_rdoc)
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_method_parameters
@@ -465,6 +300,7 @@ class RDocStatsTest < RDoc::TestCase
 
     m1 = RDoc::AnyMethod.new nil, 'm1'
     m1.record_location @tl
+    m1.line = 10
     m1.params = '(p1, p2)'
     m1.comment = 'Stuff with +p1+'
     c.add_method m1
@@ -477,23 +313,10 @@ class RDocStatsTest < RDoc::TestCase
     @store.complete :public
 
     @s.coverage_level = 1
+
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(*[
-          "class C # is documented\n",
-          "\n",
-          "  # in file file.rb\n",
-          "  # +p2+ is not documented\n",
-          "  def m1(p1, p2); end\n",
-          "\n",
-          "end\n"]),
-        blank_line)
-
-    assert_equal expected, report
+    assert_match "file.rb:\n  Method:\n    C#m1 file.rb:10\n      Undocumented params: p2\n", report
   end
 
   def test_report_method_parameters_documented
@@ -511,9 +334,8 @@ class RDocStatsTest < RDoc::TestCase
     @store.complete :public
 
     @s.coverage_level = 1
-    report = @s.report
 
-    assert_equal @s.great_job, report
+    assert_match "100% documentation!\nGreat Job!\n", @s.report
   end
 
   def test_report_method_parameters_yield
@@ -533,23 +355,196 @@ m(a, b) { |c, d| ... }
     @store.complete :public
 
     @s.coverage_level = 1
+
     report = @s.report
 
-    expected =
-      doc(
-        para('The following items are not documented:'),
-        blank_line,
-        verb(
-          "class C # is documented\n",
-          "\n",
-          "  # in file file.rb\n",
-          "  # +b+, +d+ is not documented\n",
-          "  def m; end\n",
-          "\n",
-          "end\n"),
-        blank_line)
+    assert_match "file.rb:\n  Method:\n    C#m\n      Undocumented params: b, d\n", report
+  end
 
-    assert_equal expected, report
+  def test_report_multiple_files
+    tl2 = @store.add_file 'other.rb'
+    tl2.parser = RDoc::Parser::Ruby
+
+    c1 = @tl.add_class RDoc::NormalClass, 'C1'
+    c1.record_location @tl
+
+    c2 = tl2.add_class RDoc::NormalClass, 'C2'
+    c2.record_location tl2
+
+    @store.complete :public
+
+    report = @s.report
+
+    assert_match "The following items are not documented:\n", report
+    assert_match "file.rb:\n  Class:\n    C1\n", report
+    assert_match "other.rb:\n  Class:\n    C2\n", report
+  end
+
+  def test_report_reopened_class_lists_each_file
+    tl2 = @store.add_file 'other.rb'
+    tl2.parser = RDoc::Parser::Ruby
+
+    c = @tl.add_class RDoc::NormalClass, 'C'
+    c.record_location @tl
+
+    reopened = tl2.add_class RDoc::NormalClass, 'C'
+    reopened.record_location tl2
+
+    assert_same c, reopened
+
+    @store.complete :public
+
+    report = @s.report
+
+    assert_match "file.rb:\n  Class:\n    C\n", report
+    assert_match "other.rb:\n  Class:\n    C\n", report
+  end
+
+  def test_report_reopened_class_lists_each_file_regardless_of_parse_order
+    tl2 = @store.add_file 'other.rb'
+    tl2.parser = RDoc::Parser::Ruby
+
+    c = tl2.add_class RDoc::NormalClass, 'C'
+    c.record_location tl2
+
+    reopened = @tl.add_class RDoc::NormalClass, 'C'
+    reopened.record_location @tl
+
+    assert_same c, reopened
+
+    @store.complete :public
+
+    report = @s.report
+
+    assert_match "file.rb:\n  Class:\n    C\n", report
+    assert_match "other.rb:\n  Class:\n    C\n", report
+  end
+
+  def test_report_file_sorting
+    tl_b = @store.add_file 'b.rb'
+    tl_b.parser = RDoc::Parser::Ruby
+    tl_a = @store.add_file 'a.rb'
+    tl_a.parser = RDoc::Parser::Ruby
+
+    c1 = tl_b.add_class RDoc::NormalClass, 'B'
+    c1.record_location tl_b
+
+    c2 = tl_a.add_class RDoc::NormalClass, 'A'
+    c2.record_location tl_a
+
+    @store.complete :public
+
+    report = @s.report
+
+    a_pos = report.index('a.rb:')
+    b_pos = report.index('b.rb:')
+
+    assert a_pos < b_pos, "a.rb should appear before b.rb"
+  end
+
+  def test_report_items_without_line_sort_first
+    c = @tl.add_class RDoc::NormalClass, 'C'
+    c.record_location @tl
+    c.add_comment 'C', @tl
+
+    m1 = RDoc::AnyMethod.new nil, 'with_line'
+    m1.record_location @tl
+    m1.line = 3
+    c.add_method m1
+
+    m2 = RDoc::AnyMethod.new nil, 'no_line'
+    m2.record_location @tl
+    c.add_method m2
+
+    @store.complete :public
+
+    report = @s.report
+
+    no_line_pos = report.index('no_line')
+    with_line_pos = report.index('with_line')
+
+    assert no_line_pos < with_line_pos,
+      "Items without line numbers should appear before items with line numbers"
+  end
+
+  def test_report_item_sorting_by_line
+    c = @tl.add_class RDoc::NormalClass, 'C'
+    c.record_location @tl
+    c.add_comment 'C', @tl
+
+    m1 = RDoc::AnyMethod.new nil, 'z_method'
+    m1.record_location @tl
+    m1.line = 5
+    c.add_method m1
+
+    m2 = RDoc::AnyMethod.new nil, 'a_method'
+    m2.record_location @tl
+    m2.line = 10
+    c.add_method m2
+
+    @store.complete :public
+
+    report = @s.report
+
+    z_pos = report.index('z_method')
+    a_pos = report.index('a_method')
+
+    assert z_pos < a_pos, "z_method (line 5) should appear before a_method (line 10)"
+  end
+
+  def test_report_mixed_types_in_file
+    c = @tl.add_class RDoc::NormalClass, 'C'
+    c.record_location @tl
+    c.add_comment 'C', @tl
+
+    a = RDoc::Attr.new nil, 'a', 'RW', nil
+    a.record_location @tl
+    a.line = 3
+    c.add_attribute a
+
+    k = RDoc::Constant.new 'K', nil, nil
+    k.record_location @tl
+    k.line = 5
+    c.add_constant k
+
+    m = RDoc::AnyMethod.new nil, 'm'
+    m.record_location @tl
+    m.line = 7
+    c.add_method m
+
+    @store.complete :public
+
+    report = @s.report
+
+    assert_match "file.rb:\n", report
+    assert_match "  Constant:\n    C::K file.rb:5\n", report
+    assert_match "  Attribute:\n    C#a file.rb:3\n", report
+    assert_match "  Method:\n    C#m file.rb:7\n", report
+  end
+
+  def test_report_multi_file_class
+    tl2 = @store.add_file 'ext.c'
+    tl2.parser = RDoc::Parser::C
+
+    c = @tl.add_class RDoc::NormalClass, 'C'
+    c.record_location @tl
+    c.add_comment 'C', @tl
+
+    m1 = RDoc::AnyMethod.new nil, 'ruby_method'
+    m1.record_location @tl
+    m1.line = 10
+    c.add_method m1
+
+    m2 = RDoc::AnyMethod.new nil, 'c_method'
+    m2.record_location tl2
+    c.add_method m2
+
+    @store.complete :public
+
+    report = @s.report
+
+    assert_match "ext.c:\n  Method:\n    C#c_method\n", report
+    assert_match "file.rb:\n  Method:\n    C#ruby_method file.rb:10\n", report
   end
 
   def test_summary
@@ -573,24 +568,24 @@ m(a, b) { |c, d| ... }
 
     @store.complete :public
 
-    summary = @s.summary.accept to_rdoc
-    summary.sub!(/  Elapsed:.*/m, '')
+    summary = @s.summary
+    summary.sub!(/Elapsed:.*/m, '')
 
-    expected = <<-EXPECTED
-  Files:      0
+    expected = <<~EXPECTED
+      Files:      0
 
-  Classes:    1 (1 undocumented)
-  Modules:    1 (1 undocumented)
-  Constants:  1 (1 undocumented)
-  Attributes: 1 (1 undocumented)
-  Methods:    1 (1 undocumented)
+      Classes:    1 (1 undocumented)
+      Modules:    1 (1 undocumented)
+      Constants:  1 (1 undocumented)
+      Attributes: 1 (1 undocumented)
+      Methods:    1 (1 undocumented)
 
-  Total:      5 (5 undocumented)
-    0.00% documented
+      Total:      5 (5 undocumented)
+        0.00% documented
 
     EXPECTED
 
-    assert_equal summary, expected
+    assert_equal expected, summary
   end
 
   def test_summary_level_false
@@ -601,24 +596,24 @@ m(a, b) { |c, d| ... }
 
     @s.coverage_level = false
 
-    summary = @s.summary.accept to_rdoc
-    summary.sub!(/  Elapsed:.*/m, '')
+    summary = @s.summary
+    summary.sub!(/Elapsed:.*/m, '')
 
-    expected = <<-EXPECTED
-  Files:      0
+    expected = <<~EXPECTED
+      Files:      0
 
-  Classes:    1 (1 undocumented)
-  Modules:    0 (0 undocumented)
-  Constants:  0 (0 undocumented)
-  Attributes: 0 (0 undocumented)
-  Methods:    0 (0 undocumented)
+      Classes:    1 (1 undocumented)
+      Modules:    0 (0 undocumented)
+      Constants:  0 (0 undocumented)
+      Attributes: 0 (0 undocumented)
+      Methods:    0 (0 undocumented)
 
-  Total:      1 (1 undocumented)
-    0.00% documented
+      Total:      1 (1 undocumented)
+        0.00% documented
 
     EXPECTED
 
-    assert_equal summary, expected
+    assert_equal expected, summary
   end
 
   def test_summary_level_1
@@ -637,29 +632,25 @@ m(a, b) { |c, d| ... }
     @s.coverage_level = 1
     @s.report
 
-    summary = @s.summary.accept to_rdoc
-    summary.sub!(/  Elapsed:.*/m, '')
+    summary = @s.summary
+    summary.sub!(/Elapsed:.*/m, '')
 
-    expected = <<-EXPECTED
-  Files:      0
+    expected = <<~EXPECTED
+      Files:      0
 
-  Classes:    1 (0 undocumented)
-  Modules:    0 (0 undocumented)
-  Constants:  0 (0 undocumented)
-  Attributes: 0 (0 undocumented)
-  Methods:    1 (0 undocumented)
-  Parameters: 2 (1 undocumented)
+      Classes:    1 (0 undocumented)
+      Modules:    0 (0 undocumented)
+      Constants:  0 (0 undocumented)
+      Attributes: 0 (0 undocumented)
+      Methods:    1 (0 undocumented)
+      Parameters: 2 (1 undocumented)
 
-  Total:      4 (1 undocumented)
-   75.00% documented
+      Total:      4 (1 undocumented)
+       75.00% documented
 
     EXPECTED
 
-    assert_equal summary, expected
-  end
-
-  def to_rdoc
-    RDoc::Markup::ToRdoc.new
+    assert_equal expected, summary
   end
 
   def test_undoc_params


### PR DESCRIPTION
## Summary

- Make the coverage result more concise and useful
- Make the output less confusing for C source files
- Simplify implementation by decoupling it from RDoc's markup elements
- Fix: reopened classes (defined across multiple files) are now reported under each file they appear in, not just the first

### Before (Ruby pseudo-code format)

```
class RDoc::Generator::Darkfish # is documented

    # in file lib/rdoc/generator/darkfish.rb:744
    def generate_ancestor_list(ancestors, klass); end

    # in file lib/rdoc/generator/darkfish.rb:762
    def generate_class_link(klass, rel_prefix); end

end


class RDoc::Markup::ToAnsi # is documented

    # in file lib/rdoc/markup/to_ansi.rb:29
    ANSI_STYLE_CODES_OFF = nil

    # in file lib/rdoc/markup/to_ansi.rb:59
    def add_text(text); end

    # in file lib/rdoc/markup/to_ansi.rb:131
    def calculate_text_width(text); end

end
```

### After (file-centric format)

```
lib/rdoc/generator/darkfish.rb:
  Method:
    RDoc::Generator::Darkfish#generate_ancestor_list                 lib/rdoc/generator/darkfish.rb:744
    RDoc::Generator::Darkfish#generate_class_link                    lib/rdoc/generator/darkfish.rb:762

lib/rdoc/markup/to_ansi.rb:
  Constant:
    RDoc::Markup::ToAnsi::ANSI_STYLE_CODES_OFF lib/rdoc/markup/to_ansi.rb:29
  Method:
    RDoc::Markup::ToAnsi#add_text             lib/rdoc/markup/to_ansi.rb:59
    RDoc::Markup::ToAnsi#calculate_text_width lib/rdoc/markup/to_ansi.rb:131
```

### C source file output (Ruby's object.c)

```
object.c:
  Class:
    Refinement
```

No more `class Refinement ... end` pseudo-code that makes it look like the C file is being treated as a Ruby script.

### Accuracy verification

Coverage metrics are unchanged for projects other than RDoc itself:

| Project | Branch | Master |
|---------|--------|--------|
| IRB     | 117 items, 40 undoc (65.81%) | 117 items, 40 undoc (65.81%) |
| Ruby    | 12110 items, 1472 undoc (87.84%) | 12110 items, 1472 undoc (87.84%) |