### PR TITLE
Display RBS type signatures in documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      # 2.7 breaks `test_parse_statements_nodoc_identifier_alias_method`
-      min_version: 3.0
+      min_version: 3.2
       versions: '["mswin"]'
+      engine: cruby-truffleruby
 
   test:
     needs: ruby-versions
@@ -30,10 +30,6 @@ jobs:
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head
-          - os: windows-latest
-            ruby: jruby
-          - os: windows-latest
-            ruby: jruby-head
           - os: macos-latest
             ruby: mswin
           - os: ubuntu-latest
@@ -63,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        prism_version: ['1.0.0', '1.3.0', '1.7.0', 'head']
+        prism_version: ['1.6.0', '1.7.0', 'head']
     runs-on: ubuntu-latest
     env:
       RUBYOPT: --enable-frozen_string_literal

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,5 @@ elsif ENV['PRISM_VERSION']
 end
 
 platforms :ruby do
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2')
-    gem 'mini_racer' # For testing the searcher.js file
-  end
+  gem 'mini_racer' # For testing the searcher.js file
 end

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -151,6 +151,16 @@ module RDoc
     end
   end
 
+  ##
+  # Returns +File.mtime(file)+, or +nil+ if the file cannot be stat'd
+  # (missing, permission denied, etc.).
+
+  def self.safe_mtime(file)
+    File.mtime(file)
+  rescue SystemCallError
+    nil
+  end
+
   autoload :RDoc,           "#{__dir__}/rdoc/rdoc"
 
   autoload :CrossReference, "#{__dir__}/rdoc/cross_reference"

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -13,8 +13,10 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # 3::
   #   RDoc 4.1
   #   Added is_alias_for
+  # 4::
+  #   Added type_signature_lines (serialized as joined string)
 
-  MARSHAL_VERSION = 3 # :nodoc:
+  MARSHAL_VERSION = 4 # :nodoc:
 
   ##
   # Don't rename \#initialize to \::new
@@ -60,6 +62,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     method.visibility = self.visibility
     method.comment = an_alias.comment
     method.is_alias_for = self
+    method.type_signature_lines = self.type_signature_lines
     @aliases << method
     context.add_method method if context
     method
@@ -166,6 +169,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       @parent.class,
       @section.title,
       is_alias_for,
+      @type_signature_lines&.join("\n"),
     ]
   end
 
@@ -204,6 +208,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     @parent_title  = array[13]
     @section_title = array[14]
     @is_alias_for  = array[15]
+    @type_signature_lines = array[16]&.split("\n")
 
     array[8].each do |new_name, document|
       add_alias RDoc::Alias.new(nil, @name, new_name, RDoc::Comment.from_document(document), singleton: @singleton)

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -10,8 +10,10 @@ class RDoc::Attr < RDoc::MethodAttr
   #   RDoc 4
   #    Added parent name and class
   #    Added section title
+  # 4::
+  #   Added type_signature_lines (serialized as joined string)
 
-  MARSHAL_VERSION = 3 # :nodoc:
+  MARSHAL_VERSION = 4 # :nodoc:
 
   ##
   # Is the attribute readable ('R'), writable ('W') or both ('RW')?
@@ -48,6 +50,7 @@ class RDoc::Attr < RDoc::MethodAttr
     new_attr.record_location an_alias.file
     new_attr.visibility = self.visibility
     new_attr.is_alias_for = self
+    new_attr.type_signature_lines = self.type_signature_lines
     @aliases << new_attr
     context.add_attribute new_attr
     new_attr
@@ -108,7 +111,8 @@ class RDoc::Attr < RDoc::MethodAttr
       @file.relative_name,
       @parent.full_name,
       @parent.class,
-      @section.title
+      @section.title,
+      @type_signature_lines&.join("\n"),
     ]
   end
 
@@ -140,6 +144,7 @@ class RDoc::Attr < RDoc::MethodAttr
     @parent_name   = array[8]
     @parent_class  = array[9]
     @section_title = array[10]
+    @type_signature_lines = array[11]&.split("\n")
 
     @file = RDoc::TopLevel.new array[7] if version > 1
 

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -59,6 +59,12 @@ class RDoc::MethodAttr < RDoc::CodeObject
   attr_accessor :call_seq
 
   ##
+  # RBS type signature lines from inline annotations or loaded .rbs files.
+  # Each entry is one overload or type expression.
+
+  attr_accessor :type_signature_lines
+
+  ##
   # The call_seq or the param_seq with method name, if there is no call_seq.
 
   attr_reader :arglists
@@ -86,6 +92,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
     @block_params = nil
     @call_seq     = nil
     @params       = nil
+    @type_signature_lines = nil
   end
 
   ##

--- a/lib/rdoc/generator/aliki.rb
+++ b/lib/rdoc/generator/aliki.rb
@@ -118,6 +118,21 @@ class RDoc::Generator::Aliki < RDoc::Generator::Darkfish
   end
 
   ##
+  # Returns the type signature of +method_attr+ as HTML with linked type names.
+  # Returns nil if no type signature is present.
+
+  def type_signature_html(method_attr, from_path)
+    lines = method_attr.type_signature_lines
+    return unless lines
+
+    RDoc::RbsHelper.signature_to_html(
+      lines,
+      lookup: @store.type_name_lookup,
+      from_path: from_path
+    )
+  end
+
+  ##
   # Resolves a URL for use in templates. Absolute URLs are returned unchanged.
   # Relative URLs are prefixed with rel_prefix to ensure they resolve correctly from any page.
 

--- a/lib/rdoc/generator/aliki.rb
+++ b/lib/rdoc/generator/aliki.rb
@@ -122,7 +122,7 @@ class RDoc::Generator::Aliki < RDoc::Generator::Darkfish
   # Returns nil if no type signature is present.
 
   def type_signature_html(method_attr, from_path)
-    lines = method_attr.type_signature_lines
+    lines = method_attr.type_signature_lines || @store.rbs_signature_for(method_attr)
     return unless lines
 
     RDoc::RbsHelper.signature_to_html(

--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -93,6 +93,9 @@
             <span class="method-name"><%= h attrib.name %></span>
             <span class="attribute-access-type">[<%= attrib.rw %>]</span>
           </a>
+          <%- if attrib.type_signature_lines %>
+          <span class="method-type-signature"><code><%= type_signature_html(attrib, klass.path) %></code></span>
+          <%- end %>
         </div>
 
         <div class="method-description">
@@ -149,6 +152,10 @@
                 <span class="method-args"><%= h method.param_seq %></span>
               </a>
             </div>
+          <%- end %>
+
+          <%- if method.type_signature_lines %>
+          <pre class="method-type-signature"><code><%= type_signature_html(method, klass.path) %></code></pre>
           <%- end %>
         </div>
 

--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -93,8 +93,8 @@
             <span class="method-name"><%= h attrib.name %></span>
             <span class="attribute-access-type">[<%= attrib.rw %>]</span>
           </a>
-          <%- if attrib.type_signature_lines %>
-          <span class="method-type-signature"><code><%= type_signature_html(attrib, klass.path) %></code></span>
+          <%- if (sig_html = type_signature_html(attrib, klass.path)) %>
+          <span class="method-type-signature"><code><%= sig_html %></code></span>
           <%- end %>
         </div>
 
@@ -154,8 +154,8 @@
             </div>
           <%- end %>
 
-          <%- if method.type_signature_lines %>
-          <pre class="method-type-signature"><code><%= type_signature_html(method, klass.path) %></code></pre>
+          <%- if (sig_html = type_signature_html(method, klass.path)) %>
+          <pre class="method-type-signature"><code><%= sig_html %></code></pre>
           <%- end %>
         </div>
 

--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1073,6 +1073,20 @@ main h6 a:hover {
   font-style: italic;
 }
 
+/* RBS Type Signature Links — linked types get subtle underline */
+a.rbs-type {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-border-default);
+  text-underline-offset: 0.2em;
+  transition: text-decoration-color var(--transition-fast), color var(--transition-fast);
+}
+
+a.rbs-type:hover {
+  color: var(--color-link-hover);
+  text-decoration-color: var(--color-link-hover);
+}
+
 /* Emphasis */
 em {
   text-decoration-color: var(--color-emphasis-decoration);
@@ -1334,6 +1348,49 @@ main .method-heading .method-args {
   font-weight: var(--font-weight-normal);
 }
 
+/* Type signatures — overloads stack as a code block under the method name */
+pre.method-type-signature {
+  position: relative;
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2) 0 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
+  font-family: var(--font-code);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  line-height: var(--line-height-tight);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+pre.method-type-signature::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  border-top: 1px dotted var(--color-border-default);
+}
+
+pre.method-type-signature code {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background: transparent;
+  padding: 0;
+}
+
+/* Attribute type sigs render inline after the [RW] badge */
+main .method-heading > .method-type-signature {
+  display: inline;
+  margin-left: var(--space-2);
+  font-family: var(--font-code);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
 main .method-controls {
   position: absolute;
   top: var(--space-3);
@@ -1441,6 +1498,10 @@ main .attribute-access-type {
 
   main .method-heading {
     font-size: var(--font-size-base);
+  }
+
+  pre.method-type-signature {
+    font-size: var(--font-size-xs);
   }
 
   main .method-header {

--- a/lib/rdoc/generator/template/aliki/js/aliki.js
+++ b/lib/rdoc/generator/template/aliki/js/aliki.js
@@ -435,8 +435,8 @@ function wrapCodeBlocksWithCopyButton() {
   //   not directly in rhtml templates
   // - Modifying the formatter would require extending RDoc's core internals
 
-  // Find all pre elements that are not already wrapped
-  const preElements = document.querySelectorAll('main pre:not(.code-block-wrapper pre)');
+  // Target code examples and source code; skip type signature blocks
+  const preElements = document.querySelectorAll('main pre:not(.method-type-signature)');
 
   preElements.forEach((pre) => {
     // Skip if already wrapped

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -461,16 +461,15 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def consecutive_comment(line_no)
     return unless @unprocessed_comments.first&.first == line_no
     _line_no, start_line, text = @unprocessed_comments.shift
-    type_signature_lines = extract_type_signature!(text, start_line)
-    result = parse_comment_text_to_directives(text, start_line)
-    return unless result
-    comment, directives = result
-    [comment, directives, type_signature_lines]
+    parse_comment_text_to_directives(text, start_line)
   end
 
-  # Parses comment text and returns a pair of RDoc::Comment and directives
+  # Parses comment text and returns +[RDoc::Comment, directives, type_signature_lines]+,
+  # or +nil+ if the comment is a section header (which has no associated code
+  # object).
 
   def parse_comment_text_to_directives(comment_text, start_line) # :nodoc:
+    type_signature_lines = extract_type_signature!(comment_text, start_line)
     comment_text, directives = @preprocess.parse_comment(comment_text, start_line, :ruby)
     comment = RDoc::Comment.new(comment_text, @top_level, :ruby)
     comment.normalized = true
@@ -484,7 +483,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       return
     end
     @preprocess.run_post_processes(comment, @container)
-    [comment, directives]
+    [comment, directives, type_signature_lines]
   end
 
   # Extracts the comment for this section from the normalized comment block.

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -828,7 +828,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
   # Extracts RBS type signature lines (#: ...) from raw comment text.
   # Mutates the input text to remove the extracted lines.
-  # Returns the type signature string, or nil if none found.
+  # Returns an array of extracted type signature lines, or nil if none are
+  # found. The array may contain multiple lines for overloaded signatures.
 
   def extract_type_signature!(text, start_line)
     return nil unless text.include?('#:')

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'prism'
+require_relative '../rbs_helper'
 
 # Parse and collect document from Ruby source code.
 
@@ -126,6 +127,9 @@ require 'prism'
 class RDoc::Parser::Ruby < RDoc::Parser
 
   parse_files_matching(/\.rbw?$/)
+
+  # Matches an RBS inline type annotation line: #: followed by whitespace
+  RBS_SIG_LINE = /\A#:\s/ # :nodoc:
 
   attr_accessor :visibility
   attr_reader :container, :singleton, :in_proc_block
@@ -457,10 +461,14 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def consecutive_comment(line_no)
     return unless @unprocessed_comments.first&.first == line_no
     _line_no, start_line, text = @unprocessed_comments.shift
-    parse_comment_text_to_directives(text, start_line)
+    type_signature_lines = extract_type_signature!(text, start_line)
+    result = parse_comment_text_to_directives(text, start_line)
+    return unless result
+    comment, directives = result
+    [comment, directives, type_signature_lines]
   end
 
-  # Parses comment text and retuns a pair of RDoc::Comment and directives
+  # Parses comment text and returns a pair of RDoc::Comment and directives
 
   def parse_comment_text_to_directives(comment_text, start_line) # :nodoc:
     comment_text, directives = @preprocess.parse_comment(comment_text, start_line, :ruby)
@@ -569,7 +577,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # Handles `attr :a, :b`, `attr_reader :a, :b`, `attr_writer :a, :b` and `attr_accessor :a, :b`
 
   def add_attributes(names, rw, line_no)
-    comment, directives = consecutive_comment(line_no)
+    comment, directives, type_signature_lines = consecutive_comment(line_no)
     handle_code_object_directives(@container, directives) if directives
     return unless @container.document_children
 
@@ -577,6 +585,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       a = RDoc::Attr.new(nil, symbol.to_s, rw, comment, singleton: @singleton)
       a.store = @store
       a.line = line_no
+      a.type_signature_lines = type_signature_lines
       record_location(a)
       handle_modifier_directive(a, line_no)
       @container.add_attribute(a) if should_document?(a)
@@ -615,7 +624,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
   def add_method(method_name, receiver_name:, receiver_fallback_type:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:, start_line:, args_end_line:, end_line:)
     receiver = receiver_name ? find_or_create_module_path(receiver_name, receiver_fallback_type) : @container
-    comment, directives = consecutive_comment(start_line)
+    comment, directives, type_signature_lines = consecutive_comment(start_line)
     handle_code_object_directives(@container, directives) if directives
 
     internal_add_method(
@@ -630,11 +639,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
       params: params,
       calls_super: calls_super,
       block_params: block_params,
-      tokens: tokens
+      tokens: tokens,
+      type_signature_lines: type_signature_lines
     )
   end
 
-  private def internal_add_method(method_name, container, comment:, dont_rename_initialize: false, directives:, modifier_comment_lines: nil, line_no:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:) # :nodoc:
+  private def internal_add_method(method_name, container, comment:, dont_rename_initialize: false, directives:, modifier_comment_lines: nil, line_no:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:, type_signature_lines: nil) # :nodoc:
     meth = RDoc::AnyMethod.new(nil, method_name, singleton: singleton)
     meth.comment = comment
     handle_code_object_directives(meth, directives) if directives
@@ -655,6 +665,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     meth.params ||= params || '()'
     meth.calls_super = calls_super
     meth.block_params ||= block_params if block_params
+    meth.type_signature_lines = type_signature_lines
     record_location(meth)
     meth.start_collecting_tokens(:ruby)
     tokens.each do |token|
@@ -811,6 +822,36 @@ class RDoc::Parser::Ruby < RDoc::Parser
     handle_modifier_directive(mod, end_line)
     mod.add_comment(comment, @top_level) if comment
     mod
+  end
+
+  private
+
+  # Extracts RBS type signature lines (#: ...) from raw comment text.
+  # Mutates the input text to remove the extracted lines.
+  # Returns the type signature string, or nil if none found.
+
+  def extract_type_signature!(text, start_line)
+    return nil unless text.include?('#:')
+
+    lines = text.lines
+    sig_lines, doc_lines = lines.partition { |l| l.match?(RBS_SIG_LINE) }
+    return nil if sig_lines.empty?
+
+    first_sig_line = start_line + lines.index(sig_lines.first)
+    text.replace(doc_lines.join)
+    type_signature_lines = sig_lines.map { |l| l.sub(RBS_SIG_LINE, '').strip }.reject(&:empty?)
+    return nil if type_signature_lines.empty?
+
+    warn_invalid_type_signature(type_signature_lines, first_sig_line)
+    type_signature_lines
+  end
+
+  def warn_invalid_type_signature(type_signature_lines, line_no)
+    type_signature_lines.each_with_index do |line, i|
+      next if RDoc::RbsHelper.valid_method_type?(line)
+      next if RDoc::RbsHelper.valid_type?(line)
+      @options.warn "#{@top_level.relative_name}:#{line_no + i}: invalid RBS type signature: #{line.inspect}"
+    end
   end
 
   class RDocVisitor < Prism::Visitor # :nodoc:

--- a/lib/rdoc/rbs_helper.rb
+++ b/lib/rdoc/rbs_helper.rb
@@ -36,7 +36,7 @@ module RDoc
 
       ##
       # Loads RBS signatures from the given directories.
-      # Returns a Hash mapping "ClassName#method_name" => "type sig string".
+      # Returns a Hash mapping "ClassName#method_name" => ["type sig string", ...].
 
       def load_signatures(*dirs)
         loader = RBS::EnvironmentLoader.new

--- a/lib/rdoc/rbs_helper.rb
+++ b/lib/rdoc/rbs_helper.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'pathname'
+require 'rbs'
+require 'rdoc/markup/formatter'
+
+##
+# RBS type signature support.
+# Loads type information from .rbs files, validates inline annotations,
+# and converts type signatures to HTML with linked type names.
+
+module RDoc
+  module RbsHelper
+    class << self
+
+      ##
+      # Returns true if +sig+ is a valid RBS method type signature.
+
+      def valid_method_type?(sig)
+        RBS::Parser.parse_method_type(sig, require_eof: true)
+        true
+      rescue RBS::ParsingError
+        false
+      end
+
+      ##
+      # Returns true if +sig+ is a valid RBS type signature.
+
+      def valid_type?(sig)
+        RBS::Parser.parse_type(sig, require_eof: true)
+        true
+      rescue RBS::ParsingError
+        false
+      end
+
+      ##
+      # Loads RBS signatures from the given directories.
+      # Returns a Hash mapping "ClassName#method_name" => "type sig string".
+
+      def load_signatures(*dirs)
+        loader = RBS::EnvironmentLoader.new
+        dirs.each { |dir| loader.add(path: Pathname(dir)) }
+
+        env = RBS::Environment.new
+        loader.load(env: env)
+
+        signatures = {}
+
+        env.class_decls.each do |type_name, entry|
+          class_name = type_name.to_s.delete_prefix('::')
+
+          entry.each_decl do |decl|
+            decl.members.each do |member|
+              case member
+              when RBS::AST::Members::MethodDefinition
+                key = member.singleton? ? "#{class_name}.#{member.name}" : "#{class_name}##{member.name}"
+                sigs = member.overloads.map { |o| o.method_type.to_s }
+                signatures[key] ||= sigs
+              when RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter, RBS::AST::Members::AttrAccessor
+                key = "#{class_name}##{member.name}"
+                signatures[key] ||= [member.type.to_s]
+              end
+            end
+          end
+        end
+
+        signatures
+      end
+
+      ##
+      # Converts type signature lines to HTML with type names linked to
+      # their documentation pages. Uses the RBS parser to extract type
+      # name locations precisely.
+      #
+      # +lines+ is an Array of signature line strings.
+      # +lookup+ is a Hash mapping type names to their doc paths.
+      # +from_path+ is the current page path for generating relative URLs.
+      #
+      # Returns escaped HTML with +->+ replaced by +→+.
+
+      def signature_to_html(lines, lookup:, from_path:)
+        lines.map { |line|
+          link_type_names_in_line(line, lookup, from_path).gsub('-&gt;', '&rarr;')
+        }.join("\n")
+      end
+
+      private
+
+      def link_type_names_in_line(line, lookup, from_path)
+        escaped = ERB::Util.html_escape(line)
+
+        locs = collect_type_name_locations(line)
+        return escaped if locs.empty?
+
+        result = escaped.dup
+
+        # Replace type names with links, working backwards to preserve positions.
+        # HTML escaping (e.g. -> becomes -&gt;) shifts positions, so we
+        # re-escape the prefix to find the correct offset in the result.
+        locs.sort_by { |l| -l[:start] }.each do |loc|
+          name = loc[:name]
+          next unless (target_path = lookup[name])
+
+          prefix = ERB::Util.html_escape(line[0...loc[:start]])
+          escaped_name = ERB::Util.html_escape(name)
+          start_in_escaped = prefix.length
+          end_in_escaped = start_in_escaped + escaped_name.length
+
+          href = ERB::Util.html_escape(::RDoc::Markup::Formatter.gen_relative_url(from_path, target_path))
+          result[start_in_escaped...end_in_escaped] =
+            "<a href=\"#{href}\" class=\"rbs-type\">#{escaped_name}</a>"
+        end
+
+        result
+      end
+
+      ##
+      # Extracts type name locations from a signature line using the RBS parser.
+
+      def collect_type_name_locations(line)
+        locs = []
+
+        begin
+          mt = RBS::Parser.parse_method_type(line, require_eof: true)
+        rescue RBS::ParsingError
+          begin
+            type = RBS::Parser.parse_type(line, require_eof: true)
+            collect_from_type(type, locs)
+            return locs
+          rescue RBS::ParsingError
+            return locs
+          end
+        end
+
+        mt.type.each_param { |p| collect_from_type(p.type, locs) }
+        if mt.block
+          mt.block.type.each_param { |p| collect_from_type(p.type, locs) }
+          collect_from_type(mt.block.type.return_type, locs)
+        end
+        collect_from_type(mt.type.return_type, locs)
+
+        locs
+      end
+
+      ##
+      # Recursively collects type name locations from an RBS type AST node.
+
+      def collect_from_type(type, locs)
+        case type
+        when RBS::Types::ClassInstance
+          name = type.name.to_s.delete_prefix('::')
+          if type.location
+            name_loc = type.location[:name] || type.location
+            locs << { name: name, start: name_loc.end_pos - name.length }
+          end
+          type.args.each { |a| collect_from_type(a, locs) }
+        when RBS::Types::Union, RBS::Types::Intersection, RBS::Types::Tuple
+          type.types.each { |t| collect_from_type(t, locs) }
+        when RBS::Types::Optional
+          collect_from_type(type.type, locs)
+        when RBS::Types::Record
+          type.all_fields.each_value { |t| collect_from_type(t, locs) }
+        when RBS::Types::Proc
+          type.type.each_param { |p| collect_from_type(p.type, locs) }
+          collect_from_type(type.type.return_type, locs)
+        end
+      end
+    end
+  end
+end

--- a/lib/rdoc/rbs_helper.rb
+++ b/lib/rdoc/rbs_helper.rb
@@ -58,7 +58,7 @@ module RDoc
                 sigs = member.overloads.map { |o| o.method_type.to_s }
                 signatures[key] ||= sigs
               when RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter, RBS::AST::Members::AttrAccessor
-                key = "#{class_name}##{member.name}"
+                key = member.kind == :singleton ? "#{class_name}.#{member.name}" : "#{class_name}##{member.name}"
                 signatures[key] ||= [member.type.to_s]
               end
             end

--- a/lib/rdoc/rbs_helper.rb
+++ b/lib/rdoc/rbs_helper.rb
@@ -54,9 +54,10 @@ module RDoc
             decl.members.each do |member|
               case member
               when RBS::AST::Members::MethodDefinition
-                key = member.singleton? ? "#{class_name}.#{member.name}" : "#{class_name}##{member.name}"
                 sigs = member.overloads.map { |o| o.method_type.to_s }
-                signatures[key] ||= sigs
+                method_keys_for(class_name, member).each do |key|
+                  signatures[key] ||= sigs
+                end
               when RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter, RBS::AST::Members::AttrAccessor
                 key = member.kind == :singleton ? "#{class_name}.#{member.name}" : "#{class_name}##{member.name}"
                 signatures[key] ||= [member.type.to_s]
@@ -86,6 +87,20 @@ module RDoc
       end
 
       private
+
+      # `def self?.foo: ...` produces a member whose kind is :singleton_instance —
+      # it defines both Class.foo (singleton) and a private Class#foo (instance),
+      # so we need to register the signature under both keys.
+      def method_keys_for(class_name, member)
+        case member.kind
+        when :singleton
+          ["#{class_name}.#{member.name}"]
+        when :singleton_instance
+          ["#{class_name}.#{member.name}", "#{class_name}##{member.name}"]
+        else
+          ["#{class_name}##{member.name}"]
+        end
+      end
 
       def link_type_names_in_line(line, lookup, from_path)
         escaped = ERB::Util.html_escape(line)

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -5,6 +5,7 @@ require 'find'
 require 'fileutils'
 require 'pathname'
 require 'time'
+require_relative 'rbs_helper'
 
 ##
 # This is the driver for generating RDoc output.  It handles file parsing and
@@ -473,6 +474,7 @@ The internal error was:
       @options.default_title = "RDoc Documentation"
 
       @store.complete @options.visibility
+      load_rbs_signatures
 
       start_server
       exit
@@ -491,6 +493,8 @@ The internal error was:
     @options.default_title = "RDoc Documentation"
 
     @store.complete @options.visibility
+
+    load_rbs_signatures
 
     @stats.coverage_level = @options.coverage_report
 
@@ -538,6 +542,20 @@ The internal error was:
         update_output_dir '.', @start_time, @last_modified
       end
     end
+  end
+
+  ##
+  # Loads RBS type signatures from the project's sig/ directory and
+  # RBS stdlib, then merges them into the store's code objects.
+
+  def load_rbs_signatures
+    sig_dirs = []
+    sig_dir = File.join(@options.root.to_s, 'sig')
+    sig_dirs << sig_dir if File.directory?(sig_dir)
+    signatures = RDoc::RbsHelper.load_signatures(*sig_dirs)
+    @store.merge_rbs_signatures(signatures) unless signatures.empty?
+  rescue RBS::ParsingError, Errno::ENOENT, LoadError => e
+    @options.warn "Failed to load RBS type signatures: #{e.message}"
   end
 
   ##

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -430,8 +430,8 @@ The internal error was:
 
   def remove_unparseable(files)
     files.reject do |file, *|
-      file =~ /\.(?:class|eps|erb|rbs|scpt\.txt|svg|ttf|yml)$/i or
-        (file =~ /tags$/i and
+      file =~ /\.(?:class|eps|erb|rbs|scpt\.txt|svg|ttf|yml)\z/i or
+        (file =~ /tags\z/i and
          /\A(\f\n[^,]+,\d+$|!_TAG_)/.match?(File.binread(file, 100)))
     end
   end
@@ -582,7 +582,7 @@ The internal error was:
 
   def rbs_signatures_changed?
     current = rbs_signature_mtimes
-    previous = @last_modified.select { |file, _| File.extname(file) == '.rbs' }
+    previous = @last_modified.select { |file, _| rbs_signature_file?(file) }
 
     return true unless (previous.keys - current.keys).empty?
 
@@ -597,7 +597,7 @@ The internal error was:
   # and the live server watcher can see signature-only edits.
 
   def record_rbs_signature_mtimes
-    @last_modified.reject! { |file, _| File.extname(file) == '.rbs' }
+    @last_modified.reject! { |file, _| rbs_signature_file?(file) }
     @last_modified.merge! rbs_signature_mtimes
   end
 
@@ -614,7 +614,7 @@ The internal error was:
 
   def rbs_signature_mtimes # :nodoc:
     rbs_signature_files.each_with_object({}) do |file, mtimes|
-      mtime = File.mtime(file) rescue nil
+      mtime = RDoc.safe_mtime(file)
       mtimes[file] = mtime if mtime
     end
   end

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -474,8 +474,8 @@ The internal error was:
 
       @options.default_title = "RDoc Documentation"
 
-      @store.complete @options.visibility
       load_rbs_signatures
+      @store.complete @options.visibility
 
       start_server
       exit
@@ -490,9 +490,11 @@ The internal error was:
     @store.load_cache
 
     rbs_signatures_changed = rbs_signatures_changed?
-    # When only sig/*.rbs changed, no Ruby file would be reparsed and the
-    # cached HTML pipeline keeps no in-memory class data across runs, so
-    # force a full reparse to give merge_rbs_signatures a populated store.
+    # When only sig/*.rbs changed, no Ruby file would be reparsed under
+    # normal mtime checks.  The store cache holds class metadata but not
+    # live RDoc::Context objects, so the generator would have nothing to
+    # iterate.  Force a full reparse so updated signatures show up in
+    # the rendered output.
     @last_modified.clear if rbs_signatures_changed
 
     file_info = parse_files @options.files
@@ -500,9 +502,9 @@ The internal error was:
 
     @options.default_title = "RDoc Documentation"
 
-    @store.complete @options.visibility
-
     load_rbs_signatures
+
+    @store.complete @options.visibility
 
     @stats.coverage_level = @options.coverage_report
 

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -562,7 +562,11 @@ The internal error was:
     sig_dirs << sig_dir if File.directory?(sig_dir)
     signatures = RDoc::RbsHelper.load_signatures(*sig_dirs)
     @store.merge_rbs_signatures(signatures)
-  rescue RBS::ParsingError, Errno::ENOENT, LoadError => e
+  rescue RBS::BaseError, Errno::ENOENT, LoadError => e
+    # In server mode, a previous successful load may have populated the store;
+    # drop those signatures so a now-broken sig file doesn't keep showing
+    # stale types alongside the warning.
+    @store.clear_rbs_signatures
     @options.warn "Failed to load RBS type signatures: #{e.message}"
   end
 

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -430,7 +430,7 @@ The internal error was:
 
   def remove_unparseable(files)
     files.reject do |file, *|
-      file =~ /\.(?:class|eps|erb|scpt\.txt|svg|ttf|yml)$/i or
+      file =~ /\.(?:class|eps|erb|rbs|scpt\.txt|svg|ttf|yml)$/i or
         (file =~ /tags$/i and
          /\A(\f\n[^,]+,\d+$|!_TAG_)/.match?(File.binread(file, 100)))
     end
@@ -470,6 +470,7 @@ The internal error was:
       @store.load_cache
 
       parse_files @options.files
+      record_rbs_signature_mtimes
 
       @options.default_title = "RDoc Documentation"
 
@@ -488,7 +489,14 @@ The internal error was:
 
     @store.load_cache
 
+    rbs_signatures_changed = rbs_signatures_changed?
+    # When only sig/*.rbs changed, no Ruby file would be reparsed and the
+    # cached HTML pipeline keeps no in-memory class data across runs, so
+    # force a full reparse to give merge_rbs_signatures a populated store.
+    @last_modified.clear if rbs_signatures_changed
+
     file_info = parse_files @options.files
+    record_rbs_signature_mtimes
 
     @options.default_title = "RDoc Documentation"
 
@@ -502,7 +510,7 @@ The internal error was:
       puts
 
       puts @stats.report
-    elsif file_info.empty? then
+    elsif file_info.empty? && !rbs_signatures_changed then
       $stderr.puts "\nNo newer files." unless @options.quiet
     else
       gen_klass = @options.generator
@@ -553,9 +561,58 @@ The internal error was:
     sig_dir = File.join(@options.root.to_s, 'sig')
     sig_dirs << sig_dir if File.directory?(sig_dir)
     signatures = RDoc::RbsHelper.load_signatures(*sig_dirs)
-    @store.merge_rbs_signatures(signatures) unless signatures.empty?
+    @store.merge_rbs_signatures(signatures)
   rescue RBS::ParsingError, Errno::ENOENT, LoadError => e
     @options.warn "Failed to load RBS type signatures: #{e.message}"
+  end
+
+  ##
+  # Returns all RBS signature files for the project.
+
+  def rbs_signature_files
+    Dir[File.join(@options.root.to_s, 'sig', '**', '*.rbs')].sort
+  end
+
+  ##
+  # Returns true if any RBS signature file has changed since the last run.
+
+  def rbs_signatures_changed?
+    current = rbs_signature_mtimes
+    previous = @last_modified.select { |file, _| File.extname(file) == '.rbs' }
+
+    return true unless (previous.keys - current.keys).empty?
+
+    current.any? do |file, mtime|
+      last_modified = @last_modified[file]
+      last_modified.nil? || mtime.to_i > last_modified.to_i
+    end
+  end
+
+  ##
+  # Records RBS signature file mtimes so normal generation freshness checks
+  # and the live server watcher can see signature-only edits.
+
+  def record_rbs_signature_mtimes
+    @last_modified.reject! { |file, _| File.extname(file) == '.rbs' }
+    @last_modified.merge! rbs_signature_mtimes
+  end
+
+  ##
+  # Files watched by the live preview server.
+
+  def watch_files
+    (@last_modified.keys + rbs_signature_files).uniq
+  end
+
+  def rbs_signature_file?(file) # :nodoc:
+    File.extname(file) == '.rbs'
+  end
+
+  def rbs_signature_mtimes # :nodoc:
+    rbs_signature_files.each_with_object({}) do |file, mtimes|
+      mtime = File.mtime(file) rescue nil
+      mtimes[file] = mtime if mtime
+    end
   end
 
   ##

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1415,6 +1415,7 @@ or the PAGER environment variable.
     out << RDoc::Markup::Rule.new(1)
 
     render_method_arguments out, method.arglists
+    render_method_type_signature out, method.type_signature_lines if method.type_signature_lines
     render_method_superclass out, method
     if method.is_alias_for
       al = method.is_alias_for
@@ -1450,6 +1451,10 @@ or the PAGER environment variable.
       out << method.comment.parse
       out << RDoc::Markup::BlankLine.new
     end
+  end
+
+  def render_method_type_signature(out, lines) # :nodoc:
+    out << RDoc::Markup::Verbatim.new(*lines.map { |s| s + "\n" })
   end
 
   def render_method_superclass(out, method) # :nodoc:

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1415,7 +1415,8 @@ or the PAGER environment variable.
     out << RDoc::Markup::Rule.new(1)
 
     render_method_arguments out, method.arglists
-    render_method_type_signature out, method.type_signature_lines if method.type_signature_lines
+    sig = method.type_signature_lines || store.rbs_signature_for(method)
+    render_method_type_signature out, sig if sig
     render_method_superclass out, method
     if method.is_alias_for
       al = method.is_alias_for

--- a/lib/rdoc/server.rb
+++ b/lib/rdoc/server.rb
@@ -408,10 +408,7 @@ class RDoc::Server
         $stderr.puts "Re-parsed #{changed_file_names.join(', ')} (#{duration_ms}ms)"
       end
 
-      @store.complete(@options.visibility)
-      @store.invalidate_type_name_lookup unless changed_files.empty? && removed_files.empty?
-
-      if rbs_changed || !changed_files.empty?
+      if rbs_changed
         duration_ms = measure do
           @rdoc.load_rbs_signatures
           @rdoc.record_rbs_signature_mtimes
@@ -419,8 +416,11 @@ class RDoc::Server
             @file_mtimes[file] = RDoc.safe_mtime(file)
           end
         end
-        $stderr.puts "Reloaded RBS signatures (#{duration_ms}ms)" if rbs_changed
+        $stderr.puts "Reloaded RBS signatures (#{duration_ms}ms)"
       end
+
+      @store.complete(@options.visibility)
+      @store.invalidate_type_name_lookup unless changed_files.empty? && removed_files.empty?
 
       @generator.refresh_store_data
       @page_cache.clear

--- a/lib/rdoc/server.rb
+++ b/lib/rdoc/server.rb
@@ -84,7 +84,7 @@ class RDoc::Server
     @tcp_server = TCPServer.new('127.0.0.1', @port)
     @running = true
 
-    @watcher_thread = start_watcher(@rdoc.last_modified.keys)
+    @watcher_thread = start_watcher(@rdoc.watch_files)
 
     url = "http://localhost:#{@port}"
     $stderr.puts "\nServing documentation at: \e]8;;#{url}\e\\#{url}\e]8;;\e\\"
@@ -294,9 +294,7 @@ class RDoc::Server
   # re-parsing when changes are detected.
 
   def start_watcher(source_files)
-    @file_mtimes = source_files.each_with_object({}) do |f, h|
-      h[f] = File.mtime(f) rescue nil
-    end
+    @file_mtimes = file_mtimes_for(source_files)
 
     Thread.new do
       while @running
@@ -310,6 +308,12 @@ class RDoc::Server
     end
   end
 
+  def file_mtimes_for(files)
+    files.each_with_object({}) do |f, h|
+      h[f] = File.mtime(f) rescue nil
+    end
+  end
+
   ##
   # Checks for modified, new, and deleted files.  Returns true if any
   # changes were found and processed.
@@ -317,16 +321,28 @@ class RDoc::Server
   def check_for_changes
     changed = []
     removed = []
+    changed_rbs = []
+    removed_rbs = []
 
     @file_mtimes.each do |file, old_mtime|
       unless File.exist?(file)
-        removed << file
+        if @rdoc.rbs_signature_file?(file)
+          removed_rbs << file
+        else
+          removed << file
+        end
         next
       end
 
       current_mtime = File.mtime(file) rescue nil
       next unless current_mtime
-      changed << file if old_mtime.nil? || current_mtime > old_mtime
+      next unless old_mtime.nil? || current_mtime > old_mtime
+
+      if @rdoc.rbs_signature_file?(file)
+        changed_rbs << file
+      else
+        changed << file
+      end
     end
 
     file_list = @rdoc.normalized_file_list(
@@ -341,9 +357,18 @@ class RDoc::Server
       end
     end
 
-    return false if changed.empty? && removed.empty?
+    @rdoc.rbs_signature_files.each do |file|
+      unless @file_mtimes.key?(file)
+        @file_mtimes[file] = nil
+        changed_rbs << file
+      end
+    end
 
-    reparse_and_refresh(changed, removed)
+    return false if changed.empty? && removed.empty? && changed_rbs.empty? && removed_rbs.empty?
+
+    removed_rbs.each { |file| @file_mtimes.delete(file) }
+
+    reparse_and_refresh(changed, removed, rbs_changed: !changed_rbs.empty? || !removed_rbs.empty?)
     true
   end
 
@@ -351,7 +376,7 @@ class RDoc::Server
   # Re-parses changed files, removes deleted files from the store,
   # refreshes the generator, and invalidates caches.
 
-  def reparse_and_refresh(changed_files, removed_files)
+  def reparse_and_refresh(changed_files, removed_files, rbs_changed: false)
     @mutex.synchronize do
       unless removed_files.empty?
         $stderr.puts "Removed: #{removed_files.join(', ')}"
@@ -384,6 +409,17 @@ class RDoc::Server
       end
 
       @store.complete(@options.visibility)
+
+      if rbs_changed || !changed_files.empty?
+        duration_ms = measure do
+          @rdoc.load_rbs_signatures
+          @rdoc.record_rbs_signature_mtimes
+          @rdoc.rbs_signature_files.each do |file|
+            @file_mtimes[file] = File.mtime(file) rescue nil
+          end
+        end
+        $stderr.puts "Reloaded RBS signatures (#{duration_ms}ms)" if rbs_changed
+      end
 
       @generator.refresh_store_data
       @page_cache.clear

--- a/lib/rdoc/server.rb
+++ b/lib/rdoc/server.rb
@@ -310,7 +310,7 @@ class RDoc::Server
 
   def file_mtimes_for(files)
     files.each_with_object({}) do |f, h|
-      h[f] = File.mtime(f) rescue nil
+      h[f] = RDoc.safe_mtime(f)
     end
   end
 
@@ -334,7 +334,7 @@ class RDoc::Server
         next
       end
 
-      current_mtime = File.mtime(file) rescue nil
+      current_mtime = RDoc.safe_mtime(file)
       next unless current_mtime
       next unless old_mtime.nil? || current_mtime > old_mtime
 
@@ -397,7 +397,7 @@ class RDoc::Server
             begin
               @store.clear_file_contributions(relative, keep_position: true)
               @rdoc.parse_file(f)
-              @file_mtimes[f] = File.mtime(f) rescue nil
+              @file_mtimes[f] = RDoc.safe_mtime(f)
             rescue => e
               $stderr.puts "Error parsing #{f}: #{e.message}"
             end
@@ -409,13 +409,14 @@ class RDoc::Server
       end
 
       @store.complete(@options.visibility)
+      @store.invalidate_type_name_lookup unless changed_files.empty? && removed_files.empty?
 
       if rbs_changed || !changed_files.empty?
         duration_ms = measure do
           @rdoc.load_rbs_signatures
           @rdoc.record_rbs_signature_mtimes
           @rdoc.rbs_signature_files.each do |file|
-            @file_mtimes[file] = File.mtime(file) rescue nil
+            @file_mtimes[file] = RDoc.safe_mtime(file)
           end
         end
         $stderr.puts "Reloaded RBS signatures (#{duration_ms}ms)" if rbs_changed

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -344,6 +344,66 @@ class RDoc::Store
   end
 
   ##
+  # Returns a hash mapping class/module names to their paths, for use
+  # by type signature linking. Maps both qualified names (Foo::Bar) and
+  # unambiguous unqualified names (Bar). Ambiguous unqualified names
+  # (where multiple classes share the same name) are excluded to avoid
+  # wrong links. Cached after first call.
+
+  def type_name_lookup
+    @type_name_lookup ||= begin
+      lookup = {}
+      unqualified_names = {}
+      ambiguous_names = {}
+      all_classes_and_modules.each do |cm|
+        lookup[cm.full_name] = cm.path
+        unqualified_name = cm.name
+        next if unqualified_name == cm.full_name
+
+        if ambiguous_names[unqualified_name]
+          # already known ambiguous, skip
+        elsif unqualified_names.key?(unqualified_name)
+          unqualified_names.delete(unqualified_name)
+          ambiguous_names[unqualified_name] = true
+        else
+          unqualified_names[unqualified_name] = cm.path
+        end
+      end
+      lookup.merge!(unqualified_names)
+    end
+  end
+
+  ##
+  # Merges RBS type signatures into code objects.
+  # Inline #: annotations take priority and are not overwritten.
+
+  def merge_rbs_signatures(signatures)
+    all_classes_and_modules.each do |cm|
+      cm.method_list.each do |method|
+        next if method.type_signature_lines
+
+        key = method.singleton ? "#{cm.full_name}.#{method.name}" : "#{cm.full_name}##{method.name}"
+        sig = signatures[key]
+
+        # RBS keys constructors as #initialize, but RDoc renames them to .new
+        if !sig && method.name == 'new' && method.singleton
+          sig = signatures["#{cm.full_name}#initialize"]
+        end
+
+        method.type_signature_lines = sig if sig
+      end
+
+      cm.attributes.each do |attr|
+        next if attr.type_signature_lines
+
+        if (sig = signatures["#{cm.full_name}##{attr.name}"])
+          attr.type_signature_lines = sig
+        end
+      end
+    end
+  end
+
+  ##
   # All TopLevels known to RDoc
 
   def all_files
@@ -443,6 +503,7 @@ class RDoc::Store
   # See also RDoc::Context#remove_from_documentation?
 
   def complete(min_visibility)
+    @type_name_lookup = nil
     fix_basic_object_inheritance
 
     # cache included modules before they are removed from the documentation

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -358,7 +358,6 @@ class RDoc::Store
       all_classes_and_modules.each do |cm|
         lookup[cm.full_name] = cm.path
         unqualified_name = cm.name
-        next if unqualified_name == cm.full_name
 
         if ambiguous_names[unqualified_name]
           # already known ambiguous, skip

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -381,61 +381,46 @@ class RDoc::Store
   end
 
   ##
-  # Merges RBS type signatures into code objects.
-  # Inline #: annotations take priority and are not overwritten.
+  # Stores RBS type signatures loaded from sidecar .rbs files, keyed by
+  # "ClassName#method" or "ClassName.method".  Replaces any previously
+  # stored set, so passing +{}+ clears it.  Inline +#:+ annotations on
+  # method objects are NOT touched — those are owned by the source file.
 
   def merge_rbs_signatures(signatures)
-    clear_rbs_signatures
-
-    all_classes_and_modules.each do |cm|
-      cm.method_list.each do |method|
-        next if method.type_signature_lines
-
-        sig = signatures[rbs_key(cm, method)]
-
-        # RBS keys constructors as #initialize, but RDoc renames them to .new
-        if !sig && method.name == 'new' && method.singleton
-          sig = signatures["#{cm.full_name}#initialize"]
-        end
-
-        assign_rbs_signature method, sig if sig
-      end
-
-      cm.attributes.each do |attr|
-        next if attr.type_signature_lines
-
-        if (sig = signatures[rbs_key(cm, attr)])
-          assign_rbs_signature attr, sig
-        end
-      end
-    end
+    @rbs_signatures = signatures
   end
 
-  def assign_rbs_signature(method_attr, signature) # :nodoc:
-    @rbs_signature_method_attrs ||= []
+  ##
+  # Returns the RBS type signature lines for +method_attr+ from loaded
+  # sidecar +.rbs+ files, or +nil+ if none.  Falls through to the
+  # canonical method for aliases, and handles +initialize+ -> +.new+
+  # singleton mapping.
 
-    method_attr.type_signature_lines = signature
-    @rbs_signature_method_attrs << method_attr
+  def rbs_signature_for(method_attr)
+    return nil unless @rbs_signatures
+    cm = method_attr.parent
+    return nil unless cm.respond_to?(:full_name)
 
-    method_attr.aliases.each do |aliased|
-      next if aliased.type_signature_lines
-      aliased.type_signature_lines = signature
-      @rbs_signature_method_attrs << aliased
+    key = method_attr.singleton ? "#{cm.full_name}.#{method_attr.name}" : "#{cm.full_name}##{method_attr.name}"
+    sig = @rbs_signatures[key]
+
+    # RBS keys constructors as #initialize, but RDoc renames them to .new
+    if !sig && method_attr.name == 'new' && method_attr.singleton
+      sig = @rbs_signatures["#{cm.full_name}#initialize"]
     end
+
+    # For aliases, fall through to the canonical method (its inline #:
+    # takes precedence over any sidecar signature on the alias's name).
+    if !sig && method_attr.is_alias_for
+      canonical = method_attr.is_alias_for
+      sig = canonical.type_signature_lines || rbs_signature_for(canonical)
+    end
+
+    sig
   end
 
   def clear_rbs_signatures # :nodoc:
-    return unless @rbs_signature_method_attrs
-
-    @rbs_signature_method_attrs.each do |method_attr|
-      method_attr.type_signature_lines = nil
-    end
-
-    @rbs_signature_method_attrs.clear
-  end
-
-  def rbs_key(cm, method_attr) # :nodoc:
-    method_attr.singleton ? "#{cm.full_name}.#{method_attr.name}" : "#{cm.full_name}##{method_attr.name}"
+    @rbs_signatures = nil
   end
 
   ##

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -350,6 +350,14 @@ class RDoc::Store
   # (where multiple classes share the same name) are excluded to avoid
   # wrong links. Cached after first call.
 
+  ##
+  # Invalidates the cached type name lookup.  Server mode calls this after
+  # re-parsing changes the set of classes and modules.
+
+  def invalidate_type_name_lookup # :nodoc:
+    @type_name_lookup = nil
+  end
+
   def type_name_lookup
     @type_name_lookup ||= begin
       lookup = {}
@@ -530,7 +538,6 @@ class RDoc::Store
   # See also RDoc::Context#remove_from_documentation?
 
   def complete(min_visibility)
-    @type_name_lookup = nil
     fix_basic_object_inheritance
 
     # cache included modules before they are removed from the documentation

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -377,29 +377,57 @@ class RDoc::Store
   # Inline #: annotations take priority and are not overwritten.
 
   def merge_rbs_signatures(signatures)
+    clear_rbs_signatures
+
     all_classes_and_modules.each do |cm|
       cm.method_list.each do |method|
         next if method.type_signature_lines
 
-        key = method.singleton ? "#{cm.full_name}.#{method.name}" : "#{cm.full_name}##{method.name}"
-        sig = signatures[key]
+        sig = signatures[rbs_key(cm, method)]
 
         # RBS keys constructors as #initialize, but RDoc renames them to .new
         if !sig && method.name == 'new' && method.singleton
           sig = signatures["#{cm.full_name}#initialize"]
         end
 
-        method.type_signature_lines = sig if sig
+        assign_rbs_signature method, sig if sig
       end
 
       cm.attributes.each do |attr|
         next if attr.type_signature_lines
 
-        if (sig = signatures["#{cm.full_name}##{attr.name}"])
-          attr.type_signature_lines = sig
+        if (sig = signatures[rbs_key(cm, attr)])
+          assign_rbs_signature attr, sig
         end
       end
     end
+  end
+
+  def assign_rbs_signature(method_attr, signature) # :nodoc:
+    @rbs_signature_method_attrs ||= []
+
+    method_attr.type_signature_lines = signature
+    @rbs_signature_method_attrs << method_attr
+
+    method_attr.aliases.each do |aliased|
+      next if aliased.type_signature_lines
+      aliased.type_signature_lines = signature
+      @rbs_signature_method_attrs << aliased
+    end
+  end
+
+  def clear_rbs_signatures # :nodoc:
+    return unless @rbs_signature_method_attrs
+
+    @rbs_signature_method_attrs.each do |method_attr|
+      method_attr.type_signature_lines = nil
+    end
+
+    @rbs_signature_method_attrs.clear
+  end
+
+  def rbs_key(cm, method_attr) # :nodoc:
+    method_attr.singleton ? "#{cm.full_name}.#{method_attr.name}" : "#{cm.full_name}##{method_attr.name}"
   end
 
   ##

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -63,11 +63,12 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files += s.files.grep(%r[\A[^\/]+\.(?:rdoc|md)\z])
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
   s.add_dependency 'psych', '>= 4.0.0'
   s.add_dependency 'erb'
   s.add_dependency 'tsort'
-  s.add_dependency 'prism', '>= 1.0.0'
+  s.add_dependency 'prism', '>= 1.6.0'
+  s.add_dependency 'rbs', '>= 4.0.0'
 end

--- a/test/rdoc/code_object/any_method_test.rb
+++ b/test/rdoc/code_object/any_method_test.rb
@@ -202,6 +202,40 @@ each_line(foo)
     assert_equal section,        loaded.section
   end
 
+  def test_marshal_dump_with_type_signature
+    @store.path = Dir.tmpdir
+    top_level = @store.add_file 'file.rb'
+
+    m = RDoc::AnyMethod.new nil, 'method'
+    m.type_signature_lines = ['(String) -> Integer']
+    m.record_location top_level
+
+    cm = top_level.add_class RDoc::ClassModule, 'Klass'
+    cm.add_method m
+
+    loaded = Marshal.load Marshal.dump m
+    loaded.store = @store
+
+    assert_equal ['(String) -> Integer'], loaded.type_signature_lines
+  end
+
+  def test_add_alias_copies_type_signature
+    @store.path = Dir.tmpdir
+    top_level = @store.add_file 'file.rb'
+    cm = top_level.add_class RDoc::ClassModule, 'Klass'
+
+    m = RDoc::AnyMethod.new nil, 'original'
+    m.type_signature_lines = ['(String) -> void']
+    m.record_location top_level
+    cm.add_method m
+
+    a = RDoc::Alias.new nil, 'original', 'aliased', ''
+    a.record_location top_level
+
+    aliased = m.add_alias a, cm
+    assert_equal ['(String) -> void'], aliased.type_signature_lines
+  end
+
   def test_marshal_load_aliased_method
     aliased_method = Marshal.load Marshal.dump(@c2_a)
 

--- a/test/rdoc/code_object/attr_test.rb
+++ b/test/rdoc/code_object/attr_test.rb
@@ -74,6 +74,40 @@ class RDocAttrTest < RDoc::TestCase
     assert_equal section,      loaded.section
   end
 
+  def test_marshal_dump_with_type_signature
+    @store.path = Dir.tmpdir
+    top_level = @store.add_file 'file.rb'
+
+    a = RDoc::Attr.new nil, 'name', 'R', 'a comment'
+    a.type_signature_lines = ['String']
+    a.record_location top_level
+
+    cm = top_level.add_class RDoc::ClassModule, 'Klass'
+    cm.add_attribute a
+
+    loaded = Marshal.load Marshal.dump a
+    loaded.store = @store
+
+    assert_equal ['String'], loaded.type_signature_lines
+  end
+
+  def test_add_alias_copies_type_signature
+    @store.path = Dir.tmpdir
+    top_level = @store.add_file 'file.rb'
+    cm = top_level.add_class RDoc::ClassModule, 'Klass'
+
+    a = RDoc::Attr.new nil, 'name', 'R', ''
+    a.type_signature_lines = ['String']
+    a.record_location top_level
+    cm.add_attribute a
+
+    al = RDoc::Alias.new nil, 'name', 'label', ''
+    al.record_location top_level
+
+    aliased = a.add_alias al, cm
+    assert_equal ['String'], aliased.type_signature_lines
+  end
+
   def test_marshal_dump_singleton
     tl = @store.add_file 'file.rb'
 

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2696,20 +2696,6 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal 'Convert a value', convert.comment.text.strip
   end
 
-  def test_method_without_type_signature
-    util_parser <<~RUBY
-      class Foo
-        # A plain method
-        def plain; end
-      end
-    RUBY
-
-    klass = @store.find_class_named 'Foo'
-    plain = klass.method_list.first
-    assert_nil plain.type_signature_lines
-    assert_equal 'A plain method', plain.comment.text.strip
-  end
-
   def test_method_type_signature_with_blank_line_separation
     util_parser <<~RUBY
       class Foo
@@ -2726,18 +2712,24 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal "Documentation here", bar.comment.text
   end
 
-  def test_type_signature_invalid_still_stored
-    util_parser <<~RUBY
-      class Foo
-        #: (String ->
-        def bar(x); end
-      end
-    RUBY
+  def test_type_signature_invalid_still_stored_and_warns
+    @options.verbosity = 2
+    _out, err = capture_output do
+      util_parser <<~RUBY
+        class Foo
+          #: (String ->
+          def bar(x); end
+        end
+      RUBY
+    end
 
     klass = @store.find_class_named 'Foo'
     bar = klass.method_list.first
-    # Invalid sigs are still stored (don't block display)
+    # Invalid sigs are still stored so the doc author can see what they typed.
     assert_equal ['(String ->'], bar.type_signature_lines
+    # ...but a warning must be emitted so it doesn't slip through silently.
+    # The format includes the file and line so authors can find the typo.
+    assert_match %r{:\d+: invalid RBS type signature: "\(String ->"}, err
   end
 
   def util_parser(content)

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2645,6 +2645,101 @@ class RDocParserRubyTest < RDoc::TestCase
     )
   end
 
+  def test_method_type_signature
+    util_parser <<~RUBY
+      class Foo
+        # A greeting method
+        #: (String, Integer) -> void
+        def greet(name, count); end
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    greet = klass.method_list.first
+    assert_equal 'greet', greet.name
+    assert_equal ['(String, Integer) -> void'], greet.type_signature_lines
+    assert_equal 'A greeting method', greet.comment.text.strip
+  end
+
+  def test_attribute_type_signature
+    util_parser <<~RUBY
+      class Foo
+        #: String
+        attr_reader :name
+
+        #: Integer
+        attr_accessor :count
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    attrs = klass.attributes.sort_by(&:name)
+    assert_equal 'count', attrs[0].name
+    assert_equal ['Integer'], attrs[0].type_signature_lines
+    assert_equal 'name', attrs[1].name
+    assert_equal ['String'], attrs[1].type_signature_lines
+  end
+
+  def test_method_type_signature_multiple_overloads
+    util_parser <<~RUBY
+      class Foo
+        # Convert a value
+        #: (String) -> Integer
+        #: (Integer) -> String
+        def convert(value); end
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    convert = klass.method_list.first
+    assert_equal ['(String) -> Integer', '(Integer) -> String'], convert.type_signature_lines
+    assert_equal 'Convert a value', convert.comment.text.strip
+  end
+
+  def test_method_without_type_signature
+    util_parser <<~RUBY
+      class Foo
+        # A plain method
+        def plain; end
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    plain = klass.method_list.first
+    assert_nil plain.type_signature_lines
+    assert_equal 'A plain method', plain.comment.text.strip
+  end
+
+  def test_method_type_signature_with_blank_line_separation
+    util_parser <<~RUBY
+      class Foo
+        # Documentation here
+        #
+        #: (String) -> void
+        def bar(x); end
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    bar = klass.method_list.first
+    assert_equal ['(String) -> void'], bar.type_signature_lines
+    assert_equal "Documentation here", bar.comment.text
+  end
+
+  def test_type_signature_invalid_still_stored
+    util_parser <<~RUBY
+      class Foo
+        #: (String ->
+        def bar(x); end
+      end
+    RUBY
+
+    klass = @store.find_class_named 'Foo'
+    bar = klass.method_list.first
+    # Invalid sigs are still stored (don't block display)
+    assert_equal ['(String ->'], bar.type_signature_lines
+  end
+
   def util_parser(content)
     @parser = RDoc::Parser::Ruby.new @top_level, content, @options, @stats
     @parser.scan

--- a/test/rdoc/rbs_helper_test.rb
+++ b/test/rdoc/rbs_helper_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+require 'rdoc/rbs_helper'
+require 'rdoc/markup/formatter'
+
+class RDocRbsHelperTest < RDoc::TestCase
+  def test_valid_method_type
+    assert RDoc::RbsHelper.valid_method_type?('(String) -> void')
+    assert RDoc::RbsHelper.valid_method_type?('(Integer, ?String) -> bool')
+    assert RDoc::RbsHelper.valid_method_type?('() -> Array[String]')
+  end
+
+  def test_invalid_method_type
+    refute RDoc::RbsHelper.valid_method_type?('(String ->')
+  end
+
+  def test_valid_type
+    assert RDoc::RbsHelper.valid_type?('String')
+    assert RDoc::RbsHelper.valid_type?('Array[Integer]')
+    assert RDoc::RbsHelper.valid_type?('String?')
+  end
+
+  def test_invalid_type
+    refute RDoc::RbsHelper.valid_type?('String[')
+  end
+
+  def test_load_signatures_from_directory
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'test.rbs'), <<~RBS)
+        class Greeter
+          def greet: (String name) -> void
+          attr_reader language: String
+        end
+      RBS
+
+      sigs = RDoc::RbsHelper.load_signatures(dir)
+      assert_equal ['(String name) -> void'], sigs['Greeter#greet']
+      assert_equal ['String'], sigs['Greeter#language']
+    end
+  end
+
+  def test_signature_to_html_links_known_types
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["(String) -> Integer"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+    assert_includes result, '&rarr;'
+  end
+
+  def test_signature_to_html_leaves_unknown_types_plain
+    result = RDoc::RbsHelper.signature_to_html(["(UnknownType) -> void"], lookup: {}, from_path: 'Test.html')
+
+    refute_includes result, '<a'
+    assert_includes result, 'UnknownType'
+    assert_includes result, 'void'
+  end
+
+  def test_signature_to_html_handles_qualified_names
+    lookup = { 'Foo::Bar' => 'Foo/Bar.html' }
+    result = RDoc::RbsHelper.signature_to_html(["(::Foo::Bar) -> void"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="Foo/Bar.html" class="rbs-type">Foo::Bar</a>'
+  end
+
+  def test_signature_to_html_multiline
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["(String) -> Integer", "(Integer) -> String"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+    assert_includes result, "\n"
+  end
+
+  def test_signature_to_html_union_type
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["(String | Integer) -> void"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+  end
+
+  def test_signature_to_html_optional_type
+    lookup = { 'String' => 'String.html' }
+    result = RDoc::RbsHelper.signature_to_html(["String?"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+  end
+
+  def test_signature_to_html_tuple_type
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["[String, Integer]"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+  end
+
+  def test_signature_to_html_intersection_type
+    lookup = { 'String' => 'String.html', 'Comparable' => 'Comparable.html' }
+    result = RDoc::RbsHelper.signature_to_html(["(String & Comparable) -> void"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Comparable.html" class="rbs-type">Comparable</a>'
+  end
+
+  def test_signature_to_html_proc_type
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["^(String) -> Integer"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+  end
+
+  def test_signature_to_html_links_block_return_type
+    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
+    result = RDoc::RbsHelper.signature_to_html(["() { (String) -> Integer } -> void"], lookup: lookup, from_path: 'Test.html')
+
+    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
+    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+  end
+
+  def test_signature_to_html_unparseable_signature
+    result = RDoc::RbsHelper.signature_to_html(["(String ->"], lookup: { 'String' => 'String.html' }, from_path: 'Test.html')
+
+    # Unparseable sigs are returned as escaped HTML with no links
+    refute_includes result, '<a'
+    assert_includes result, '(String'
+  end
+
+end

--- a/test/rdoc/rbs_helper_test.rb
+++ b/test/rdoc/rbs_helper_test.rb
@@ -97,56 +97,34 @@ class RDocRbsHelperTest < RDoc::TestCase
     lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
     result = RDoc::RbsHelper.signature_to_html(["(String) -> Integer", "(Integer) -> String"], lookup: lookup, from_path: 'Test.html')
 
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
-    assert_includes result, "\n"
+    first, second = result.split("\n", 2)
+    assert_match %r{<a href="String\.html"[^>]*>String</a>.*&rarr;.*<a href="Integer\.html"[^>]*>Integer</a>}, first
+    assert_match %r{<a href="Integer\.html"[^>]*>Integer</a>.*&rarr;.*<a href="String\.html"[^>]*>String</a>}, second
   end
 
-  def test_signature_to_html_union_type
-    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
-    result = RDoc::RbsHelper.signature_to_html(["(String | Integer) -> void"], lookup: lookup, from_path: 'Test.html')
+  def test_signature_to_html_links_types_inside_compound_forms
+    lookup = {
+      'String'     => 'String.html',
+      'Integer'    => 'Integer.html',
+      'Comparable' => 'Comparable.html',
+    }
 
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
-  end
+    cases = [
+      ['union',        "(String | Integer) -> void",        %w[String Integer]],
+      ['optional',     "String?",                           %w[String]],
+      ['tuple',        "[String, Integer]",                 %w[String Integer]],
+      ['intersection', "(String & Comparable) -> void",     %w[String Comparable]],
+      ['proc',         "^(String) -> Integer",              %w[String Integer]],
+      ['block',        "() { (String) -> Integer } -> void", %w[String Integer]],
+    ]
 
-  def test_signature_to_html_optional_type
-    lookup = { 'String' => 'String.html' }
-    result = RDoc::RbsHelper.signature_to_html(["String?"], lookup: lookup, from_path: 'Test.html')
-
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-  end
-
-  def test_signature_to_html_tuple_type
-    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
-    result = RDoc::RbsHelper.signature_to_html(["[String, Integer]"], lookup: lookup, from_path: 'Test.html')
-
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
-  end
-
-  def test_signature_to_html_intersection_type
-    lookup = { 'String' => 'String.html', 'Comparable' => 'Comparable.html' }
-    result = RDoc::RbsHelper.signature_to_html(["(String & Comparable) -> void"], lookup: lookup, from_path: 'Test.html')
-
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Comparable.html" class="rbs-type">Comparable</a>'
-  end
-
-  def test_signature_to_html_proc_type
-    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
-    result = RDoc::RbsHelper.signature_to_html(["^(String) -> Integer"], lookup: lookup, from_path: 'Test.html')
-
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
-  end
-
-  def test_signature_to_html_links_block_return_type
-    lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
-    result = RDoc::RbsHelper.signature_to_html(["() { (String) -> Integer } -> void"], lookup: lookup, from_path: 'Test.html')
-
-    assert_includes result, '<a href="String.html" class="rbs-type">String</a>'
-    assert_includes result, '<a href="Integer.html" class="rbs-type">Integer</a>'
+    cases.each do |form, sig, expected_types|
+      result = RDoc::RbsHelper.signature_to_html([sig], lookup: lookup, from_path: 'Test.html')
+      expected_types.each do |type|
+        assert_includes result, %(<a href="#{lookup[type]}" class="rbs-type">#{type}</a>),
+          "#{form} signature #{sig.inspect} did not link #{type}"
+      end
+    end
   end
 
   def test_signature_to_html_unparseable_signature

--- a/test/rdoc/rbs_helper_test.rb
+++ b/test/rdoc/rbs_helper_test.rb
@@ -40,6 +40,20 @@ class RDocRbsHelperTest < RDoc::TestCase
     end
   end
 
+  def test_load_signatures_registers_module_function_methods_under_both_keys
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'test.rbs'), <<~RBS)
+        class Greeter
+          def self?.shout: (String text) -> String
+        end
+      RBS
+
+      sigs = RDoc::RbsHelper.load_signatures(dir)
+      assert_equal ['(String text) -> String'], sigs['Greeter.shout']
+      assert_equal ['(String text) -> String'], sigs['Greeter#shout']
+    end
+  end
+
   def test_load_signatures_keeps_instance_and_singleton_attributes_separate
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, 'test.rbs'), <<~RBS)

--- a/test/rdoc/rbs_helper_test.rb
+++ b/test/rdoc/rbs_helper_test.rb
@@ -40,6 +40,21 @@ class RDocRbsHelperTest < RDoc::TestCase
     end
   end
 
+  def test_load_signatures_keeps_instance_and_singleton_attributes_separate
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'test.rbs'), <<~RBS)
+        class Greeter
+          attr_reader language: String
+          attr_reader self.language: Integer
+        end
+      RBS
+
+      sigs = RDoc::RbsHelper.load_signatures(dir)
+      assert_equal ['String'], sigs['Greeter#language']
+      assert_equal ['Integer'], sigs['Greeter.language']
+    end
+  end
+
   def test_signature_to_html_links_known_types
     lookup = { 'String' => 'String.html', 'Integer' => 'Integer.html' }
     result = RDoc::RbsHelper.signature_to_html(["(String) -> Integer"], lookup: lookup, from_path: 'Test.html')

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -106,7 +106,7 @@ class RDocRDocTest < RDoc::TestCase
 
       example = store.find_class_or_module 'Example'
       greet = example.find_method 'greet', false
-      assert_equal ['() -> String'], greet.type_signature_lines
+      assert_equal ['() -> String'], store.rbs_signature_for(greet)
     end
   end
 
@@ -132,7 +132,7 @@ class RDocRDocTest < RDoc::TestCase
       example.add_method method
 
       @rdoc.load_rbs_signatures
-      assert_equal ['() -> String'], method.type_signature_lines
+      assert_equal ['() -> String'], @rdoc.store.rbs_signature_for(method)
 
       File.write sig, "class Example\n  def greet: ( -> "
       @options.verbosity = 2
@@ -141,7 +141,7 @@ class RDocRDocTest < RDoc::TestCase
       end
 
       assert_includes err, 'Failed to load RBS type signatures'
-      assert_nil method.type_signature_lines
+      assert_nil @rdoc.store.rbs_signature_for(method)
     end
   end
 

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -2,6 +2,19 @@
 require_relative 'helper'
 
 class RDocRDocTest < RDoc::TestCase
+  class RegenerationTrackingGenerator
+    class << self
+      attr_accessor :generated_store
+    end
+
+    def initialize(store, _options)
+      @store = store
+    end
+
+    def generate
+      self.class.generated_store = @store
+    end
+  end
 
   def setup
     super
@@ -38,6 +51,63 @@ class RDocRDocTest < RDoc::TestCase
 
     assert_equal 'MAIN_PAGE.rdoc', store.main
     assert_equal 'title',          store.title
+  end
+
+  def test_document_regenerates_when_rbs_file_changed
+    temp_dir do |dir|
+      source = File.join dir, 'example.rb'
+      sig_dir = File.join dir, 'sig'
+      sig = File.join sig_dir, 'example.rbs'
+      output_dir = File.join dir, 'doc'
+
+      FileUtils.mkdir_p sig_dir
+      FileUtils.mkdir_p output_dir
+
+      File.write source, <<~RUBY
+        class Example
+          def greet
+          end
+        end
+      RUBY
+
+      File.write sig, <<~RBS
+        class Example
+          def greet: () -> String
+        end
+      RBS
+
+      source_mtime = Time.at 1000
+      old_sig_mtime = Time.at 1000
+      new_sig_mtime = Time.at 2000
+      FileUtils.touch source, mtime: source_mtime
+      FileUtils.touch sig, mtime: new_sig_mtime
+
+      File.open @rdoc.output_flag_file(output_dir), 'w' do |io|
+        io.puts Time.at(1500).rfc2822
+        io.puts "#{source}\t#{source_mtime.rfc2822}"
+        io.puts "#{sig}\t#{old_sig_mtime.rfc2822}"
+      end
+
+      options = RDoc::Options.new
+      options.files = [source]
+      options.root = Pathname dir
+      options.op_dir = output_dir
+      options.force_update = false
+      options.quiet = true
+      options.generator = RegenerationTrackingGenerator
+      RegenerationTrackingGenerator.generated_store = nil
+
+      capture_output do
+        RDoc::RDoc.new.document options
+      end
+
+      store = RegenerationTrackingGenerator.generated_store
+      refute_nil store
+
+      example = store.find_class_or_module 'Example'
+      greet = example.find_method 'greet', false
+      assert_equal ['() -> String'], greet.type_signature_lines
+    end
   end
 
   def test_document_with_dry_run # functional test

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -110,6 +110,41 @@ class RDocRDocTest < RDoc::TestCase
     end
   end
 
+  def test_load_rbs_signatures_clears_stale_signatures_on_failure
+    temp_dir do |dir|
+      sig_dir = File.join dir, 'sig'
+      sig = File.join sig_dir, 'example.rbs'
+      FileUtils.mkdir_p sig_dir
+
+      File.write sig, <<~RBS
+        class Example
+          def greet: () -> String
+        end
+      RBS
+
+      @options.root = Pathname(dir)
+      @options.op_dir = dir
+      @rdoc.store = RDoc::Store.new(@options)
+
+      top_level = @rdoc.store.add_file 'example.rb'
+      example = top_level.add_class RDoc::NormalClass, 'Example'
+      method = RDoc::AnyMethod.new nil, 'greet'
+      example.add_method method
+
+      @rdoc.load_rbs_signatures
+      assert_equal ['() -> String'], method.type_signature_lines
+
+      File.write sig, "class Example\n  def greet: ( -> "
+      @options.verbosity = 2
+      _out, err = capture_output do
+        @rdoc.load_rbs_signatures
+      end
+
+      assert_includes err, 'Failed to load RBS type signatures'
+      assert_nil method.type_signature_lines
+    end
+  end
+
   def test_document_with_dry_run # functional test
     options = RDoc::Options.new
     options.files = [File.expand_path('../xref_data.rb', __FILE__)]

--- a/test/rdoc/rdoc_server_test.rb
+++ b/test/rdoc/rdoc_server_test.rb
@@ -99,6 +99,6 @@ class RDocServerTest < RDoc::TestCase
 
     example = @rdoc.store.find_class_or_module 'Example'
     greet = example.find_method 'greet', false
-    assert_equal ['() -> String'], greet.type_signature_lines
+    assert_equal ['() -> String'], @rdoc.store.rbs_signature_for(greet)
   end
 end

--- a/test/rdoc/rdoc_server_test.rb
+++ b/test/rdoc/rdoc_server_test.rb
@@ -10,7 +10,13 @@ class RDocServerTest < RDoc::TestCase
 
     File.write File.join(@dir, "PAGE.md"), "# A Page\n\nSome content.\n"
     File.write File.join(@dir, "NOTES.rdoc"), "= Notes\n\nSome notes.\n"
-    File.write File.join(@dir, "example.rb"), "# A class\nclass Example; end\n"
+    File.write File.join(@dir, "example.rb"), <<~RUBY
+      # A class
+      class Example
+        def greet
+        end
+      end
+    RUBY
 
     @options.files = [@dir]
     @options.op_dir = File.join(@dir, "_site")
@@ -70,5 +76,29 @@ class RDocServerTest < RDoc::TestCase
 
     assert_equal 404, status
     assert_equal 'text/html', content_type
+  end
+
+  def test_check_for_changes_reloads_rbs_signatures
+    @server.instance_variable_set(:@file_mtimes, @rdoc.last_modified.keys.to_h { |file|
+      [file, File.mtime(file)]
+    })
+
+    sig_dir = File.join @dir, 'sig'
+    FileUtils.mkdir_p sig_dir
+    File.write File.join(sig_dir, 'example.rbs'), <<~RBS
+      class Example
+        def greet: () -> String
+      end
+    RBS
+
+    _out, err = capture_output do
+      assert @server.send(:check_for_changes)
+    end
+
+    assert_not_include err, 'Error parsing'
+
+    example = @rdoc.store.find_class_or_module 'Example'
+    greet = example.find_method 'greet', false
+    assert_equal ['() -> String'], greet.type_signature_lines
   end
 end

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -1289,4 +1289,92 @@ class RDocStoreTest < XrefTestCase
     assert_not_include @s.classes_hash, 'GoneClass'
   end
 
+  def test_merge_rbs_signatures
+    m = RDoc::AnyMethod.new(nil, 'greet')
+    m.params = '(name)'
+    @klass.add_method m
+
+    a = RDoc::Attr.new(nil, 'language', 'R', '')
+    @klass.add_attribute a
+
+    @s.merge_rbs_signatures(
+      'Object#greet' => ['(String name) -> void'],
+      'Object#language' => ['String']
+    )
+
+    assert_equal ['(String name) -> void'], m.type_signature_lines
+    assert_equal ['String'], a.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_singleton_method
+    @s.merge_rbs_signatures(
+      'Object.cmethod' => ['() -> String']
+    )
+
+    assert_equal ['() -> String'], @cmeth.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_constructor
+    ctor = RDoc::AnyMethod.new nil, 'new', singleton: true
+    ctor.record_location @top_level
+    @klass.add_method ctor
+
+    @s.merge_rbs_signatures(
+      'Object#initialize' => ['(String name) -> void']
+    )
+
+    assert_equal ['(String name) -> void'], ctor.type_signature_lines
+  end
+
+  def test_type_name_lookup
+    @s.complete :public
+
+    lookup = @s.type_name_lookup
+    assert_equal @klass.path, lookup['Object']
+    assert_equal @nest_klass.path, lookup['Object::SubClass']
+    assert_equal @mod.path, lookup['Mod']
+    assert_equal @nest_klass.path, lookup['SubClass']
+  end
+
+  def test_type_name_lookup_ambiguous_unqualified_name_excluded
+    file = @s.add_file 'other.rb'
+    other_klass = file.add_class RDoc::NormalClass, 'Other::SubClass'
+    other_klass.record_location file
+    @s.complete :public
+
+    lookup = @s.type_name_lookup
+
+    # Both qualified names are present
+    assert_equal @nest_klass.path, lookup['Object::SubClass']
+    assert_equal other_klass.path, lookup['Other::SubClass']
+
+    # Ambiguous unqualified name is excluded to avoid wrong links
+    refute lookup.key?('SubClass')
+  end
+
+
+  def test_merge_rbs_signatures_does_not_overwrite_inline_annotations
+    m = RDoc::AnyMethod.new(nil, 'greet')
+    m.params = '(name)'
+    m.type_signature_lines = ['(String) -> void']
+    @klass.add_method m
+
+    @s.merge_rbs_signatures(
+      'Object#greet' => ['(String name, ?Integer count) -> void']
+    )
+
+    assert_equal ['(String) -> void'], m.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_unmatched_key
+    @s.merge_rbs_signatures(
+      'Object#nonexistent' => ['(String) -> void']
+    )
+
+    # No method matches — nothing should blow up, no sigs assigned
+    @klass.method_list.each do |m|
+      assert_nil m.type_signature_lines
+    end
+  end
+
 end

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -1326,6 +1326,70 @@ class RDocStoreTest < XrefTestCase
     assert_equal ['(String name) -> void'], ctor.type_signature_lines
   end
 
+  def test_merge_rbs_signatures_replaces_previous_rbs_signature
+    @s.merge_rbs_signatures(
+      'Object#method' => ['() -> String']
+    )
+
+    @s.merge_rbs_signatures(
+      'Object#method' => ['() -> Integer']
+    )
+
+    assert_equal ['() -> Integer'], @meth.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_propagates_to_method_alias
+    original = RDoc::AnyMethod.new nil, 'original'
+    original.record_location @top_level
+    @klass.add_method original
+
+    alias_def = RDoc::Alias.new nil, 'original', 'aliased', ''
+    alias_def.record_location @top_level
+    aliased = original.add_alias alias_def, @klass
+
+    @s.merge_rbs_signatures(
+      'Object#original' => ['() -> String']
+    )
+
+    assert_equal ['() -> String'], original.type_signature_lines
+    assert_equal ['() -> String'], aliased.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_propagates_to_attribute_alias
+    original = RDoc::Attr.new nil, 'language', 'R', ''
+    original.record_location @top_level
+    @klass.add_attribute original
+
+    alias_def = RDoc::Alias.new nil, 'language', 'locale', ''
+    alias_def.record_location @top_level
+    aliased = original.add_alias alias_def, @klass
+
+    @s.merge_rbs_signatures(
+      'Object#language' => ['String']
+    )
+
+    assert_equal ['String'], original.type_signature_lines
+    assert_equal ['String'], aliased.type_signature_lines
+  end
+
+  def test_merge_rbs_signatures_keeps_instance_and_singleton_attributes_separate
+    instance_attr = RDoc::Attr.new nil, 'language', 'R', ''
+    instance_attr.record_location @top_level
+    @klass.add_attribute instance_attr
+
+    singleton_attr = RDoc::Attr.new nil, 'language', 'R', '', singleton: true
+    singleton_attr.record_location @top_level
+    @klass.add_attribute singleton_attr
+
+    @s.merge_rbs_signatures(
+      'Object#language' => ['String'],
+      'Object.language' => ['Integer']
+    )
+
+    assert_equal ['String'], instance_attr.type_signature_lines
+    assert_equal ['Integer'], singleton_attr.type_signature_lines
+  end
+
   def test_type_name_lookup
     @s.complete :public
 

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -1326,16 +1326,16 @@ class RDocStoreTest < XrefTestCase
     assert_equal ['(String name) -> void'], ctor.type_signature_lines
   end
 
-  def test_merge_rbs_signatures_replaces_previous_rbs_signature
+  def test_merge_rbs_signatures_clears_signatures_removed_in_subsequent_merge
     @s.merge_rbs_signatures(
       'Object#method' => ['() -> String']
     )
+    assert_equal ['() -> String'], @meth.type_signature_lines
 
-    @s.merge_rbs_signatures(
-      'Object#method' => ['() -> Integer']
-    )
-
-    assert_equal ['() -> Integer'], @meth.type_signature_lines
+    # Subsequent merge no longer mentions the key — the signature must be
+    # cleared rather than left stale, so live-reload reflects deletions.
+    @s.merge_rbs_signatures({})
+    assert_nil @meth.type_signature_lines
   end
 
   def test_merge_rbs_signatures_propagates_to_method_alias
@@ -1445,17 +1445,6 @@ class RDocStoreTest < XrefTestCase
     )
 
     assert_equal ['(String) -> void'], m.type_signature_lines
-  end
-
-  def test_merge_rbs_signatures_unmatched_key
-    @s.merge_rbs_signatures(
-      'Object#nonexistent' => ['(String) -> void']
-    )
-
-    # No method matches — nothing should blow up, no sigs assigned
-    @klass.method_list.each do |m|
-      assert_nil m.type_signature_lines
-    end
   end
 
 end

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -1302,8 +1302,11 @@ class RDocStoreTest < XrefTestCase
       'Object#language' => ['String']
     )
 
-    assert_equal ['(String name) -> void'], m.type_signature_lines
-    assert_equal ['String'], a.type_signature_lines
+    assert_equal ['(String name) -> void'], @s.rbs_signature_for(m)
+    assert_equal ['String'], @s.rbs_signature_for(a)
+    # Inline #: lines on the method are untouched
+    assert_nil m.type_signature_lines
+    assert_nil a.type_signature_lines
   end
 
   def test_merge_rbs_signatures_singleton_method
@@ -1311,7 +1314,7 @@ class RDocStoreTest < XrefTestCase
       'Object.cmethod' => ['() -> String']
     )
 
-    assert_equal ['() -> String'], @cmeth.type_signature_lines
+    assert_equal ['() -> String'], @s.rbs_signature_for(@cmeth)
   end
 
   def test_merge_rbs_signatures_constructor
@@ -1323,22 +1326,22 @@ class RDocStoreTest < XrefTestCase
       'Object#initialize' => ['(String name) -> void']
     )
 
-    assert_equal ['(String name) -> void'], ctor.type_signature_lines
+    assert_equal ['(String name) -> void'], @s.rbs_signature_for(ctor)
   end
 
   def test_merge_rbs_signatures_clears_signatures_removed_in_subsequent_merge
     @s.merge_rbs_signatures(
       'Object#method' => ['() -> String']
     )
-    assert_equal ['() -> String'], @meth.type_signature_lines
+    assert_equal ['() -> String'], @s.rbs_signature_for(@meth)
 
     # Subsequent merge no longer mentions the key — the signature must be
     # cleared rather than left stale, so live-reload reflects deletions.
     @s.merge_rbs_signatures({})
-    assert_nil @meth.type_signature_lines
+    assert_nil @s.rbs_signature_for(@meth)
   end
 
-  def test_merge_rbs_signatures_propagates_to_method_alias
+  def test_rbs_signature_for_propagates_to_method_alias
     original = RDoc::AnyMethod.new nil, 'original'
     original.record_location @top_level
     @klass.add_method original
@@ -1351,11 +1354,11 @@ class RDocStoreTest < XrefTestCase
       'Object#original' => ['() -> String']
     )
 
-    assert_equal ['() -> String'], original.type_signature_lines
-    assert_equal ['() -> String'], aliased.type_signature_lines
+    assert_equal ['() -> String'], @s.rbs_signature_for(original)
+    assert_equal ['() -> String'], @s.rbs_signature_for(aliased)
   end
 
-  def test_merge_rbs_signatures_propagates_to_attribute_alias
+  def test_rbs_signature_for_propagates_to_attribute_alias
     original = RDoc::Attr.new nil, 'language', 'R', ''
     original.record_location @top_level
     @klass.add_attribute original
@@ -1368,8 +1371,8 @@ class RDocStoreTest < XrefTestCase
       'Object#language' => ['String']
     )
 
-    assert_equal ['String'], original.type_signature_lines
-    assert_equal ['String'], aliased.type_signature_lines
+    assert_equal ['String'], @s.rbs_signature_for(original)
+    assert_equal ['String'], @s.rbs_signature_for(aliased)
   end
 
   def test_merge_rbs_signatures_keeps_instance_and_singleton_attributes_separate
@@ -1386,8 +1389,24 @@ class RDocStoreTest < XrefTestCase
       'Object.language' => ['Integer']
     )
 
-    assert_equal ['String'], instance_attr.type_signature_lines
-    assert_equal ['Integer'], singleton_attr.type_signature_lines
+    assert_equal ['String'], @s.rbs_signature_for(instance_attr)
+    assert_equal ['Integer'], @s.rbs_signature_for(singleton_attr)
+  end
+
+  def test_rbs_signature_for_returns_nil_when_no_signatures_loaded
+    assert_nil @s.rbs_signature_for(@meth)
+  end
+
+  def test_rbs_signature_for_does_not_overwrite_inline_lookup
+    # Inline #: lives on the method itself; sidecar lookup is separate.
+    @meth.type_signature_lines = ['() -> String  # inline']
+    @s.merge_rbs_signatures(
+      'Object#method' => ['() -> String  # sidecar']
+    )
+
+    # Both sources are readable; the consumer chooses precedence (inline wins).
+    assert_equal ['() -> String  # inline'], @meth.type_signature_lines
+    assert_equal ['() -> String  # sidecar'], @s.rbs_signature_for(@meth)
   end
 
   def test_type_name_lookup
@@ -1433,18 +1452,5 @@ class RDocStoreTest < XrefTestCase
     assert_equal nested_string.path, lookup['Gem::Elements::String']
   end
 
-
-  def test_merge_rbs_signatures_does_not_overwrite_inline_annotations
-    m = RDoc::AnyMethod.new(nil, 'greet')
-    m.params = '(name)'
-    m.type_signature_lines = ['(String) -> void']
-    @klass.add_method m
-
-    @s.merge_rbs_signatures(
-      'Object#greet' => ['(String name, ?Integer count) -> void']
-    )
-
-    assert_equal ['(String) -> void'], m.type_signature_lines
-  end
 
 end

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -1352,6 +1352,23 @@ class RDocStoreTest < XrefTestCase
     refute lookup.key?('SubClass')
   end
 
+  def test_type_name_lookup_top_level_class_wins_over_nested_namesake
+    top_level_string = @top_level.add_class RDoc::NormalClass, 'String'
+    top_level_string.record_location @top_level
+
+    nested_string = @top_level.add_class RDoc::NormalClass, 'Gem::Elements::String'
+    nested_string.record_location @top_level
+
+    @s.complete :public
+
+    lookup = @s.type_name_lookup
+
+    # Top-level class retains its own path; nested namesake does not
+    # hijack the unqualified name.
+    assert_equal top_level_string.path, lookup['String']
+    assert_equal nested_string.path, lookup['Gem::Elements::String']
+  end
+
 
   def test_merge_rbs_signatures_does_not_overwrite_inline_annotations
     m = RDoc::AnyMethod.new(nil, 'greet')

--- a/test/rdoc/ri/driver_test.rb
+++ b/test/rdoc/ri/driver_test.rb
@@ -737,6 +737,20 @@ class RDocRIDriverTest < RDoc::TestCase
     assert_match %r%blah.6%,        out
   end
 
+  def test_display_method_with_type_signature
+    util_store
+
+    @blah.type_signature_lines = ['(Integer) -> String']
+    @store1.save
+
+    out, = capture_output do
+      @driver.display_method 'Foo::Bar#blah'
+    end
+
+    assert_match %r%Foo::Bar#blah%, out
+    assert_match %r%\(Integer\) -> String%, out
+  end
+
   def test_display_method_attribute
     util_store
 


### PR DESCRIPTION
## Summary

- Display RBS type signatures in HTML documentation and RI terminal output
- Source type information from inline `#:` annotations and `.rbs` files (including RBS stdlib)
- Link type names in signatures to their documentation pages

![type-signatures](https://github.com/user-attachments/assets/6450ddc0-5a1d-4721-9a0e-36723171a047)

## Details

**New module: `RDoc::RbsHelper`**
- Loads RBS signatures from `sig/` directories and stdlib declarations via `RBS::EnvironmentLoader`
- Validates inline `#:` annotations using `RBS::Parser`, warns with file:line on invalid signatures
- Renders type signatures as HTML with type names linked to their documentation pages using `a.rbs-type`

**Parser integration (`PrismRuby`)**
- Extracts `#:` annotation lines from comments via `RBS_SIG_LINE` constant
- Attaches parsed type signatures to `MethodAttr#type_signature_lines`
- Inline annotations take priority over `.rbs` file signatures

**Store**
- `merge_rbs_signatures` fills in type signatures from loaded `.rbs` files where no inline annotation exists
- `type_name_lookup` builds a cached name-to-path map for type linking; ambiguous unqualified names are excluded to avoid wrong links

**Display**
- Aliki theme: method signatures render as styled `<pre>` blocks with dotted separator; attribute signatures render inline after the `[RW]` badge
- RI driver: type signatures display as verbatim blocks after argument lists
- JS updated to exclude type signature blocks from copy-button wrapping

**Serialization**
- `MARSHAL_VERSION` bumped to 4 for both `AnyMethod` and `Attr` (additive — appends `type_signature_lines` to marshal array)

**CI/Dependencies**
- Minimum Ruby bumped to 3.2 (required by `rbs` 4.0)
- Added `rbs >= 4.0.0` and `prism >= 1.6.0` dependencies
- Dropped JRuby from CI matrix (`rbs` has a C extension); TruffleRuby retained (verified working)