### PR TITLE
Fix CSS to prevent method name overflow

### DIFF
--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1329,6 +1329,7 @@ main .method-heading .method-callseq {
 
 main .method-heading .method-name {
   font-weight: var(--font-weight-semibold);
+  overflow-wrap: anywhere;
 }
 
 main .method-heading .method-args {


### PR DESCRIPTION
This prevents method names from overflowing their container by adding `overflow-wrap: anywhere` to the `.method-name` CSS.

The `anywhere` property value is now widely supported.

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap#anywhere

Demo:

https://github.com/user-attachments/assets/336747ba-beb9-4fe0-94f2-b0db02960058

