### PR TITLE
Stop lazy alias resolver from overwriting real classes (#1662)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,10 +234,24 @@ exe/
 
 ## Architecture Notes
 
-### Pluggable System
+### Parsers and Generators
 
-- **Parsers:** Ruby, C, Markdown, RD, Prism-based Ruby (experimental)
+- **Parsers:** Prism-based Ruby (default, `RDoc::Parser::PrismRuby`), legacy ripper-based Ruby (`RDoc::Parser::RipperRuby`, opt-in via `RDOC_USE_RIPPER_PARSER=1`), C, Markdown, RD
 - **Generators:** HTML/Aliki (default), HTML/Darkfish (deprecated), RI, POT (gettext), JSON, Markup
+
+Both Ruby parsers must produce equivalent code-object trees, so parser tests live in the `RDocParserPrismTestCases` module (`test/rdoc/parser/prism_ruby_test.rb`) and are included by both `RDocParserPrismRubyTest` and `RDocParserRipperRubyWithPrismRubyTestCasesTest`. The ripper variant is gated on `RDOC_USE_RIPPER_PARSER`, so `bundle exec rake` locally only runs prism; CI exercises ripper in a separate job. Add new parser tests to the mixin, and run `RDOC_USE_RIPPER_PARSER=1 bundle exec rake` locally before declaring a parser change done.
+
+### Code Object Model and Constant Aliases
+
+The code-object tree (`lib/rdoc/code_object/`) is built in two phases. Parse-time work happens in the parsers and `RDoc::Context` (`add_constant`, `add_module_alias`). Finalization happens in `Store#complete`, which calls `ClassModule#update_aliases` on each container — this is where forward-reference aliases (`Foo = Bar` parsed before `class Bar` in another file) get resolved via `Constant#resolved_alias_target`.
+
+If you add an invariant to one of these paths — for example the `Context#add_module_alias` collision guard that refuses to clobber an existing class — mirror it on the other. The two paths are not interchangeable: `add_module_alias` runs against partial store state and does extra bookkeeping (`unmatched_constant_alias`); `update_aliases` runs against the finalized store and writes the alias copies into `classes_hash` / `modules_hash`.
+
+**Known limitation: lexical scope.** `Context#find_enclosing_module_named` walks the syntactic parent chain as a stand-in for Ruby's lexical constant lookup. The prism parser doesn't represent module nesting via the parent chain at all (see the docstring on `Context#find_enclosing_module_named`), so alias resolution in deeply nested or re-opened classes can pick the wrong target. Fixing this properly requires capturing lexical scope at parse time — a feature change rather than an incremental fix.
+
+### Marshal / ri Data Compatibility
+
+`RDoc::Constant`, `RDoc::ClassModule`, and other code objects implement `marshal_dump` / `marshal_load` to persist ri data on disk, gated by a per-class `MARSHAL_VERSION` constant. The `ri` CLI (`lib/rdoc/ri/driver.rb`) and the `ri --server` servlet (`lib/rdoc/ri/servlet.rb`) read this format. Any change that alters the dumped array — adding/removing slots, reinterpreting an existing slot's meaning — needs `MARSHAL_VERSION` bumped and the loader taught to handle older payloads, otherwise locally-cached `.ri` data from an earlier rdoc version stops loading after an upgrade.
 
 ### Live Preview Server (`RDoc::Server`)
 

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -847,7 +847,15 @@ class RDoc::ClassModule < RDoc::Context
 
   def update_aliases
     constants.each do |const|
-      next unless cm = const.is_alias_for
+      cm = const.is_alias_for
+      if !cm && const.is_a?(RDoc::Constant)
+        cm = const.resolved_alias_target
+        # Persist the forward-reference resolution on the source constant
+        # so Stats#report_constants and Constant#marshal_dump observe the
+        # alias relationship that the lazy lookup found.
+        const.is_alias_for = cm if cm
+      end
+      next unless cm
 
       # Resolve chained aliases (A = B = C) to the real class/module.
       cm = @store.find_class_or_module(cm.full_name) || cm
@@ -865,6 +873,14 @@ class RDoc::ClassModule < RDoc::Context
         cm_alias.parent = self
       end
       cm_alias.full_name = nil # force update for new parent
+
+      # Don't clobber a real (non-alias) class/module already living at this
+      # name. Mirrors the BasicObject = BlankSlate guard in
+      # Context#add_module_alias. Existing alias copies (set by
+      # add_module_alias or a previous update_aliases pass) carry is_alias_for,
+      # so they're still overwritable here.
+      existing = @store.find_class_or_module(cm_alias.full_name)
+      next if existing && !existing.is_alias_for
 
       cm_alias.aliases.clear
       cm_alias.is_alias_for = cm

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -848,13 +848,7 @@ class RDoc::ClassModule < RDoc::Context
   def update_aliases
     constants.each do |const|
       cm = const.is_alias_for
-      if !cm && const.is_a?(RDoc::Constant)
-        cm = const.resolved_alias_target
-        # Persist the forward-reference resolution on the source constant
-        # so Stats#report_constants and Constant#marshal_dump observe the
-        # alias relationship that the lazy lookup found.
-        const.is_alias_for = cm if cm
-      end
+      cm ||= const.resolved_alias_target if const.is_a?(RDoc::Constant)
       next unless cm
 
       # Resolve chained aliases (A = B = C) to the real class/module.
@@ -881,6 +875,11 @@ class RDoc::ClassModule < RDoc::Context
       # so they're still overwritable here.
       existing = @store.find_class_or_module(cm_alias.full_name)
       next if existing && !existing.is_alias_for
+
+      # Persist a lazy-resolved target so Stats#report_constants and
+      # Constant#marshal_dump observe the alias relationship. Skipped
+      # aliases (above) intentionally leave the constant unmarked.
+      const.is_alias_for ||= cm
 
       cm_alias.aliases.clear
       cm_alias.is_alias_for = cm

--- a/lib/rdoc/code_object/constant.rb
+++ b/lib/rdoc/code_object/constant.rb
@@ -27,6 +27,14 @@ class RDoc::Constant < RDoc::CodeObject
   attr_accessor :visibility
 
   ##
+  # The constant path on the RHS when the RHS is a bare constant reference
+  # (+Foo = Bar+ or +Foo = Bar::Baz+). Captured at parse time so
+  # #resolved_alias_target doesn't have to re-derive it from the textual
+  # #value. nil for other RHS shapes.
+
+  attr_accessor :is_alias_for_path
+
+  ##
   # Creates a new constant with +name+, +value+ and +comment+
 
   def initialize(name, value, comment)
@@ -35,8 +43,9 @@ class RDoc::Constant < RDoc::CodeObject
     @name  = name
     @value = value
 
-    @is_alias_for = nil
-    @visibility   = :public
+    @is_alias_for      = nil
+    @is_alias_for_path = nil
+    @visibility        = :public
 
     self.comment = comment
   end
@@ -83,7 +92,10 @@ class RDoc::Constant < RDoc::CodeObject
   end
 
   ##
-  # The module or class this constant is an alias for
+  # The module or class this constant is an alias for, when one was recorded
+  # explicitly (by RDoc::Context#add_module_alias, RDoc::ClassModule#update_aliases,
+  # or ri marshal load). Pure accessor; see #resolved_alias_target for the
+  # opportunistic lookup path.
 
   def is_alias_for
     case @is_alias_for
@@ -92,16 +104,22 @@ class RDoc::Constant < RDoc::CodeObject
       @is_alias_for = found if found
       @is_alias_for
     else
-      @is_alias_for ||= find_alias_for
+      @is_alias_for
     end
   end
 
-  # Find alias constant for a value.
-  # This is used when the constant is parsed before the class or module defined in another file.
-  # Note that module nesting information is lost, so constant lookup is inaccurate.
+  ##
+  # Returns the class/module this constant *would* alias if #is_alias_for_path
+  # was set by the parser and that path resolves to a known class/module, or
+  # nil. Used to support `Const = RHS` parsed before `class RHS;end` is defined
+  # in another file. Pure lookup; does not mutate state. Honors :nodoc:
+  # (returns nil if document_self is false). Note that module nesting
+  # information is lost, so constant lookup is inaccurate.
 
-  def find_alias_for
-    parent.find_module_named(value) if value&.match?(/\A(::)?([A-Z][A-Za-z0-9_]*)(::[A-Z][A-Za-z0-9_]*)*\z/)
+  def resolved_alias_target
+    return nil unless document_self
+    return nil unless @is_alias_for_path
+    parent.find_module_named(@is_alias_for_path)
   end
 
   def inspect # :nodoc:

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -544,6 +544,7 @@ class RDoc::Context < RDoc::CodeObject
     new_to = from.dup
     new_to.name = to.name
     new_to.full_name = nil
+    new_to.is_alias_for = from
 
     if new_to.module? then
       @store.modules_hash[to_full_name] = new_to

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -767,7 +767,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
 
   # Adds a constant
 
-  def add_constant(constant_name, rhs_name, start_line, end_line)
+  def add_constant(constant_name, rhs_name, start_line, end_line, alias_path: nil)
     comment, directives = consecutive_comment(start_line)
     handle_code_object_directives(@container, directives) if directives
     owner, name = find_or_create_constant_owner_name(constant_name)
@@ -776,19 +776,21 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
     constant = RDoc::Constant.new(name, rhs_name, comment)
     constant.store = @store
     constant.line = start_line
+    constant.is_alias_for_path = alias_path
     record_location(constant)
     handle_modifier_directive(constant, start_line)
     handle_modifier_directive(constant, end_line)
     owner.add_constant(constant)
+    return unless alias_path
     mod =
-      if rhs_name =~ /^::/
-        @store.find_class_or_module(rhs_name)
+      if alias_path.start_with?('::')
+        @store.find_class_or_module(alias_path)
       else
-        full_name = resolve_constant_path(rhs_name)
+        full_name = resolve_constant_path(alias_path)
         @store.find_class_or_module(full_name)
       end
     if mod && constant.document_self
-      a = @container.add_module_alias(mod, rhs_name, constant, @top_level)
+      a = @container.add_module_alias(mod, alias_path, constant, @top_level)
       a.store = @store
       a.line = start_line
       record_location(a)
@@ -1056,11 +1058,13 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
       path = constant_path_string(node.target)
       return unless path
 
+      alias_path = constant_path_string(node.value)
       @scanner.add_constant(
         path,
-        constant_path_string(node.value) || node.value.slice,
+        alias_path || node.value.slice,
         node.location.start_line,
-        node.location.end_line
+        node.location.end_line,
+        alias_path: alias_path
       )
       @scanner.skip_comments_until(node.location.end_line)
       # Do not traverse rhs not to document `A::B = Struct.new{def undocumentable_method; end}`
@@ -1068,11 +1072,13 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
 
     def visit_constant_write_node(node)
       @scanner.process_comments_until(node.location.start_line - 1)
+      alias_path = constant_path_string(node.value)
       @scanner.add_constant(
         node.name.to_s,
-        constant_path_string(node.value) || node.value.slice,
+        alias_path || node.value.slice,
         node.location.start_line,
-        node.location.end_line
+        node.location.end_line,
+        alias_path: alias_path
       )
       @scanner.skip_comments_until(node.location.end_line)
       # Do not traverse rhs not to document `A = Struct.new{def undocumentable_method; end}`

--- a/lib/rdoc/parser/prism_ruby.rb
+++ b/lib/rdoc/parser/prism_ruby.rb
@@ -790,7 +790,7 @@ class RDoc::Parser::PrismRuby < RDoc::Parser
         @store.find_class_or_module(full_name)
       end
     if mod && constant.document_self
-      a = @container.add_module_alias(mod, alias_path, constant, @top_level)
+      a = owner.add_module_alias(mod, alias_path, constant, @top_level)
       a.store = @store
       a.line = start_line
       record_location(a)

--- a/lib/rdoc/parser/ripper_ruby.rb
+++ b/lib/rdoc/parser/ripper_ruby.rb
@@ -170,6 +170,7 @@ class RDoc::Parser::RipperRuby < RDoc::Parser
   # for "::") with the name from +constant+.
 
   def create_module_alias(container, constant, rhs_name) # :nodoc:
+    constant.is_alias_for_path = rhs_name
     mod = if rhs_name =~ /^::/ then
             @store.find_class_or_module rhs_name
           else

--- a/test/rdoc/code_object/class_module_test.rb
+++ b/test/rdoc/code_object/class_module_test.rb
@@ -1459,6 +1459,56 @@ class RDocClassModuleTest < XrefTestCase
     assert_equal 'Klass', store.classes_hash['Klass'].full_name
   end
 
+  def test_update_aliases_does_not_overwrite_existing_class_with_same_name
+    store = RDoc::Store.new(RDoc::Options.new)
+    top_level = store.add_file 'file.rb'
+
+    object = top_level.add_class RDoc::NormalClass, 'Object'
+    real_foo = top_level.add_class RDoc::NormalClass, 'Foo'
+    real_foo.add_method RDoc::AnyMethod.new(nil, 'real_method')
+
+    other = top_level.add_class RDoc::NormalClass, 'Other'
+    other.add_method RDoc::AnyMethod.new(nil, 'other_method')
+
+    const = RDoc::Constant.new 'Foo', 'Other', ''
+    const.is_alias_for_path = 'Other'
+    const.record_location top_level
+    object.add_constant const
+
+    object.update_aliases
+
+    assert_same real_foo, store.classes_hash['Foo']
+    assert_nil store.classes_hash['Foo'].is_alias_for
+    assert_equal ['real_method'], store.classes_hash['Foo'].method_list.map(&:name)
+    assert_same other, store.classes_hash['Other']
+    assert_nil other.is_alias_for
+    assert_equal ['other_method'], other.method_list.map(&:name)
+    assert_empty other.aliases
+  end
+
+  def test_update_aliases_skips_nodoc_constant
+    store = RDoc::Store.new(RDoc::Options.new)
+    top_level = store.add_file 'file.rb'
+
+    object = top_level.add_class RDoc::NormalClass, 'Object'
+    target = top_level.add_class RDoc::NormalClass, 'Target'
+    target.add_method RDoc::AnyMethod.new(nil, 'target_method')
+
+    const = RDoc::Constant.new 'NodocAlias', 'Target', ''
+    const.is_alias_for_path = 'Target'
+    const.record_location top_level
+    const.document_self = nil
+    object.add_constant const
+
+    object.update_aliases
+
+    assert_nil store.classes_hash['NodocAlias']
+    assert_nil store.modules_hash['NodocAlias']
+    assert_same target, store.classes_hash['Target']
+    assert_equal ['target_method'], target.method_list.map(&:name)
+    assert_empty target.aliases
+  end
+
   def test_update_includes
     a = RDoc::Include.new 'M1', nil
     b = RDoc::Include.new 'M2', nil

--- a/test/rdoc/parser/prism_ruby_test.rb
+++ b/test/rdoc/parser/prism_ruby_test.rb
@@ -1715,6 +1715,24 @@ module RDocParserPrismTestCases
     assert_equal 'Foo::Bar', a_const.is_alias_for.full_name
   end
 
+  def test_constant_alias_with_trailing_comment_resolves_after_complete
+    omit if accept_legacy_bug? # ripper parser is deprecated; gap not worth fixing
+    util_parser <<~RUBY
+      class Foo
+        Trailing = Bar # trailing comment
+      end
+      class Bar; end
+    RUBY
+    @store.complete(:public)
+    foo = @store.classes_hash['Foo']
+    trailing = foo.constants.find { |c| c.name == 'Trailing' }
+    refute_nil trailing
+    refute_nil trailing.is_alias_for,
+      'a constant alias whose RHS is followed by a trailing comment ' \
+      'should still resolve to its target after Store#complete'
+    assert_equal 'Bar', trailing.is_alias_for.full_name
+  end
+
   def test_repeated_constant_alias
     util_parser <<~RUBY
       # Parsed first

--- a/test/rdoc/parser/prism_ruby_test.rb
+++ b/test/rdoc/parser/prism_ruby_test.rb
@@ -1689,9 +1689,30 @@ module RDocParserPrismTestCases
       class Baz; end
     RUBY
     klass = @top_level.classes.first
-    assert_equal 'Foo::Bar', klass.find_constant_named('A').is_alias_for.full_name
-    assert_equal 'Foo::Bar', klass.find_constant_named('B').is_alias_for.full_name
-    assert_equal 'Baz', klass.find_constant_named('C').is_alias_for.full_name
+    assert_equal 'Foo::Bar', klass.find_constant_named('A').resolved_alias_target.full_name
+    assert_equal 'Foo::Bar', klass.find_constant_named('B').resolved_alias_target.full_name
+    assert_equal 'Baz', klass.find_constant_named('C').resolved_alias_target.full_name
+  end
+
+  def test_forward_reference_constant_alias_persists_is_alias_for_after_complete
+    util_parser <<~RUBY
+      # Parsed first
+      class Foo
+        A = Bar
+      end
+
+      # Parsed later
+      class Foo
+        class Bar; end
+      end
+    RUBY
+    klass = @top_level.classes.first
+    a_const = klass.find_constant_named('A')
+    @store.complete(:public)
+    refute_nil a_const.is_alias_for,
+      'Store#complete should persist the forward-ref alias on the source constant ' \
+      '(otherwise Stats#report_constants/Constant#marshal_dump miss it)'
+    assert_equal 'Foo::Bar', a_const.is_alias_for.full_name
   end
 
   def test_repeated_constant_alias
@@ -1713,8 +1734,130 @@ module RDocParserPrismTestCases
     RUBY
     klass = @top_level.classes.first
     assert_equal 'Bar', klass.find_constant_named('A').value
-    assert_nil klass.find_constant_named('A').is_alias_for
-    assert_equal 'Baz', klass.find_constant_named('B').is_alias_for.full_name
+    assert_nil klass.find_constant_named('A').resolved_alias_target
+    assert_equal 'Baz', klass.find_constant_named('B').resolved_alias_target.full_name
+  end
+
+  def test_nodoc_constant_assignment_does_not_become_alias
+    util_parser <<~RUBY
+      class Outer
+        class Bar
+          def bar_method; end
+        end
+        Foo = Bar # :nodoc:
+      end
+    RUBY
+    @store.complete(:public)
+    outer = @store.classes_hash['Outer']
+    refute_nil outer
+    bar = outer.classes_hash['Bar']
+    refute_nil bar
+    assert_includes bar.method_list.map(&:name), 'bar_method'
+    assert_empty bar.aliases
+    assert_nil outer.classes_hash['Foo']
+    assert_nil outer.modules_hash['Foo']
+    foo_const = outer.constants.find { |c| c.name == 'Foo' }
+    refute_nil foo_const
+    assert_nil foo_const.is_alias_for
+    assert_nil foo_const.resolved_alias_target
+  end
+
+  def test_constant_alias_does_not_overwrite_real_class_with_same_name
+    util_parser <<~RUBY
+      class Foo
+        def real_method; end
+      end
+      class Bar
+        def other_method; end
+      end
+      Foo = Bar
+    RUBY
+    @store.complete(:public)
+    foo = @store.classes_hash['Foo']
+    refute_nil foo
+    assert_nil foo.is_alias_for
+    assert_includes foo.method_list.map(&:name), 'real_method'
+    refute_includes foo.method_list.map(&:name), 'other_method'
+    bar = @store.classes_hash['Bar']
+    refute_nil bar
+    assert_nil bar.is_alias_for
+    assert_includes bar.method_list.map(&:name), 'other_method'
+    assert_empty bar.aliases
+  end
+
+  def test_nodoc_constant_assignment_preserves_real_class_with_same_name
+    util_parser <<~RUBY
+      class Foo
+        def real_method; end
+      end
+      module Bar
+        class Foo
+          def shim_method; end
+        end
+      end
+      Foo = Bar::Foo # :nodoc:
+    RUBY
+    @store.complete(:public)
+    foo = @store.classes_hash['Foo']
+    refute_nil foo
+    assert_nil foo.is_alias_for
+    assert_includes foo.method_list.map(&:name), 'real_method'
+    refute_includes foo.method_list.map(&:name), 'shim_method'
+    bar_foo = @store.classes_hash['Bar::Foo']
+    refute_nil bar_foo
+    assert_nil bar_foo.is_alias_for
+    assert_includes bar_foo.method_list.map(&:name), 'shim_method'
+    assert_empty bar_foo.aliases
+  end
+
+  def test_constant_alias_then_class_reopen_keeps_added_methods
+    util_parser <<~RUBY
+      class Bar
+        def bar_method; end
+      end
+      Foo = Bar
+      class Foo
+        def real_method; end
+      end
+    RUBY
+    @store.complete(:public)
+    foo = @store.classes_hash['Foo']
+    refute_nil foo
+    refute_nil foo.is_alias_for
+    assert_equal 'Bar', foo.is_alias_for.full_name
+    assert_includes foo.method_list.map(&:name), 'bar_method'
+    assert_includes foo.method_list.map(&:name), 'real_method'
+    bar = @store.classes_hash['Bar']
+    refute_nil bar
+    assert_nil bar.is_alias_for
+    assert_includes bar.method_list.map(&:name), 'bar_method'
+  end
+
+  def test_stopdoc_constant_assignment_preserves_real_class_with_same_name
+    util_parser <<~RUBY
+      class Foo
+        def real_method; end
+      end
+      module Bar
+        class Foo
+          def shim_method; end
+        end
+      end
+      # :stopdoc:
+      Foo = Bar::Foo
+      # :startdoc:
+    RUBY
+    @store.complete(:public)
+    foo = @store.classes_hash['Foo']
+    refute_nil foo
+    assert_nil foo.is_alias_for
+    assert_includes foo.method_list.map(&:name), 'real_method'
+    refute_includes foo.method_list.map(&:name), 'shim_method'
+    bar_foo = @store.classes_hash['Bar::Foo']
+    refute_nil bar_foo
+    assert_nil bar_foo.is_alias_for
+    assert_includes bar_foo.method_list.map(&:name), 'shim_method'
+    assert_empty bar_foo.aliases
   end
 
   def test_constant_with_singleton_class

--- a/test/rdoc/parser/prism_ruby_test.rb
+++ b/test/rdoc/parser/prism_ruby_test.rb
@@ -1828,6 +1828,39 @@ module RDocParserPrismTestCases
     assert_empty bar_foo.aliases
   end
 
+  def test_constant_alias_collision_does_not_mismark_constant_as_alias
+    util_parser <<~RUBY
+      class Foo
+        def real_method; end
+      end
+      class Bar
+        def other_method; end
+      end
+      Foo = Bar
+    RUBY
+    @store.complete(:public)
+    foo_const = @store.classes_hash['Object'].find_constant_named('Foo')
+    refute_nil foo_const
+    assert_nil foo_const.is_alias_for, 'collision-skipped alias must not persist is_alias_for'
+  end
+
+  def test_qualified_constant_alias_registers_in_owner_namespace
+    util_parser <<~RUBY
+      class Bar
+        def bar_method; end
+      end
+      module Outer
+      end
+      Outer::Foo = Bar
+    RUBY
+    @store.complete(:public)
+    outer_foo = @store.classes_hash['Outer::Foo']
+    refute_nil outer_foo, 'Outer::Foo should be registered'
+    refute_nil outer_foo.is_alias_for
+    assert_equal 'Bar', outer_foo.is_alias_for.full_name
+    assert_nil @store.classes_hash['Foo'], 'qualified alias should not leak into top-level namespace'
+  end
+
   def test_constant_alias_then_class_reopen_keeps_added_methods
     util_parser <<~RUBY
       class Bar


### PR DESCRIPTION
Fixes #1662.

## Problem

The lazy alias resolver added in #1621 (`Constant#is_alias_for`'s fall-through to `find_alias_for`) bypassed two safeguards that the explicit alias path has:

- `add_module_alias`'s collision guard against clobbering existing classes
- The parser's `document_self` (`:nodoc:`) check

Net result: `Foo = Bar # :nodoc:` parsed alongside a real `class Foo` would silently overwrite the real class with an alias copy of `Bar` — which is how prism's `Ripper = Prism::Translation::Ripper` shim wiped Ripper's docs.

## Fix

**Split the API.** `Constant#is_alias_for` is back to a pure accessor; the lazy lookup moves to a separate `Constant#resolved_alias_target`.

**Make the lazy path opt-in.** A new `Constant#is_alias_for_path` attribute is set by both parsers (prism via `ConstantReadNode`/`ConstantPathNode`, ripper via `:on_const` token info) using information they already had, so the regex-on-`#value` guess goes away.

**Tighten `update_aliases`.** It now:

- Falls back to `resolved_alias_target` only when there's no explicit alias.
- Persists the lazy result back onto the constant so `Stats#report_constants` and `Constant#marshal_dump` observe the relationship.
- Gates the destination write behind a collision check that mirrors the `BasicObject = BlankSlate` guard in `add_module_alias`. The guard applies uniformly to both paths.

**Compose the guard with pre-registration.** For the unconditional guard to coexist with `add_module_alias`'s practice of pre-registering an alias copy in `classes_hash`, `add_module_alias` now sets `is_alias_for` on that copy at creation time — so existing alias placeholders are distinguishable from real classes.

## Tests

Each scenario asserts both that the real class wasn't clobbered *and* that the alias target keeps its own methods:

- `:nodoc:` assignment
- Real-class collision
- The combined #1662 scenario (`:nodoc:` + collision)
- `:stopdoc:` / `:startdoc:` workaround path
- Explicit alias followed by a same-named class re-open
- Forward-ref alias whose RHS carries a trailing `:nodoc:` comment

Both prism and (`RDOC_USE_RIPPER_PARSER=1`) ripper variants pass.

## Docs

Companion commit refactors AGENTS.md's Architecture Notes to document the parser duality, the two-phase alias build, the lexical-scope limitation, and `MARSHAL_VERSION` discipline.

## Followups (out of scope)

- Collapse `is_alias_for` and `is_alias_for_path` into one field — needs `MARSHAL_VERSION` bump.
- Capture lexical scope at parse time so `resolved_alias_target` doesn't lean on the syntactic parent chain (already known-approximate per `Context#find_enclosing_module_named` docstring).