### PR TITLE
Remove `ruby-title` class

### DIFF
--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -15,8 +15,6 @@ module RDoc::TokenStream
   # with the given class names. Other token types are not wrapped in spans.
 
   def self.to_html(token_stream)
-    starting_title = false
-
     token_stream.map do |t|
       next unless t
 
@@ -46,15 +44,6 @@ module RDoc::TokenStream
               end
 
       text = t[:text]
-
-      if :on_ident == t[:kind] && starting_title
-        starting_title = false
-        style = 'ruby-identifier ruby-title'
-      end
-
-      if :on_kw == t[:kind] and 'def' == t[:text]
-        starting_title = true
-      end
 
       text = CGI.escapeHTML text
 

--- a/test/rdoc/markup/to_html_test.rb
+++ b/test/rdoc/markup/to_html_test.rb
@@ -568,7 +568,7 @@ end
 
     expected = <<-'EXPECTED'
 
-<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">foo</span>
+<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier">foo</span>
   [
     <span class="ruby-string">&#39;\\&#39;</span>,
     <span class="ruby-string">&#39;\&#39;&#39;</span>,
@@ -588,7 +588,7 @@ end
     <span class="ruby-regexp">/#{}/</span>
   ]
 <span class="ruby-keyword">end</span>
-<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">bar</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier">bar</span>
 <span class="ruby-keyword">end</span>
 </pre>
     EXPECTED
@@ -618,7 +618,7 @@ end
 
     expected = <<-'EXPECTED'
 
-<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">foo</span>
+<pre class="ruby"><span class="ruby-keyword">def</span> <span class="ruby-identifier">foo</span>
   [
     <span class="ruby-string">`\\`</span>,
     <span class="ruby-string">`\&#39;\&quot;\``</span>,
@@ -628,7 +628,7 @@ end
     <span class="ruby-node">`#{}`</span>
   ]
 <span class="ruby-keyword">end</span>
-<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">bar</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier">bar</span>
 <span class="ruby-keyword">end</span>
 </pre>
     EXPECTED
@@ -702,7 +702,7 @@ end
 
     %w[| ^ &amp; &lt;=&gt; == === =~ &gt; &gt;= &lt; &lt;= &lt;&lt; &gt;&gt; + - * / % ** ~ +@ -@ [] []= ` !  != !~].each do |html_escaped_op|
       expected += <<-EXPECTED
-<span class="ruby-keyword">def</span> <span class="ruby-identifier ruby-title">#{html_escaped_op}</span>
+<span class="ruby-keyword">def</span> <span class="ruby-identifier">#{html_escaped_op}</span>
 <span class="ruby-keyword">end</span>
       EXPECTED
     end


### PR DESCRIPTION
It was added for sdoc in https://github.com/ruby/rdoc/commit/acc499bad1984aeb4589334b4b434cb59df992ae
But since https://github.com/rails/sdoc/commit/41a790bad5fb95d10103342dee7a9c8b89880a2b it doesn't use it anymore, and rdoc has no use for it as well.