### PR TITLE
Remove parser module indirection used in testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ exe/
 - **Parsers:** Prism-based Ruby (`RDoc::Parser::Ruby`), C, Markdown, RD
 - **Generators:** HTML/Aliki (default), HTML/Darkfish (deprecated), RI, POT (gettext), JSON, Markup
 
-Parser tests live in the `RDocParserRubyTestCases` module (`test/rdoc/parser/ruby_test.rb`) and are included by `RDocParserRubyTest`. Add new parser tests to the mixin.
+Parser tests live in the `RDocParserRubyTest` class (`test/rdoc/parser/ruby_test.rb`).
 
 ### Code Object Model and Constant Aliases
 

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -4,7 +4,7 @@ require_relative '../helper'
 require 'rdoc/parser'
 require 'rdoc/parser/ruby'
 
-module RDocParserRubyTestCases
+class RDocParserRubyTest < RDoc::TestCase
   def setup
     super
 
@@ -2528,10 +2528,6 @@ module RDocParserRubyTestCases
     assert_equal "foo1\nbar1", m1.call_seq.chomp
     assert_equal "ARGF.readlines(a)\nARGF.readlines(b)\nARGF.readlines(c)\nARGF.readlines(d)", m2.call_seq.chomp
   end
-end
-
-class RDocParserRubyTest < RDoc::TestCase
-  include RDocParserRubyTestCases
 
   def util_parser(content)
     @parser = RDoc::Parser::Ruby.new @top_level, content, @options, @stats


### PR DESCRIPTION
The ripper parser is gone, so this is not needed anymore

Makes it so that I can easily run individual tests via ruby-lsp It's their limitation really but seems ok to do regardless