### PR TITLE
Drop dead rdoc/markdown handling from rubygems plugin

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -9,7 +9,6 @@
 # - RDoc is a old version that doesn't have rubygems_plugin.rb.
 
 require_relative 'rdoc/rubygems_hook'
-require_relative 'rdoc/markdown'
 
 Gem.done_installing(&RDoc::RubyGemsHook.method(:generate))
 Gem.pre_uninstall(&RDoc::RubyGemsHook.method(:remove))

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -9,15 +9,7 @@
 # - RDoc is a old version that doesn't have rubygems_plugin.rb.
 
 require_relative 'rdoc/rubygems_hook'
+require_relative 'rdoc/markdown'
 
-# To install dependency libraries of RDoc, you need to run bundle install.
-# At that time, rdoc/markdown is not generated.
-# If generate and remove are executed at that time, an error will occur.
-# So, we can't register generate and remove to Gem at that time.
-begin
-  require_relative 'rdoc/markdown'
-rescue LoadError
-else
-  Gem.done_installing(&RDoc::RubyGemsHook.method(:generate))
-  Gem.pre_uninstall(&RDoc::RubyGemsHook.method(:remove))
-end
+Gem.done_installing(&RDoc::RubyGemsHook.method(:generate))
+Gem.pre_uninstall(&RDoc::RubyGemsHook.method(:remove))


### PR DESCRIPTION
`lib/rubygems_plugin.rb` carries a `begin / rescue LoadError / else` block around `require_relative 'rdoc/markdown'`, gating hook registration on the require succeeding. The accompanying comment explains the guard exists because `markdown.rb` used to be kpeg-generated during `bundle install` and could be absent mid-bootstrap.

That window no longer exists. `lib/rdoc/markdown.rb` is generated and committed, and `RDoc::RubyGemsHook` doesn't reference `RDoc::Markdown` itself — any markdown source actually encountered during doc generation is loaded lazily by the parser dispatcher. So both the guard and the require it gated are dead code.

This drops both, and as a side effect skips parsing ~16k LOC of kpeg-generated parser on every `gem` CLI invocation and every `bundle install` resolution path.
