### PR TITLE
Remove obsolete -V short flag from --visibility option

### DIFF
--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -895,7 +895,7 @@ Usage: #{opt.program_name} [options] [names...]
 
       opt.separator nil
 
-      opt.on("--visibility=VISIBILITY", "-V", RDoc::VISIBILITIES + [:nodoc],
+      opt.on("--visibility=VISIBILITY", RDoc::VISIBILITIES + [:nodoc],
              "Minimum visibility to document a method.",
              "One of 'public', 'protected' (the default),",
              "'private' or 'nodoc' (show everything)") do |value|

--- a/test/rdoc/rdoc_options_test.rb
+++ b/test/rdoc/rdoc_options_test.rb
@@ -697,6 +697,15 @@ rdoc_include:
     assert_equal :nodoc, @options.visibility
   end
 
+  def test_parse_verbose
+    @options.parse %w[--verbose]
+    assert_equal 2, @options.verbosity
+
+    @options = RDoc::Options.new
+    @options.parse %w[-V]
+    assert_equal 2, @options.verbosity
+  end
+
   def test_parse_write_options
     tmpdir = File.join Dir.tmpdir, "test_rdoc_options_#{$$}"
     FileUtils.mkdir_p tmpdir


### PR DESCRIPTION
The `--visibility` option declared `-V` as a short flag, but `--verbose` declares the same `-V` later in the option parser. OptionParser silently lets the later registration win, so `-V` has actually been an alias for `--verbose` rather than `--visibility` — making the visibility short flag obsolete and misleading anyone who reads the source expecting it to work.

This drops `-V` from the `--visibility=VISIBILITY` definition in `lib/rdoc/options.rb`. `--verbose -V` continues to work exactly as before; `--visibility` retains its long form. There is no behavior change for users who were relying on whatever `-V` actually did at runtime.

Adds `test_parse_verbose` to `test/rdoc/rdoc_options_test.rb` so the `-V` → `--verbose` wiring is locked in and a future re-introduction of the duplicate short flag would be caught by the test suite.
