### PR TITLE
Remove `MetaMethod` and `GhostMethod`

### DIFF
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -197,8 +197,6 @@ module RDoc
   autoload :Alias,          "#{__dir__}/rdoc/code_object/alias"
   autoload :AnyMethod,      "#{__dir__}/rdoc/code_object/any_method"
   autoload :MethodAttr,     "#{__dir__}/rdoc/code_object/method_attr"
-  autoload :GhostMethod,    "#{__dir__}/rdoc/code_object/ghost_method"
-  autoload :MetaMethod,     "#{__dir__}/rdoc/code_object/meta_method"
   autoload :Attr,           "#{__dir__}/rdoc/code_object/attr"
 
   autoload :Constant,       "#{__dir__}/rdoc/code_object/constant"

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -16,8 +16,6 @@
 # * RDoc::MethodAttr
 #   * RDoc::Attr
 #   * RDoc::AnyMethod
-#     * RDoc::GhostMethod
-#     * RDoc::MetaMethod
 # * RDoc::Alias
 # * RDoc::Constant
 # * RDoc::Require

--- a/lib/rdoc/code_object/ghost_method.rb
+++ b/lib/rdoc/code_object/ghost_method.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-##
-# GhostMethod represents a method referenced only by a comment
-
-class RDoc::GhostMethod < RDoc::AnyMethod
-end

--- a/lib/rdoc/code_object/meta_method.rb
+++ b/lib/rdoc/code_object/meta_method.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-##
-# MetaMethod represents a meta-programmed method
-
-class RDoc::MetaMethod < RDoc::AnyMethod
-end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -308,7 +308,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     name, = signature.split %r%[ \(]%, 2
 
-    meth = RDoc::GhostMethod.new comment.text, name
+    meth = RDoc::AnyMethod.new comment.text, name
     record_location(meth)
     meth.line = start_line
     meth.call_seq = signature


### PR DESCRIPTION
RDoc has no special handling for these. `MetaMethod` is unreferenced, and `GhostMethod` was only used for tomdoc.