### PR TITLE
Fix circular require of RDoc::Parser::RubyColorizer

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -2,7 +2,6 @@
 require 'cgi/escape'
 require 'cgi/util' unless defined?(CGI::EscapeExt)
 require 'prism'
-require 'rdoc/parser/ruby_colorizer'
 
 ##
 # Outputs RDoc markup as HTML.

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -293,5 +293,5 @@ require_relative 'parser/c'
 require_relative 'parser/changelog'
 require_relative 'parser/markdown'
 require_relative 'parser/rd'
-
 require_relative 'parser/ruby'
+require_relative 'parser/ruby_colorizer'

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'prism'
-require_relative 'ruby_colorizer'
 
 # Parse and collect document from Ruby source code.
 

--- a/test/rdoc/parser/ruby_colorizer_test.rb
+++ b/test/rdoc/parser/ruby_colorizer_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require_relative '../helper'
-require 'rdoc/parser/ruby_colorizer'
+require 'prism'
 
 class RDocParserRubyColorizerTest < RDoc::TestCase
   def token(kind, text)


### PR DESCRIPTION
Loading `RubyColorizer` will trigger autoload of `RDoc::Parser`, and `require_relative 'parser/ruby'`.
`parser/ruby.rb` shouldn't require `ruby_colorizer.rb` to avoid circular require.

Originally found in `rake test` log, but can be reproduced with:
```
$ ruby -W -rrdoc -Ilib -e 'p RDoc::Markup::ToHtml'
warning: loading in progress, circular require considered harmful
```