### PR TITLE
Remove `RDoc::MethodAttr#text`

### DIFF
--- a/lib/rdoc/code_object/alias.rb
+++ b/lib/rdoc/code_object/alias.rb
@@ -26,18 +26,12 @@ class RDoc::Alias < RDoc::CodeObject
   attr_reader :singleton
 
   ##
-  # Source file token stream
-
-  attr_reader :text
-
-  ##
-  # Creates a new Alias with a token stream of +text+ that aliases +old_name+
+  # Creates a new Alias that aliases +old_name+
   # to +new_name+, has +comment+ and is a +singleton+ context.
 
-  def initialize(text, old_name, new_name, comment, singleton: false)
+  def initialize(old_name, new_name, comment, singleton: false)
     super()
 
-    @text = text
     @singleton = singleton
     @old_name = old_name
     @new_name = new_name

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -39,10 +39,10 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   include RDoc::TokenStream
 
   ##
-  # Creates a new AnyMethod with a token stream +text+ and +name+
+  # Creates a new AnyMethod with name +name+
 
-  def initialize(text, name, singleton: false)
-    super(text, name, singleton: singleton)
+  def initialize(name, singleton: false)
+    super(name, singleton: singleton)
 
     @c_function = nil
     @dont_rename_initialize = false
@@ -55,7 +55,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # Adds +an_alias+ as an alias for this method in +context+.
 
   def add_alias(an_alias, context = nil)
-    method = self.class.new an_alias.text, an_alias.new_name, singleton: singleton
+    method = self.class.new an_alias.new_name, singleton: singleton
 
     method.record_location an_alias.file
     method.params = self.params
@@ -211,7 +211,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     @type_signature_lines = array[16]&.split("\n")
 
     array[8].each do |new_name, document|
-      add_alias RDoc::Alias.new(nil, @name, new_name, RDoc::Comment.from_document(document), singleton: @singleton)
+      add_alias RDoc::Alias.new(@name, new_name, RDoc::Comment.from_document(document), singleton: @singleton)
     end
 
     @parent_name ||= if @full_name =~ /#/ then

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -21,11 +21,11 @@ class RDoc::Attr < RDoc::MethodAttr
   attr_accessor :rw
 
   ##
-  # Creates a new Attr with body +text+, +name+, read/write status +rw+ and
+  # Creates a new Attr with +name+, read/write status +rw+ and
   # +comment+.  +singleton+ marks this as a class attribute.
 
-  def initialize(text, name, rw, comment, singleton: false)
-    super(text, name, singleton: singleton)
+  def initialize(name, rw, comment, singleton: false)
+    super(name, singleton: singleton)
 
     @rw = rw
     self.comment = comment
@@ -46,7 +46,7 @@ class RDoc::Attr < RDoc::MethodAttr
 
   def add_alias(an_alias, context)
     access_type = an_alias.new_name.end_with?('=') ? 'W' : 'R'
-    new_attr = self.class.new(text, an_alias.new_name, access_type, comment, singleton: singleton)
+    new_attr = self.class.new(an_alias.new_name, access_type, comment, singleton: singleton)
     new_attr.record_location an_alias.file
     new_attr.visibility = self.visibility
     new_attr.is_alias_for = self

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -414,7 +414,7 @@ class RDoc::ClassModule < RDoc::Context
       singleton  ||= false
       visibility ||= :public
 
-      attr = RDoc::Attr.new nil, name, rw, nil, singleton: singleton
+      attr = RDoc::Attr.new name, rw, nil, singleton: singleton
 
       add_attribute attr
       attr.visibility = visibility
@@ -441,7 +441,7 @@ class RDoc::ClassModule < RDoc::Context
         @visibility = visibility
 
         methods.each do |name, file|
-          method = RDoc::AnyMethod.new nil, name, singleton: type == 'class'
+          method = RDoc::AnyMethod.new name, singleton: type == 'class'
           method.record_location RDoc::TopLevel.new file
           add_method method
         end

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -22,11 +22,6 @@ class RDoc::MethodAttr < RDoc::CodeObject
   attr_accessor :singleton
 
   ##
-  # Source file token stream
-
-  attr_reader :text
-
-  ##
   # Array of other names for this method/attribute
 
   attr_reader :aliases
@@ -70,15 +65,14 @@ class RDoc::MethodAttr < RDoc::CodeObject
   attr_reader :arglists
 
   ##
-  # Creates a new MethodAttr from token stream +text+ and method or attribute
+  # Creates a new MethodAttr with method or attribute
   # name +name+.
   #
   # Usually this is called by super from a subclass.
 
-  def initialize(text, name, singleton: false)
+  def initialize(name, singleton: false)
     super()
 
-    @text = text
     @name = name
 
     @aliases      = []
@@ -361,13 +355,6 @@ class RDoc::MethodAttr < RDoc::CodeObject
       if alias_for then
         q.breakable
         q.text alias_for
-      end
-
-      if text then
-        q.breakable
-        q.text "text:"
-        q.breakable
-        q.pp @text
       end
 
       unless comment.empty? then

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -248,7 +248,7 @@ class RDoc::Parser::C < RDoc::Parser
   # method that reference the same function.
 
   def add_alias(var_name, class_obj, old_name, new_name, comment)
-    al = RDoc::Alias.new '', old_name, new_name, comment, singleton: @singleton_classes.key?(var_name)
+    al = RDoc::Alias.new old_name, new_name, comment, singleton: @singleton_classes.key?(var_name)
     al.record_location @top_level
     class_obj.add_alias al
     @stats.add_alias al
@@ -848,7 +848,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     name = attr_name.gsub(/rb_intern(?:_const)?\("([^"]+)"\)/, '\1')
 
-    attr = RDoc::Attr.new '', name, rw, comment
+    attr = RDoc::Attr.new name, rw, comment
 
     attr.record_location @top_level
     class_obj.add_attribute attr
@@ -1007,7 +1007,7 @@ class RDoc::Parser::C < RDoc::Parser
       end
 
       singleton = singleton || %w[singleton_method module_function].include?(type)
-      meth_obj = RDoc::AnyMethod.new '', meth_name, singleton: singleton
+      meth_obj = RDoc::AnyMethod.new meth_name, singleton: singleton
       meth_obj.c_function = function
 
       p_count = Integer(param_count) rescue -1

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -311,7 +311,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     name, = signature.split %r%[ \(]%, 2
 
-    meth = RDoc::AnyMethod.new comment.text, name
+    meth = RDoc::AnyMethod.new name
     record_location(meth)
     meth.line = start_line
     meth.call_seq = signature
@@ -377,7 +377,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
     if attributes
       attributes.each do |attr|
-        a = RDoc::Attr.new(@container, attr, rw, comment, singleton: @singleton)
+        a = RDoc::Attr.new(attr, rw, comment, singleton: @singleton)
         a.store = @store
         a.line = line_no
         record_location(a)
@@ -562,7 +562,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     comment, directives = consecutive_comment(line_no)
     handle_code_object_directives(@container, directives) if directives
     visibility = @container.find_method(old_name, @singleton)&.visibility || :public
-    a = RDoc::Alias.new(nil, old_name, new_name, comment, singleton: @singleton)
+    a = RDoc::Alias.new(old_name, new_name, comment, singleton: @singleton)
     handle_modifier_directive(a, line_no)
     a.store = @store
     a.line = line_no
@@ -581,7 +581,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     return unless @container.document_children
 
     names.each do |symbol|
-      a = RDoc::Attr.new(nil, symbol.to_s, rw, comment, singleton: @singleton)
+      a = RDoc::Attr.new(symbol.to_s, rw, comment, singleton: @singleton)
       a.store = @store
       a.line = line_no
       a.type_signature_lines = type_signature_lines
@@ -644,7 +644,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   end
 
   private def internal_add_method(method_name, container, comment:, dont_rename_initialize: false, directives:, modifier_comment_lines: nil, line_no:, visibility:, singleton:, params:, calls_super:, block_params:, tokens:, type_signature_lines: nil) # :nodoc:
-    meth = RDoc::AnyMethod.new(nil, method_name, singleton: singleton)
+    meth = RDoc::AnyMethod.new(method_name, singleton: singleton)
     meth.comment = comment
     handle_code_object_directives(meth, directives) if directives
     modifier_comment_lines&.each do |line|

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -1218,7 +1218,7 @@ or the PAGER environment variable.
     comment = RDoc::Comment.new("missing documentation at #{e.file}")
     comment.parse
 
-    method = RDoc::AnyMethod.new nil, name
+    method = RDoc::AnyMethod.new name
     method.comment = comment
     method
   end

--- a/test/rdoc/code_object/alias_test.rb
+++ b/test/rdoc/code_object/alias_test.rb
@@ -4,7 +4,7 @@ require_relative '../xref_test_case'
 class RDocAliasTest < XrefTestCase
 
   def test_to_s
-    a = RDoc::Alias.new nil, 'a', 'b', ''
+    a = RDoc::Alias.new 'a', 'b', ''
     a.parent = @c2
 
     assert_equal 'alias: b -> #a in: RDoc::NormalClass C2 < Object', a.to_s

--- a/test/rdoc/code_object/any_method_test.rb
+++ b/test/rdoc/code_object/any_method_test.rb
@@ -4,7 +4,7 @@ require_relative '../xref_test_case'
 class RDocAnyMethodTest < XrefTestCase
 
   def test_aref
-    m = RDoc::AnyMethod.new nil, 'method?'
+    m = RDoc::AnyMethod.new 'method?'
 
     assert_equal 'method-i-method-3F', m.aref
 
@@ -14,7 +14,7 @@ class RDocAnyMethodTest < XrefTestCase
   end
 
   def test_arglists
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
 
     assert_nil m.arglists
 
@@ -40,7 +40,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_call_seq_equals
-    m = RDoc::AnyMethod.new nil, nil
+    m = RDoc::AnyMethod.new nil
 
     m.call_seq = ''
 
@@ -52,8 +52,8 @@ method(a, b) { |c, d| ... }
   end
 
   def test_call_seq_alias_for
-    a = RDoc::AnyMethod.new nil, "each"
-    m = RDoc::AnyMethod.new nil, "each_line"
+    a = RDoc::AnyMethod.new "each"
+    m = RDoc::AnyMethod.new "each_line"
 
     a.call_seq = <<-CALLSEQ
 each(foo)
@@ -70,13 +70,13 @@ each_line(foo)
   end
 
   def test_has_call_seq?
-    m = RDoc::AnyMethod.new nil, "each_line"
-    m2 = RDoc::AnyMethod.new nil, "each"
+    m = RDoc::AnyMethod.new "each_line"
+    m2 = RDoc::AnyMethod.new "each"
     assert_equal false, m.has_call_seq?
     m.call_seq = "each_line()"
     assert_equal true, m.has_call_seq?
 
-    m = RDoc::AnyMethod.new nil, "each_line"
+    m = RDoc::AnyMethod.new "each_line"
     m.is_alias_for = m2
     assert_equal false, m.has_call_seq?
     m2.call_seq = "each_line()"
@@ -93,7 +93,7 @@ each_line(foo)
 
     assert_equal @c2_b, loaded.is_alias_for, 'Marshal.load'
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.store = @store
     m1.instance_variable_set :@is_alias_for, ['Missing', false, 'method']
 
@@ -106,7 +106,7 @@ each_line(foo)
     top_level = @store.add_file 'file.rb'
     cm = top_level.add_class RDoc::ClassModule, 'Klass'
 
-    method_with_call_seq = RDoc::AnyMethod.new(nil, "method_with_call_seq")
+    method_with_call_seq = RDoc::AnyMethod.new("method_with_call_seq")
     method_with_call_seq.call_seq = <<~SEQ
       method_with_call_seq(a)
       method_with_call_seq(a, b)
@@ -116,7 +116,7 @@ each_line(foo)
     cm.add_method(method_with_call_seq)
 
     alias_to_method = method_with_call_seq.add_alias(
-      RDoc::Alias.new(nil, "method_with_call_seq", "alias_to_method", "comment"),
+      RDoc::Alias.new("method_with_call_seq", "alias_to_method", "comment"),
       cm
     )
 
@@ -131,7 +131,7 @@ each_line(foo)
     top_level = @store.add_file 'file.rb'
     cm = top_level.add_class RDoc::ClassModule, 'Klass'
 
-    method_with_call_seq = RDoc::AnyMethod.new(nil, "method_with_call_seq")
+    method_with_call_seq = RDoc::AnyMethod.new("method_with_call_seq")
     method_with_call_seq.call_seq = <<~SEQ
       method_with_call_seq(a)
       method_with_call_seq(a, b)
@@ -139,7 +139,7 @@ each_line(foo)
     cm.add_method(method_with_call_seq)
 
     alias_to_method = method_with_call_seq.add_alias(
-      RDoc::Alias.new(nil, "method_with_call_seq", "alias_to_method", "comment"),
+      RDoc::Alias.new("method_with_call_seq", "alias_to_method", "comment"),
       cm
     )
 
@@ -153,7 +153,7 @@ each_line(foo)
   end
 
   def test_param_seq_with_variable_expansion
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
     m.block_params = '"Hello, #{world}", yield_arg'
     m.params = 'a'
@@ -165,7 +165,7 @@ each_line(foo)
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'
 
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.block_params = 'some_block'
     m.call_seq     = 'call_seq'
     m.comment      = 'this is a comment'
@@ -177,7 +177,7 @@ each_line(foo)
 
     section = cm.sections.first
 
-    al = RDoc::Alias.new nil, 'method', 'aliased', 'alias comment'
+    al = RDoc::Alias.new 'method', 'aliased', 'alias comment'
     al_m = m.add_alias al, cm
 
     loaded = Marshal.load Marshal.dump m
@@ -206,7 +206,7 @@ each_line(foo)
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'
 
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.type_signature_lines = ['(String) -> Integer']
     m.record_location top_level
 
@@ -224,12 +224,12 @@ each_line(foo)
     top_level = @store.add_file 'file.rb'
     cm = top_level.add_class RDoc::ClassModule, 'Klass'
 
-    m = RDoc::AnyMethod.new nil, 'original'
+    m = RDoc::AnyMethod.new 'original'
     m.type_signature_lines = ['(String) -> void']
     m.record_location top_level
     cm.add_method m
 
-    a = RDoc::Alias.new nil, 'original', 'aliased', ''
+    a = RDoc::Alias.new 'original', 'aliased', ''
     a.record_location top_level
 
     aliased = m.add_alias a, cm
@@ -283,14 +283,14 @@ each_line(foo)
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'
 
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
 
     cm = top_level.add_class RDoc::ClassModule, 'Klass'
     cm.add_method m
 
     section = cm.sections.first
 
-    al = RDoc::Alias.new nil, 'method', 'aliased', 'alias comment'
+    al = RDoc::Alias.new 'method', 'aliased', 'alias comment'
     al_m = m.add_alias al, cm
 
     loaded = Marshal.load "\x04\bU:\x14RDoc::AnyMethod[\x0Fi\x00I" +
@@ -331,7 +331,7 @@ each_line(foo)
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'
 
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.block_params = 'some_block'
     m.call_seq     = 'call_seq'
     m.comment      = 'this is a comment'
@@ -343,7 +343,7 @@ each_line(foo)
 
     section = cm.sections.first
 
-    al = RDoc::Alias.new nil, 'method', 'aliased', 'alias comment'
+    al = RDoc::Alias.new 'method', 'aliased', 'alias comment'
     al_m = m.add_alias al, cm
 
     loaded = Marshal.load "\x04\bU:\x14RDoc::AnyMethod[\x14i\bI" +
@@ -382,13 +382,13 @@ each_line(foo)
   end
 
   def test_name
-    m = RDoc::AnyMethod.new nil, nil
+    m = RDoc::AnyMethod.new nil
 
     assert_nil m.name
   end
 
   def test_name_call_seq
-    m = RDoc::AnyMethod.new nil, nil
+    m = RDoc::AnyMethod.new nil
 
     m.call_seq = "yields(name)\nyields(name, description)"
 
@@ -396,7 +396,7 @@ each_line(foo)
   end
 
   def test_name_call_seq_dot
-    m = RDoc::AnyMethod.new nil, nil
+    m = RDoc::AnyMethod.new nil
 
     m.call_seq = "obj.yields(name)\nobj.yields(name, description)"
 
@@ -404,7 +404,7 @@ each_line(foo)
   end
 
   def test_param_list_block_params
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.block_params = 'c, d'
@@ -413,7 +413,7 @@ each_line(foo)
   end
 
   def test_param_list_call_seq
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     call_seq = <<-SEQ
@@ -427,7 +427,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_default
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '(b = default)'
@@ -436,7 +436,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_params
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '(a, b)'
@@ -445,7 +445,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_params_block_params
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '(a, b)'
@@ -455,7 +455,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_empty_params_with_block
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '()'
@@ -465,7 +465,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_ampersand_param_block_params
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '(a, b, &block)'
@@ -475,7 +475,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_list_ampersand_param
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     m.params = '(a, b, &block)'
@@ -484,7 +484,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_seq
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
     m.params = 'a'
 
@@ -504,7 +504,7 @@ method(a, b) { |c, d| ... }
   end
 
   def test_param_seq_call_seq
-    m = RDoc::AnyMethod.new nil, 'method'
+    m = RDoc::AnyMethod.new 'method'
     m.parent = @c1
 
     call_seq = <<-SEQ
@@ -524,8 +524,8 @@ method(a, b) { |c, d| ... }
   end
 
   def test_skip_description?
-    m = RDoc::AnyMethod.new nil, "each_line"
-    m2 = RDoc::AnyMethod.new nil, "each"
+    m = RDoc::AnyMethod.new "each_line"
+    m2 = RDoc::AnyMethod.new "each"
     assert_equal false, m.skip_description?
     assert_equal false, m2.skip_description?
 
@@ -556,12 +556,12 @@ method(a, b) { |c, d| ... }
   end
 
   def test_superclass_method
-    m3 = RDoc::AnyMethod.new '', 'no_super'
+    m3 = RDoc::AnyMethod.new 'no_super'
 
-    m2 = RDoc::AnyMethod.new '', 'supers'
+    m2 = RDoc::AnyMethod.new 'supers'
     m2.calls_super = true
 
-    m1 = RDoc::AnyMethod.new '', 'supers'
+    m1 = RDoc::AnyMethod.new 'supers'
 
     c1 = RDoc::NormalClass.new 'Outer'
     c1.store = @store
@@ -580,10 +580,10 @@ method(a, b) { |c, d| ... }
   end
 
   def test_superclass_method_multilevel
-    m2 = RDoc::AnyMethod.new '', 'supers'
+    m2 = RDoc::AnyMethod.new 'supers'
     m2.calls_super = true
 
-    m1 = RDoc::AnyMethod.new '', 'supers'
+    m1 = RDoc::AnyMethod.new 'supers'
 
     c1 = RDoc::NormalClass.new 'Outer'
     c1.store = @store

--- a/test/rdoc/code_object/attr_test.rb
+++ b/test/rdoc/code_object/attr_test.rb
@@ -6,11 +6,11 @@ class RDocAttrTest < RDoc::TestCase
   def setup
     super
 
-    @a = RDoc::Attr.new nil, 'attr', 'RW', ''
+    @a = RDoc::Attr.new 'attr', 'RW', ''
   end
 
   def test_aref
-    m = RDoc::Attr.new nil, 'attr', 'RW', nil
+    m = RDoc::Attr.new 'attr', 'RW', nil
 
     assert_equal 'attribute-i-attr', m.aref
   end
@@ -78,7 +78,7 @@ class RDocAttrTest < RDoc::TestCase
     @store.path = Dir.tmpdir
     top_level = @store.add_file 'file.rb'
 
-    a = RDoc::Attr.new nil, 'name', 'R', 'a comment'
+    a = RDoc::Attr.new 'name', 'R', 'a comment'
     a.type_signature_lines = ['String']
     a.record_location top_level
 
@@ -96,12 +96,12 @@ class RDocAttrTest < RDoc::TestCase
     top_level = @store.add_file 'file.rb'
     cm = top_level.add_class RDoc::ClassModule, 'Klass'
 
-    a = RDoc::Attr.new nil, 'name', 'R', ''
+    a = RDoc::Attr.new 'name', 'R', ''
     a.type_signature_lines = ['String']
     a.record_location top_level
     cm.add_attribute a
 
-    al = RDoc::Alias.new nil, 'name', 'label', ''
+    al = RDoc::Alias.new 'name', 'label', ''
     al.record_location top_level
 
     aliased = a.add_alias al, cm
@@ -231,8 +231,8 @@ class RDocAttrTest < RDoc::TestCase
       "test_add_alias_#{an_alias[:new_name]}_for_attr_#{orig_attr[:type]}_sets_correct_rw"
     ) do
       context = RDoc::Context.new
-      attr = RDoc::Attr.new nil, 'bar', orig_attr[:rw], ''
-      als = RDoc::Alias.new nil, an_alias[:old_name], an_alias[:new_name], ''
+      attr = RDoc::Attr.new 'bar', orig_attr[:rw], ''
+      als = RDoc::Alias.new an_alias[:old_name], an_alias[:new_name], ''
 
       new_attr = attr.add_alias als, context
 

--- a/test/rdoc/code_object/class_module_test.rb
+++ b/test/rdoc/code_object/class_module_test.rb
@@ -169,12 +169,12 @@ class RDocClassModuleTest < XrefTestCase
     cm.document_self = true
     cm.record_location tl
 
-    a1 = RDoc::Attr.new nil, 'a1', 'RW', ''
+    a1 = RDoc::Attr.new 'a1', 'RW', ''
     a1.record_location tl
-    a2 = RDoc::Attr.new nil, 'a2', 'RW', '', singleton: true
+    a2 = RDoc::Attr.new 'a2', 'RW', '', singleton: true
     a2.record_location tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location tl
 
     c1 = RDoc::Constant.new 'C1', nil, ''
@@ -247,11 +247,11 @@ class RDocClassModuleTest < XrefTestCase
     cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
     cm.record_location tl
 
-    a1 = RDoc::Attr.new nil, 'a1', 'RW', ''
+    a1 = RDoc::Attr.new 'a1', 'RW', ''
     a1.record_location tl
     a1.document_self = false
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location tl
     m1.document_self = false
 
@@ -296,8 +296,8 @@ class RDocClassModuleTest < XrefTestCase
     ns = tl.add_module RDoc::NormalModule, 'Namespace'
     cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
 
-    a = RDoc::Attr.new(nil, 'a1', 'RW', '')
-    m = RDoc::AnyMethod.new(nil, 'm1')
+    a = RDoc::Attr.new('a1', 'RW', '')
+    m = RDoc::AnyMethod.new('m1')
     c = RDoc::Constant.new('C1', nil, '')
     i = RDoc::Include.new('I1', '')
 
@@ -356,12 +356,12 @@ class RDocClassModuleTest < XrefTestCase
     cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
     cm.record_location tl
 
-    a1 = RDoc::Attr.new nil, 'a1', 'RW', ''
+    a1 = RDoc::Attr.new 'a1', 'RW', ''
     a1.record_location tl
-    a2 = RDoc::Attr.new nil, 'a2', 'RW', '', singleton: true
+    a2 = RDoc::Attr.new 'a2', 'RW', '', singleton: true
     a2.record_location tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location tl
 
     c1 = RDoc::Constant.new 'C1', nil, ''
@@ -435,12 +435,12 @@ class RDocClassModuleTest < XrefTestCase
     cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
     cm.record_location tl
 
-    a1 = RDoc::Attr.new nil, 'a1', 'RW', ''
+    a1 = RDoc::Attr.new 'a1', 'RW', ''
     a1.record_location tl
-    a2 = RDoc::Attr.new nil, 'a2', 'RW', '', singleton: true
+    a2 = RDoc::Attr.new 'a2', 'RW', '', singleton: true
     a2.record_location tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location tl
 
     c1 = RDoc::Constant.new 'C1', nil, ''
@@ -520,12 +520,12 @@ class RDocClassModuleTest < XrefTestCase
     cm = ns.add_class RDoc::NormalClass, 'Klass', 'Super'
     cm.record_location tl
 
-    a1 = RDoc::Attr.new nil, 'a1', 'RW', ''
+    a1 = RDoc::Attr.new 'a1', 'RW', ''
     a1.record_location tl
-    a2 = RDoc::Attr.new nil, 'a2', 'RW', '', singleton: true
+    a2 = RDoc::Attr.new 'a2', 'RW', '', singleton: true
     a2.record_location tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location tl
 
     c1 = RDoc::Constant.new 'C1', nil, ''
@@ -681,30 +681,30 @@ class RDocClassModuleTest < XrefTestCase
 
     cm1 = RDoc::ClassModule.new 'Klass'
 
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a1', 'RW', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a1', 'RW', '')
     attr.record_location tl1
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a3', 'R', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a3', 'R', '')
     attr.record_location tl1
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a4', 'R', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a4', 'R', '')
     attr.record_location tl1
 
     cm2 = RDoc::ClassModule.new 'Klass'
     # TODO allow merging when comment == ''
     cm2.instance_variable_set :@comment, @RM::Document.new
 
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a2', 'RW', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a2', 'RW', '')
     attr.record_location tl2
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a3', 'W', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a3', 'W', '')
     attr.record_location tl1
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a4', 'W', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a4', 'W', '')
     attr.record_location tl1
 
     cm1.merge cm2
 
     expected = [
-      RDoc::Attr.new(nil, 'a2', 'RW', ''),
-      RDoc::Attr.new(nil, 'a3', 'W',  ''),
-      RDoc::Attr.new(nil, 'a4', 'W',  ''),
+      RDoc::Attr.new('a2', 'RW', ''),
+      RDoc::Attr.new('a3', 'W',  ''),
+      RDoc::Attr.new('a4', 'W',  ''),
     ]
 
     expected.each do |a| a.parent = cm1 end
@@ -716,28 +716,28 @@ class RDocClassModuleTest < XrefTestCase
 
     cm1 = RDoc::ClassModule.new 'Klass'
 
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a1', 'RW', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a1', 'RW', '')
     attr.record_location tl1
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a3', 'R', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a3', 'R', '')
     attr.record_location tl1
-    attr = cm1.add_attribute RDoc::Attr.new(nil, 'a4', 'R', '')
+    attr = cm1.add_attribute RDoc::Attr.new('a4', 'R', '')
     attr.record_location tl1
 
     cm2 = RDoc::ClassModule.new 'Klass'
     # TODO allow merging when comment == ''
     cm2.instance_variable_set :@comment, @RM::Document.new
 
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a2', 'RW', '')
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a3', 'W', '')
-    attr = cm2.add_attribute RDoc::Attr.new(nil, 'a4', 'W', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a2', 'RW', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a3', 'W', '')
+    attr = cm2.add_attribute RDoc::Attr.new('a4', 'W', '')
 
     cm1.merge cm2
 
     expected = [
-      RDoc::Attr.new(nil, 'a1', 'RW', ''),
-      RDoc::Attr.new(nil, 'a2', 'RW', ''),
-      RDoc::Attr.new(nil, 'a3', 'RW', ''),
-      RDoc::Attr.new(nil, 'a4', 'RW', ''),
+      RDoc::Attr.new('a1', 'RW', ''),
+      RDoc::Attr.new('a2', 'RW', ''),
+      RDoc::Attr.new('a3', 'RW', ''),
+      RDoc::Attr.new('a4', 'RW', ''),
     ]
 
     expected.each do |a| a.parent = cm1 end
@@ -1005,28 +1005,28 @@ class RDocClassModuleTest < XrefTestCase
 
     cm1 = tl1.add_class RDoc::NormalClass, 'Klass'
 
-    meth = cm1.add_method RDoc::AnyMethod.new(nil, 'm1')
+    meth = cm1.add_method RDoc::AnyMethod.new('m1')
     meth.record_location tl1
-    meth = cm1.add_method RDoc::AnyMethod.new(nil, 'm3')
+    meth = cm1.add_method RDoc::AnyMethod.new('m3')
     meth.record_location tl1
 
     cm2 = RDoc::ClassModule.new 'Klass'
     cm2.store = @store
     cm2.instance_variable_set :@comment, @RM::Document.new
 
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm2')
+    meth = cm2.add_method RDoc::AnyMethod.new('m2')
     meth.record_location tl2
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm3')
+    meth = cm2.add_method RDoc::AnyMethod.new('m3')
     meth.record_location tl1
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm4')
+    meth = cm2.add_method RDoc::AnyMethod.new('m4')
     meth.record_location tl1
 
     cm1.merge cm2
 
     expected = [
-      RDoc::AnyMethod.new(nil, 'm2'),
-      RDoc::AnyMethod.new(nil, 'm3'),
-      RDoc::AnyMethod.new(nil, 'm4'),
+      RDoc::AnyMethod.new('m2'),
+      RDoc::AnyMethod.new('m3'),
+      RDoc::AnyMethod.new('m4'),
     ]
 
     expected.each do |a| a.parent = cm1 end
@@ -1039,26 +1039,26 @@ class RDocClassModuleTest < XrefTestCase
 
     cm1 = tl1.add_class RDoc::NormalClass, 'Klass'
 
-    meth = cm1.add_method RDoc::AnyMethod.new(nil, 'm1')
+    meth = cm1.add_method RDoc::AnyMethod.new('m1')
     meth.record_location tl1
-    meth = cm1.add_method RDoc::AnyMethod.new(nil, 'm3')
+    meth = cm1.add_method RDoc::AnyMethod.new('m3')
     meth.record_location tl1
 
     cm2 = RDoc::ClassModule.new 'Klass'
     cm2.store = @store
     cm2.instance_variable_set :@comment, @RM::Document.new
 
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm2')
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm3')
-    meth = cm2.add_method RDoc::AnyMethod.new(nil, 'm4')
+    meth = cm2.add_method RDoc::AnyMethod.new('m2')
+    meth = cm2.add_method RDoc::AnyMethod.new('m3')
+    meth = cm2.add_method RDoc::AnyMethod.new('m4')
 
     cm1.merge cm2
 
     expected = [
-      RDoc::AnyMethod.new(nil, 'm1'),
-      RDoc::AnyMethod.new(nil, 'm2'),
-      RDoc::AnyMethod.new(nil, 'm3'),
-      RDoc::AnyMethod.new(nil, 'm4'),
+      RDoc::AnyMethod.new('m1'),
+      RDoc::AnyMethod.new('m2'),
+      RDoc::AnyMethod.new('m3'),
+      RDoc::AnyMethod.new('m4'),
     ]
 
     expected.each do |a| a.parent = cm1 end
@@ -1465,10 +1465,10 @@ class RDocClassModuleTest < XrefTestCase
 
     object = top_level.add_class RDoc::NormalClass, 'Object'
     real_foo = top_level.add_class RDoc::NormalClass, 'Foo'
-    real_foo.add_method RDoc::AnyMethod.new(nil, 'real_method')
+    real_foo.add_method RDoc::AnyMethod.new('real_method')
 
     other = top_level.add_class RDoc::NormalClass, 'Other'
-    other.add_method RDoc::AnyMethod.new(nil, 'other_method')
+    other.add_method RDoc::AnyMethod.new('other_method')
 
     const = RDoc::Constant.new 'Foo', 'Other', ''
     const.is_alias_for_path = 'Other'
@@ -1492,7 +1492,7 @@ class RDocClassModuleTest < XrefTestCase
 
     object = top_level.add_class RDoc::NormalClass, 'Object'
     target = top_level.add_class RDoc::NormalClass, 'Target'
-    target.add_method RDoc::AnyMethod.new(nil, 'target_method')
+    target.add_method RDoc::AnyMethod.new('target_method')
 
     const = RDoc::Constant.new 'NodocAlias', 'Target', ''
     const.is_alias_for_path = 'Target'
@@ -1672,35 +1672,35 @@ class RDocClassModuleTest < XrefTestCase
       incmod_const = @incmod.add_constant(RDoc::Constant.new("INCMOD_CONST", nil, ""))
       incmod_const.section = @incmod.add_section("Incmod const section")
 
-      incmod_method = @incmod.add_method(RDoc::AnyMethod.new(nil, "incmod_method_without_a_section"))
-      incmod_method = @incmod.add_method(RDoc::AnyMethod.new(nil, "incmod_method"))
+      incmod_method = @incmod.add_method(RDoc::AnyMethod.new("incmod_method_without_a_section"))
+      incmod_method = @incmod.add_method(RDoc::AnyMethod.new("incmod_method"))
       incmod_method.section = @incmod.add_section("Incmod method section")
 
-      incmod_attr = @incmod.add_attribute(RDoc::Attr.new(nil, "incmod_attr_without_a_section", "RW", ""))
-      incmod_attr = @incmod.add_attribute(RDoc::Attr.new(nil, "incmod_attr", "RW", ""))
+      incmod_attr = @incmod.add_attribute(RDoc::Attr.new("incmod_attr_without_a_section", "RW", ""))
+      incmod_attr = @incmod.add_attribute(RDoc::Attr.new("incmod_attr", "RW", ""))
       incmod_attr.section = @incmod.add_section("Incmod attr section")
 
-      incmod_private_method = @incmod.add_method(RDoc::AnyMethod.new(nil, "incmod_private_method"))
+      incmod_private_method = @incmod.add_method(RDoc::AnyMethod.new("incmod_private_method"))
       incmod_private_method.visibility = :private
 
-      incmod_private_attr = @incmod.add_attribute(RDoc::Attr.new(nil, "incmod_private_attr", "RW", ""))
+      incmod_private_attr = @incmod.add_attribute(RDoc::Attr.new("incmod_private_attr", "RW", ""))
       incmod_private_attr.visibility = :private
 
       extmod_tl = @store.add_file("extmod.rb")
       @extmod = extmod_tl.add_module(RDoc::NormalModule, "Extmod")
 
-      extmod_method = @extmod.add_method(RDoc::AnyMethod.new(nil, "extmod_method_without_a_section"))
-      extmod_method = @extmod.add_method(RDoc::AnyMethod.new(nil, "extmod_method"))
+      extmod_method = @extmod.add_method(RDoc::AnyMethod.new("extmod_method_without_a_section"))
+      extmod_method = @extmod.add_method(RDoc::AnyMethod.new("extmod_method"))
       extmod_method.section = @extmod.add_section("Extmod method section")
 
-      extmod_attr = @extmod.add_attribute(RDoc::Attr.new(nil, "extmod_attr_without_a_section", "RW", "", singleton: true))
-      extmod_attr = @extmod.add_attribute(RDoc::Attr.new(nil, "extmod_attr", "RW", "", singleton: true))
+      extmod_attr = @extmod.add_attribute(RDoc::Attr.new("extmod_attr_without_a_section", "RW", "", singleton: true))
+      extmod_attr = @extmod.add_attribute(RDoc::Attr.new("extmod_attr", "RW", "", singleton: true))
       extmod_attr.section = @extmod.add_section("Extmod attr section")
 
-      extmod_private_method = @extmod.add_method(RDoc::AnyMethod.new(nil, "extmod_private_method"))
+      extmod_private_method = @extmod.add_method(RDoc::AnyMethod.new("extmod_private_method"))
       extmod_private_method.visibility = :private
 
-      extmod_private_attr = @extmod.add_attribute(RDoc::Attr.new(nil, "extmod_private_attr", "RW", "", singleton: true))
+      extmod_private_attr = @extmod.add_attribute(RDoc::Attr.new("extmod_private_attr", "RW", "", singleton: true))
       extmod_private_attr.visibility = :private
 
       @klass.add_include(RDoc::Include.new("Incmod", nil))

--- a/test/rdoc/code_object/method_attr_test.rb
+++ b/test/rdoc/code_object/method_attr_test.rb
@@ -8,7 +8,7 @@ class RDocMethodAttrTest < XrefTestCase
   end
 
   def test_block_params_equal
-    m = RDoc::MethodAttr.new(nil, 'foo')
+    m = RDoc::MethodAttr.new('foo')
 
     m.block_params = ''
     assert_equal '', m.block_params
@@ -146,17 +146,17 @@ class RDocMethodAttrTest < XrefTestCase
 
   def test_spaceship_orders_symbols_first
     # in the desired sort order
-    m_plus       = RDoc::AnyMethod.new nil, '+'
-    m_eqeq       = RDoc::AnyMethod.new nil, '=='
-    m_bracket    = RDoc::AnyMethod.new nil, '[]'
-    m_caret      = RDoc::AnyMethod.new nil, '^'
-    m_bar        = RDoc::AnyMethod.new nil, '|'
-    m_tilde      = RDoc::AnyMethod.new nil, '~'
-    m_Alpha      = RDoc::AnyMethod.new nil, 'Alpha'
-    m_Zero       = RDoc::AnyMethod.new nil, 'Zero'
-    m_alpha      = RDoc::AnyMethod.new nil, 'alpha'
-    m_zero       = RDoc::AnyMethod.new nil, 'zero'
-    m_konnichiwa = RDoc::AnyMethod.new nil, 'こんにちは'
+    m_plus       = RDoc::AnyMethod.new '+'
+    m_eqeq       = RDoc::AnyMethod.new '=='
+    m_bracket    = RDoc::AnyMethod.new '[]'
+    m_caret      = RDoc::AnyMethod.new '^'
+    m_bar        = RDoc::AnyMethod.new '|'
+    m_tilde      = RDoc::AnyMethod.new '~'
+    m_Alpha      = RDoc::AnyMethod.new 'Alpha'
+    m_Zero       = RDoc::AnyMethod.new 'Zero'
+    m_alpha      = RDoc::AnyMethod.new 'alpha'
+    m_zero       = RDoc::AnyMethod.new 'zero'
+    m_konnichiwa = RDoc::AnyMethod.new 'こんにちは'
 
     assert_equal(-1, m_plus <=> m_eqeq)
     assert_equal(-1, m_eqeq <=> m_bracket)
@@ -180,10 +180,10 @@ class RDocMethodAttrTest < XrefTestCase
       s = RDoc::RI::Store.new(RDoc::Options.new, path: tmpdir)
 
       top_level = s.add_file 'file.rb'
-      meth_bang = RDoc::AnyMethod.new nil, 'method!'
+      meth_bang = RDoc::AnyMethod.new 'method!'
       meth_bang.record_location top_level
 
-      meth_bang_alias = RDoc::Alias.new nil, 'method!', 'method_bang', ''
+      meth_bang_alias = RDoc::Alias.new 'method!', 'method_bang', ''
       meth_bang_alias.record_location top_level
 
       klass = top_level.add_class RDoc::NormalClass, 'Object'

--- a/test/rdoc/generator/aliki/search_index_test.rb
+++ b/test/rdoc/generator/aliki/search_index_test.rb
@@ -84,7 +84,7 @@ class RDocGeneratorAlikiSearchIndexTest < RDoc::TestCase
 
   def test_build_search_index_includes_instance_methods
     @klass = @top_level.add_class RDoc::NormalClass, 'MyClass'
-    @meth = RDoc::AnyMethod.new nil, 'my_method'
+    @meth = RDoc::AnyMethod.new 'my_method'
     @meth.singleton = false
     @klass.add_method @meth
     @store.complete :private
@@ -100,7 +100,7 @@ class RDocGeneratorAlikiSearchIndexTest < RDoc::TestCase
 
   def test_build_search_index_includes_class_methods
     @klass = @top_level.add_class RDoc::NormalClass, 'MyClass'
-    @meth = RDoc::AnyMethod.new nil, 'my_class_method'
+    @meth = RDoc::AnyMethod.new 'my_class_method'
     @meth.singleton = true
     @klass.add_method @meth
     @store.complete :private
@@ -161,13 +161,13 @@ class RDocGeneratorAlikiSearchIndexTest < RDoc::TestCase
   def test_build_search_index_includes_special_method_names
     @klass = @top_level.add_class RDoc::NormalClass, 'MyClass'
 
-    @bracket_method = RDoc::AnyMethod.new nil, '[]'
+    @bracket_method = RDoc::AnyMethod.new '[]'
     @klass.add_method @bracket_method
 
-    @shovel_method = RDoc::AnyMethod.new nil, '<<'
+    @shovel_method = RDoc::AnyMethod.new '<<'
     @klass.add_method @shovel_method
 
-    @equals_method = RDoc::AnyMethod.new nil, '=='
+    @equals_method = RDoc::AnyMethod.new '=='
     @klass.add_method @equals_method
 
     @store.complete :private

--- a/test/rdoc/generator/aliki_test.rb
+++ b/test/rdoc/generator/aliki_test.rb
@@ -41,8 +41,8 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
 
     @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
 
-    @meth = RDoc::AnyMethod.new nil, 'method'
-    @meth_with_html_tag_yield = RDoc::AnyMethod.new nil, 'method_with_html_tag_yield'
+    @meth = RDoc::AnyMethod.new 'method'
+    @meth_with_html_tag_yield = RDoc::AnyMethod.new 'method_with_html_tag_yield'
     @meth_with_html_tag_yield.block_params = '%<<script>alert("atui")</script>>, yield_arg'
 
     @klass.add_method @meth

--- a/test/rdoc/generator/darkfish_test.rb
+++ b/test/rdoc/generator/darkfish_test.rb
@@ -41,11 +41,11 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
 
     @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
 
-    @meth = RDoc::AnyMethod.new nil, 'method'
-    @meth_bang = RDoc::AnyMethod.new nil, 'method!'
-    @meth_with_html_tag_yield = RDoc::AnyMethod.new nil, 'method_with_html_tag_yield'
+    @meth = RDoc::AnyMethod.new 'method'
+    @meth_bang = RDoc::AnyMethod.new 'method!'
+    @meth_with_html_tag_yield = RDoc::AnyMethod.new 'method_with_html_tag_yield'
     @meth_with_html_tag_yield.block_params = '%<<script>alert("atui")</script>>, yield_arg'
-    @attr = RDoc::Attr.new nil, 'attr', 'RW', ''
+    @attr = RDoc::Attr.new 'attr', 'RW', ''
 
     @klass.add_method @meth
     @klass.add_method @meth_bang

--- a/test/rdoc/generator/json_index_test.rb
+++ b/test/rdoc/generator/json_index_test.rb
@@ -31,13 +31,13 @@ class RDocGeneratorJsonIndexTest < RDoc::TestCase
 
     @klass = @top_level.add_class RDoc::NormalClass, 'C'
 
-    @meth = @klass.add_method RDoc::AnyMethod.new(nil, 'meth')
+    @meth = @klass.add_method RDoc::AnyMethod.new('meth')
     @meth.record_location @top_level
 
     @nest_klass = @klass.add_class RDoc::NormalClass, 'D'
     @nest_klass.record_location @top_level
 
-    @nest_meth = @nest_klass.add_method RDoc::AnyMethod.new(nil, 'meth')
+    @nest_meth = @nest_klass.add_method RDoc::AnyMethod.new('meth')
 
     @ignored = @top_level.add_class RDoc::NormalClass, 'Ignored'
     @ignored.ignore

--- a/test/rdoc/generator/pot_test.rb
+++ b/test/rdoc/generator/pot_test.rb
@@ -19,11 +19,11 @@ class RDocGeneratorPOTTest < RDoc::TestCase
 
     @const = RDoc::Constant.new "CONSTANT", "29", "This is a constant"
 
-    @meth = RDoc::AnyMethod.new nil, 'method'
+    @meth = RDoc::AnyMethod.new 'method'
     @meth.record_location @top_level
     @meth.comment = 'This is a method'
 
-    @attr = RDoc::Attr.new nil, 'attr', 'RW', ''
+    @attr = RDoc::Attr.new 'attr', 'RW', ''
     @attr.record_location @top_level
     @attr.comment = 'This is an attribute'
 

--- a/test/rdoc/generator/ri_test.rb
+++ b/test/rdoc/generator/ri_test.rb
@@ -18,13 +18,13 @@ class RDocGeneratorRITest < RDoc::TestCase
     @top_level = @store.add_file 'file.rb'
     @klass = @top_level.add_class RDoc::NormalClass, 'Object'
 
-    @meth = RDoc::AnyMethod.new nil, 'method'
+    @meth = RDoc::AnyMethod.new 'method'
     @meth.record_location @top_level
 
-    @meth_bang = RDoc::AnyMethod.new nil, 'method!'
+    @meth_bang = RDoc::AnyMethod.new 'method!'
     @meth_bang.record_location @top_level
 
-    @attr = RDoc::Attr.new nil, 'attr', 'RW', ''
+    @attr = RDoc::Attr.new 'attr', 'RW', ''
     @attr.record_location @top_level
 
     @klass.add_method @meth

--- a/test/rdoc/markup/pre_process_test.rb
+++ b/test/rdoc/markup/pre_process_test.rb
@@ -148,7 +148,7 @@ contents of a string.
   end
 
   def test_handle_directive_downcase
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'ARG', 'a, b', method
 
@@ -156,7 +156,7 @@ contents of a string.
   end
 
   def test_handle_directive_arg
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'arg', 'a, b', method
 
@@ -170,7 +170,7 @@ contents of a string.
   end
 
   def test_handle_directive_args
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'args', 'a, b', method
 
@@ -255,7 +255,7 @@ contents of a string.
   end
 
   def test_handle_directive_notnew
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'notnew', nil, m
 
@@ -263,7 +263,7 @@ contents of a string.
   end
 
   def test_handle_directive_not_new
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'not_new', nil, m
 
@@ -271,7 +271,7 @@ contents of a string.
   end
 
   def test_handle_directive_not_dash_new
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'not-new', nil, m
 
@@ -435,7 +435,7 @@ contents of a string.
   end
 
   def test_handle_directive_yield
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = 'index, &block'
 
     @pp.handle_directive '', 'yield', 'item', method
@@ -445,7 +445,7 @@ contents of a string.
   end
 
   def test_handle_directive_yield_block_param
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '&block'
 
     @pp.handle_directive '', 'yield', 'item', method
@@ -455,7 +455,7 @@ contents of a string.
   end
 
   def test_handle_directive_yield_no_context
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'yield', 'item', method
 
@@ -463,7 +463,7 @@ contents of a string.
   end
 
   def test_handle_directive_yields
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
 
     @pp.handle_directive '', 'yields', 'item', method
 

--- a/test/rdoc/markup/to_html_crossref_test.rb
+++ b/test/rdoc/markup/to_html_crossref_test.rb
@@ -169,7 +169,7 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_percent
-    m = @c1.add_method RDoc::AnyMethod.new nil, '%'
+    m = @c1.add_method RDoc::AnyMethod.new '%'
 
     result = @to.convert 'rdoc-ref:C1#%'
 
@@ -183,7 +183,7 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_escape_html
-    m = @c1.add_method RDoc::AnyMethod.new nil, '<<'
+    m = @c1.add_method RDoc::AnyMethod.new '<<'
 
     result = @to.convert 'rdoc-ref:C1#<<'
 
@@ -196,7 +196,7 @@ class RDocMarkupToHtmlCrossrefTest < XrefTestCase
   end
 
   def test_convert_RDOCLINK_rdoc_ref_method_percent_label
-    m = @c1.add_method RDoc::AnyMethod.new nil, '%'
+    m = @c1.add_method RDoc::AnyMethod.new '%'
 
     result = @to.convert 'rdoc-ref:C1#%@f'
 

--- a/test/rdoc/markup/to_html_snippet_test.rb
+++ b/test/rdoc/markup/to_html_snippet_test.rb
@@ -381,7 +381,7 @@ class RDocMarkupToHtmlSnippetTest < RDoc::Markup::FormatterTestCase
   end
 
   def test_accept_heading_aref_method
-    @to.code_object = RDoc::AnyMethod.new nil, 'foo'
+    @to.code_object = RDoc::AnyMethod.new 'foo'
     @to.start_accepting
 
     @to.accept_heading @RM::Heading.new(1, 'Hello')

--- a/test/rdoc/markup/to_html_test.rb
+++ b/test/rdoc/markup/to_html_test.rb
@@ -341,7 +341,7 @@ class RDocMarkupToHtmlTest < RDoc::Markup::FormatterTestCase
   end
 
   def test_accept_heading_aref_method
-    @to.code_object = RDoc::AnyMethod.new nil, 'foo'
+    @to.code_object = RDoc::AnyMethod.new 'foo'
     @to.start_accepting
 
     @to.accept_heading @RM::Heading.new(1, 'Hello')

--- a/test/rdoc/parser/c_test.rb
+++ b/test/rdoc/parser/c_test.rb
@@ -338,7 +338,7 @@ VALUE cFoo = rb_struct_define(
     attributes = klass.attributes
     assert_equal 3, attributes.size, -> {attributes}
     ["some", "various", "fields"].zip(attributes) do |name, attr|
-      assert_equal RDoc::Attr.new("", name, "RW", ""), attr
+      assert_equal RDoc::Attr.new(name, "RW", ""), attr
     end
   end
 
@@ -359,7 +359,7 @@ VALUE cFoo = rb_struct_define_under(
     attributes = klass.attributes
     assert_equal 3, attributes.size, -> {attributes}
     ["some", "various", "fields"].zip(attributes) do |name, attr|
-      assert_equal RDoc::Attr.new("", name, "RW", ""), attr
+      assert_equal RDoc::Attr.new(name, "RW", ""), attr
     end
   end
 
@@ -1495,7 +1495,7 @@ If no arguments are given:
     COMMENT
 
     parser = util_parser
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
+    method_obj = RDoc::AnyMethod.new 'blah'
 
     parser.find_modifiers comment, method_obj
 
@@ -1512,7 +1512,7 @@ If no arguments are given:
     COMMENT
 
     parser = util_parser
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
+    method_obj = RDoc::AnyMethod.new 'blah'
 
     parser.find_modifiers comment, method_obj
 
@@ -1529,7 +1529,7 @@ If no arguments are given:
     COMMENT
 
     parser = util_parser
-    method_obj = RDoc::AnyMethod.new nil, 'blah'
+    method_obj = RDoc::AnyMethod.new 'blah'
 
     parser.find_modifiers comment, method_obj
 

--- a/test/rdoc/rdoc_context_test.rb
+++ b/test/rdoc/rdoc_context_test.rb
@@ -31,7 +31,7 @@ class RDocContextTest < XrefTestCase
   end
 
   def test_add_alias
-    as = RDoc::Alias.new nil, 'old_name', 'new_name', 'comment'
+    as = RDoc::Alias.new 'old_name', 'new_name', 'comment'
 
     @context.add_alias as
 
@@ -50,9 +50,9 @@ class RDocContextTest < XrefTestCase
   def test_add_alias_method_attr
     top_level = @store.add_file 'file.rb'
 
-    attr = RDoc::Attr.new nil, 'old_name', 'R', ''
+    attr = RDoc::Attr.new 'old_name', 'R', ''
 
-    as = RDoc::Alias.new nil, 'old_name', 'new_name', 'comment'
+    as = RDoc::Alias.new 'old_name', 'new_name', 'comment'
     as.record_location top_level
     as.parent = @context
 
@@ -70,10 +70,10 @@ class RDocContextTest < XrefTestCase
   def test_add_alias_method
     top_level = @store.add_file 'file.rb'
 
-    meth = RDoc::AnyMethod.new nil, 'old_name'
+    meth = RDoc::AnyMethod.new 'old_name'
     meth.singleton = false
 
-    as = RDoc::Alias.new nil, 'old_name', 'new_name', 'comment'
+    as = RDoc::Alias.new 'old_name', 'new_name', 'comment'
     as.record_location top_level
     as.parent = @context
 
@@ -89,9 +89,9 @@ class RDocContextTest < XrefTestCase
   end
 
   def test_add_alias_method_singleton
-    meth = RDoc::AnyMethod.new nil, 'old_name', singleton: true
+    meth = RDoc::AnyMethod.new 'old_name', singleton: true
 
-    as = RDoc::Alias.new nil, 'old_name', 'new_name', 'comment', singleton: true
+    as = RDoc::Alias.new 'old_name', 'new_name', 'comment', singleton: true
 
     as.parent = @context
 
@@ -193,7 +193,7 @@ class RDocContextTest < XrefTestCase
   end
 
   def test_add_method
-    meth = RDoc::AnyMethod.new nil, 'old_name'
+    meth = RDoc::AnyMethod.new 'old_name'
     meth.visibility = nil
 
     @context.add_method meth
@@ -203,8 +203,8 @@ class RDocContextTest < XrefTestCase
   end
 
   def test_add_method_alias
-    as = RDoc::Alias.new nil, 'old_name', 'new_name', 'comment'
-    meth = RDoc::AnyMethod.new nil, 'old_name'
+    as = RDoc::Alias.new 'old_name', 'new_name', 'comment'
+    meth = RDoc::AnyMethod.new 'old_name'
 
     @context.add_alias as
     refute_empty @context.external_aliases
@@ -219,14 +219,14 @@ class RDocContextTest < XrefTestCase
   def test_add_method_duplicate
     @store.options.verbosity = 2
 
-    meth1 = RDoc::AnyMethod.new nil, 'name'
+    meth1 = RDoc::AnyMethod.new 'name'
     meth1.record_location @store.add_file 'first.rb'
     meth1.visibility = nil
     meth1.comment = comment 'first'
 
     @context.add_method meth1
 
-    meth2 = RDoc::AnyMethod.new nil, 'name'
+    meth2 = RDoc::AnyMethod.new 'name'
     meth2.record_location @store.add_file 'second.rb'
     meth2.comment = comment 'second'
 
@@ -247,14 +247,14 @@ class RDocContextTest < XrefTestCase
   def test_add_method_duplicate_loading
     @context.store = nil
 
-    meth1 = RDoc::AnyMethod.new nil, 'name'
+    meth1 = RDoc::AnyMethod.new 'name'
     meth1.record_location @store.add_file 'first.rb'
     meth1.visibility = nil
     meth1.comment = comment 'first'
 
     @context.add_method meth1
 
-    meth2 = RDoc::AnyMethod.new nil, 'name'
+    meth2 = RDoc::AnyMethod.new 'name'
     meth2.record_location @store.add_file 'second.rb'
     meth2.comment = comment 'second'
 
@@ -620,7 +620,7 @@ class RDocContextTest < XrefTestCase
 
     assert context.fully_documented?
 
-    a = RDoc::Attr.new '', 'a', 'RW', nil
+    a = RDoc::Attr.new 'a', 'RW', nil
 
     context.add_attribute a
 
@@ -812,10 +812,10 @@ class RDocContextTest < XrefTestCase
 
   def test_section_contents
     default = @context.sections.first
-    @context.add_method RDoc::AnyMethod.new(nil, 'm1')
+    @context.add_method RDoc::AnyMethod.new('m1')
 
     b = @context.add_section 'B'
-    m = @context.add_method RDoc::AnyMethod.new(nil, 'm2')
+    m = @context.add_method RDoc::AnyMethod.new('m2')
     m.section = b
 
     assert_equal [default, b], @context.section_contents
@@ -824,7 +824,7 @@ class RDocContextTest < XrefTestCase
   def test_section_contents_no_default
     @context = RDoc::Context.new
     b = @context.add_section 'B'
-    m = @context.add_method RDoc::AnyMethod.new(nil, 'm')
+    m = @context.add_method RDoc::AnyMethod.new('m')
     m.section = b
 
     assert_equal [b], @context.section_contents
@@ -833,7 +833,7 @@ class RDocContextTest < XrefTestCase
   def test_section_contents_only_default
     @context = RDoc::Context.new
 
-    @context.add_method RDoc::AnyMethod.new(nil, 'm')
+    @context.add_method RDoc::AnyMethod.new('m')
 
     assert_empty @context.section_contents
   end
@@ -841,7 +841,7 @@ class RDocContextTest < XrefTestCase
   def test_section_contents_unused
     @context = RDoc::Context.new
 
-    @context.add_method RDoc::AnyMethod.new(nil, 'm')
+    @context.add_method RDoc::AnyMethod.new('m')
     @context.add_section 'B'
 
     assert_empty @context.section_contents
@@ -923,13 +923,13 @@ class RDocContextTest < XrefTestCase
   end
 
   def util_visibilities
-    @pub  = RDoc::AnyMethod.new nil, 'pub'
-    @prot = RDoc::AnyMethod.new nil, 'prot'
-    @priv = RDoc::AnyMethod.new nil, 'priv'
+    @pub  = RDoc::AnyMethod.new 'pub'
+    @prot = RDoc::AnyMethod.new 'prot'
+    @priv = RDoc::AnyMethod.new 'priv'
 
-    @apub  = RDoc::Attr.new nil, 'pub',  'RW', nil
-    @aprot = RDoc::Attr.new nil, 'prot', 'RW', nil
-    @apriv = RDoc::Attr.new nil, 'priv', 'RW', nil
+    @apub  = RDoc::Attr.new 'pub',  'RW', nil
+    @aprot = RDoc::Attr.new 'prot', 'RW', nil
+    @apriv = RDoc::Attr.new 'priv', 'RW', nil
 
     @cpub  = RDoc::Constant.new 'CONST_PUBLIC', nil, nil
     @cpriv = RDoc::Constant.new 'CONST_PRIVATE', nil, nil

--- a/test/rdoc/rdoc_cross_reference_test.rb
+++ b/test/rdoc/rdoc_cross_reference_test.rb
@@ -181,10 +181,10 @@ class RDocCrossReferenceTest < XrefTestCase
   def assert_resolve_method(x)
     @c1.methods_hash.clear
 
-    i_op = RDoc::AnyMethod.new nil, x
+    i_op = RDoc::AnyMethod.new x
     @c1.add_method i_op
 
-    c_op = RDoc::AnyMethod.new nil, x, singleton: true
+    c_op = RDoc::AnyMethod.new x, singleton: true
     @c1.add_method c_op
 
     assert_ref i_op, x

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -128,7 +128,7 @@ class RDocRDocTest < RDoc::TestCase
 
       top_level = @rdoc.store.add_file 'example.rb'
       example = top_level.add_class RDoc::NormalClass, 'Example'
-      method = RDoc::AnyMethod.new nil, 'greet'
+      method = RDoc::AnyMethod.new 'greet'
       example.add_method method
 
       @rdoc.load_rbs_signatures

--- a/test/rdoc/rdoc_stats_test.rb
+++ b/test/rdoc/rdoc_stats_test.rb
@@ -37,7 +37,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    a = RDoc::Attr.new nil, 'a', 'RW', nil
+    a = RDoc::Attr.new 'a', 'RW', nil
     a.record_location @tl
     a.line = 3
     c.add_attribute a
@@ -55,7 +55,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    a = RDoc::Attr.new nil, 'a', 'RW', 'a'
+    a = RDoc::Attr.new 'a', 'RW', 'a'
     a.record_location @tl
     c.add_attribute a
 
@@ -117,7 +117,7 @@ class RDocStatsTest < RDoc::TestCase
     c = @tl.add_class RDoc::NormalClass, 'C'
     c.record_location @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     c.add_method m
     m.comment = 'm'
@@ -134,7 +134,7 @@ class RDocStatsTest < RDoc::TestCase
     c = @tl.add_class RDoc::NormalClass, 'Object'
     c.record_location @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     c.add_method m
     m.comment = 'm'
@@ -149,7 +149,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     c.add_method m
     m.comment = 'm'
@@ -164,7 +164,7 @@ class RDocStatsTest < RDoc::TestCase
     c1.record_location @tl
     c1.add_comment 'C1', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location @tl
     c1.add_method m1
     m1.comment = 'm1'
@@ -172,7 +172,7 @@ class RDocStatsTest < RDoc::TestCase
     c2 = @tl.add_class RDoc::NormalClass, 'C2'
     c2.record_location @tl
 
-    m2 = RDoc::AnyMethod.new nil, 'm2'
+    m2 = RDoc::AnyMethod.new 'm2'
     m2.record_location @tl
     c2.add_method m2
     m2.comment = 'm2'
@@ -237,12 +237,12 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location @tl
     m1.line = 5
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'm2'
+    m2 = RDoc::AnyMethod.new 'm2'
     m2.record_location @tl
     c.add_method m2
     m2.comment = 'm2'
@@ -260,12 +260,12 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1', singleton: true
+    m1 = RDoc::AnyMethod.new 'm1', singleton: true
     m1.record_location @tl
     m1.line = 8
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'm2', singleton: true
+    m2 = RDoc::AnyMethod.new 'm2', singleton: true
     m2.record_location @tl
     c.add_method m2
     m2.comment = 'm2'
@@ -283,7 +283,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     c.add_method m
     m.comment = 'm'
@@ -298,14 +298,14 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'm1'
+    m1 = RDoc::AnyMethod.new 'm1'
     m1.record_location @tl
     m1.line = 10
     m1.params = '(p1, p2)'
     m1.comment = 'Stuff with +p1+'
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'm2'
+    m2 = RDoc::AnyMethod.new 'm2'
     m2.record_location @tl
     c.add_method m2
     m2.comment = 'm2'
@@ -325,7 +325,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     m.params = '(p1)'
     m.comment = 'Stuff with +p1+'
@@ -343,7 +343,7 @@ class RDocStatsTest < RDoc::TestCase
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     m.call_seq = <<-SEQ
 m(a) { |c| ... }
@@ -447,12 +447,12 @@ m(a, b) { |c, d| ... }
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'with_line'
+    m1 = RDoc::AnyMethod.new 'with_line'
     m1.record_location @tl
     m1.line = 3
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'no_line'
+    m2 = RDoc::AnyMethod.new 'no_line'
     m2.record_location @tl
     c.add_method m2
 
@@ -472,12 +472,12 @@ m(a, b) { |c, d| ... }
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'z_method'
+    m1 = RDoc::AnyMethod.new 'z_method'
     m1.record_location @tl
     m1.line = 5
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'a_method'
+    m2 = RDoc::AnyMethod.new 'a_method'
     m2.record_location @tl
     m2.line = 10
     c.add_method m2
@@ -497,7 +497,7 @@ m(a, b) { |c, d| ... }
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    a = RDoc::Attr.new nil, 'a', 'RW', nil
+    a = RDoc::Attr.new 'a', 'RW', nil
     a.record_location @tl
     a.line = 3
     c.add_attribute a
@@ -507,7 +507,7 @@ m(a, b) { |c, d| ... }
     k.line = 5
     c.add_constant k
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     m.line = 7
     c.add_method m
@@ -530,12 +530,12 @@ m(a, b) { |c, d| ... }
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m1 = RDoc::AnyMethod.new nil, 'ruby_method'
+    m1 = RDoc::AnyMethod.new 'ruby_method'
     m1.record_location @tl
     m1.line = 10
     c.add_method m1
 
-    m2 = RDoc::AnyMethod.new nil, 'c_method'
+    m2 = RDoc::AnyMethod.new 'c_method'
     m2.record_location tl2
     c.add_method m2
 
@@ -554,7 +554,7 @@ m(a, b) { |c, d| ... }
     m = @tl.add_module RDoc::NormalModule, 'M'
     m.record_location @tl
 
-    a = RDoc::Attr.new nil, 'a', 'RW', nil
+    a = RDoc::Attr.new 'a', 'RW', nil
     a.record_location @tl
     c.add_attribute a
 
@@ -562,7 +562,7 @@ m(a, b) { |c, d| ... }
     c_c.record_location @tl
     c.add_constant c_c
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     c.add_method m
 
@@ -621,7 +621,7 @@ m(a, b) { |c, d| ... }
     c.record_location @tl
     c.add_comment 'C', @tl
 
-    m = RDoc::AnyMethod.new nil, 'm'
+    m = RDoc::AnyMethod.new 'm'
     m.record_location @tl
     m.params = '(p1, p2)'
     m.comment = 'Stuff with +p1+'
@@ -654,7 +654,7 @@ m(a, b) { |c, d| ... }
   end
 
   def test_undoc_params
-    method = RDoc::AnyMethod.new [], 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '(a)'
     method.comment = comment 'comment'
 
@@ -665,7 +665,7 @@ m(a, b) { |c, d| ... }
   end
 
   def test_undoc_params_block
-    method = RDoc::AnyMethod.new [], 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '(&a)'
     method.comment = comment '+a+'
 
@@ -676,7 +676,7 @@ m(a, b) { |c, d| ... }
   end
 
   def test_undoc_params_documented
-    method = RDoc::AnyMethod.new [], 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '(a)'
     method.comment = comment '+a+'
 
@@ -687,7 +687,7 @@ m(a, b) { |c, d| ... }
   end
 
   def test_undoc_params_keywords
-    method = RDoc::AnyMethod.new [], 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '(**a)'
     method.comment = comment '+a+'
 
@@ -698,7 +698,7 @@ m(a, b) { |c, d| ... }
   end
 
   def test_undoc_params_splat
-    method = RDoc::AnyMethod.new [], 'm'
+    method = RDoc::AnyMethod.new 'm'
     method.params = '(*a)'
     method.comment = comment '+a+'
 

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -20,20 +20,20 @@ class RDocStoreTest < XrefTestCase
     @klass.add_comment 'original', @top_level
     @klass.record_location @top_level
 
-    @cmeth = RDoc::AnyMethod.new nil, 'cmethod', singleton: true
+    @cmeth = RDoc::AnyMethod.new 'cmethod', singleton: true
     @cmeth.record_location @top_level
 
     @meth_comment = RDoc::Comment.new 'method comment'
     @meth_comment.location = @top_level
 
-    @meth = RDoc::AnyMethod.new nil, 'method'
+    @meth = RDoc::AnyMethod.new 'method'
     @meth.record_location @top_level
     @meth.comment = @meth_comment
 
-    @meth_bang = RDoc::AnyMethod.new nil, 'method!'
+    @meth_bang = RDoc::AnyMethod.new 'method!'
     @meth_bang.record_location @top_level
 
-    @meth_bang_alias = RDoc::Alias.new nil, 'method!', 'method_bang', ''
+    @meth_bang_alias = RDoc::Alias.new 'method!', 'method_bang', ''
     @meth_bang_alias.record_location @top_level
 
     @meth_bang.add_alias @meth_bang_alias, @klass
@@ -41,7 +41,7 @@ class RDocStoreTest < XrefTestCase
     @attr_comment = RDoc::Comment.new 'attribute comment'
     @attr_comment.location = @top_level
 
-    @attr = RDoc::Attr.new nil, 'attr', 'RW', ''
+    @attr = RDoc::Attr.new 'attr', 'RW', ''
     @attr.record_location @top_level
     @attr.comment = @attr_comment
 
@@ -51,7 +51,7 @@ class RDocStoreTest < XrefTestCase
     @klass.add_attribute @attr
 
     @nest_klass = @klass.add_class RDoc::NormalClass, 'SubClass'
-    @nest_meth = RDoc::AnyMethod.new nil, 'method'
+    @nest_meth = RDoc::AnyMethod.new 'method'
     @nest_meth.record_location @top_level
 
     @nest_incl = RDoc::Include.new 'Incl', ''
@@ -402,7 +402,7 @@ class RDocStoreTest < XrefTestCase
       mod.method_list
     end.sort
 
-    _meth_bang_alias = RDoc::AnyMethod.new nil, 'method_bang'
+    _meth_bang_alias = RDoc::AnyMethod.new 'method_bang'
     _meth_bang_alias.parent = @klass
 
     assert_equal [@meth, @meth_bang, _meth_bang_alias, @nest_meth, @cmeth],
@@ -825,7 +825,7 @@ class RDocStoreTest < XrefTestCase
 
     klass = RDoc::NormalClass.new 'Object'
 
-    meth = klass.add_method RDoc::AnyMethod.new(nil, 'replace')
+    meth = klass.add_method RDoc::AnyMethod.new('replace')
     meth.record_location @top_level
 
     # load original, save newly updated class
@@ -1052,7 +1052,7 @@ class RDocStoreTest < XrefTestCase
     klass.record_location file
     file.add_to_classes_or_modules klass
 
-    meth = RDoc::AnyMethod.new nil, 'solo_method'
+    meth = RDoc::AnyMethod.new 'solo_method'
     meth.record_location file
     klass.add_method meth
 
@@ -1070,7 +1070,7 @@ class RDocStoreTest < XrefTestCase
     mod.record_location file
     file.add_to_classes_or_modules mod
 
-    meth = RDoc::AnyMethod.new nil, 'solo_method'
+    meth = RDoc::AnyMethod.new 'solo_method'
     meth.record_location file
     mod.add_method meth
 
@@ -1091,11 +1091,11 @@ class RDocStoreTest < XrefTestCase
     file_a.add_to_classes_or_modules klass
     file_b.add_to_classes_or_modules klass
 
-    meth_a = RDoc::AnyMethod.new nil, 'from_a'
+    meth_a = RDoc::AnyMethod.new 'from_a'
     meth_a.record_location file_a
     klass.add_method meth_a
 
-    meth_b = RDoc::AnyMethod.new nil, 'from_b'
+    meth_b = RDoc::AnyMethod.new 'from_b'
     meth_b.record_location file_b
     klass.add_method meth_b
 
@@ -1128,20 +1128,20 @@ class RDocStoreTest < XrefTestCase
     file_b.add_to_classes_or_modules klass
 
     # Methods from different files
-    meth_a = RDoc::AnyMethod.new nil, 'meth_a'
+    meth_a = RDoc::AnyMethod.new 'meth_a'
     meth_a.record_location file_a
     klass.add_method meth_a
 
-    meth_b = RDoc::AnyMethod.new nil, 'meth_b'
+    meth_b = RDoc::AnyMethod.new 'meth_b'
     meth_b.record_location file_b
     klass.add_method meth_b
 
     # Attributes from different files
-    attr_a = RDoc::Attr.new nil, 'attr_a', 'R', ''
+    attr_a = RDoc::Attr.new 'attr_a', 'R', ''
     attr_a.record_location file_a
     klass.add_attribute attr_a
 
-    attr_b = RDoc::Attr.new nil, 'attr_b', 'R', ''
+    attr_b = RDoc::Attr.new 'attr_b', 'R', ''
     attr_b.record_location file_b
     klass.add_attribute attr_b
 
@@ -1290,11 +1290,11 @@ class RDocStoreTest < XrefTestCase
   end
 
   def test_merge_rbs_signatures
-    m = RDoc::AnyMethod.new(nil, 'greet')
+    m = RDoc::AnyMethod.new('greet')
     m.params = '(name)'
     @klass.add_method m
 
-    a = RDoc::Attr.new(nil, 'language', 'R', '')
+    a = RDoc::Attr.new('language', 'R', '')
     @klass.add_attribute a
 
     @s.merge_rbs_signatures(
@@ -1318,7 +1318,7 @@ class RDocStoreTest < XrefTestCase
   end
 
   def test_merge_rbs_signatures_constructor
-    ctor = RDoc::AnyMethod.new nil, 'new', singleton: true
+    ctor = RDoc::AnyMethod.new 'new', singleton: true
     ctor.record_location @top_level
     @klass.add_method ctor
 
@@ -1342,11 +1342,11 @@ class RDocStoreTest < XrefTestCase
   end
 
   def test_rbs_signature_for_propagates_to_method_alias
-    original = RDoc::AnyMethod.new nil, 'original'
+    original = RDoc::AnyMethod.new 'original'
     original.record_location @top_level
     @klass.add_method original
 
-    alias_def = RDoc::Alias.new nil, 'original', 'aliased', ''
+    alias_def = RDoc::Alias.new 'original', 'aliased', ''
     alias_def.record_location @top_level
     aliased = original.add_alias alias_def, @klass
 
@@ -1359,11 +1359,11 @@ class RDocStoreTest < XrefTestCase
   end
 
   def test_rbs_signature_for_propagates_to_attribute_alias
-    original = RDoc::Attr.new nil, 'language', 'R', ''
+    original = RDoc::Attr.new 'language', 'R', ''
     original.record_location @top_level
     @klass.add_attribute original
 
-    alias_def = RDoc::Alias.new nil, 'language', 'locale', ''
+    alias_def = RDoc::Alias.new 'language', 'locale', ''
     alias_def.record_location @top_level
     aliased = original.add_alias alias_def, @klass
 
@@ -1376,11 +1376,11 @@ class RDocStoreTest < XrefTestCase
   end
 
   def test_merge_rbs_signatures_keeps_instance_and_singleton_attributes_separate
-    instance_attr = RDoc::Attr.new nil, 'language', 'R', ''
+    instance_attr = RDoc::Attr.new 'language', 'R', ''
     instance_attr.record_location @top_level
     @klass.add_attribute instance_attr
 
-    singleton_attr = RDoc::Attr.new nil, 'language', 'R', '', singleton: true
+    singleton_attr = RDoc::Attr.new 'language', 'R', '', singleton: true
     singleton_attr.record_location @top_level
     @klass.add_attribute singleton_attr
 

--- a/test/rdoc/rdoc_tom_doc_test.rb
+++ b/test/rdoc/rdoc_tom_doc_test.rb
@@ -26,7 +26,7 @@ class RDocTomDocTest < RDoc::TestCase
 
     pp.handle comment, parent
 
-    method = parent.add_method RDoc::AnyMethod.new(nil, 'm')
+    method = parent.add_method RDoc::AnyMethod.new('m')
 
     assert_equal 'Public', method.section.title
     assert_equal "# Do some stuff\n", comment.text

--- a/test/rdoc/rdoc_top_level_test.rb
+++ b/test/rdoc/rdoc_top_level_test.rb
@@ -25,7 +25,7 @@ class RDocTopLevelTest < XrefTestCase
   end
 
   def test_add_alias
-    a = RDoc::Alias.new nil, 'old', 'new', nil
+    a = RDoc::Alias.new 'old', 'new', nil
     @top_level.add_alias a
 
     object = @store.find_class_named 'Object'
@@ -37,7 +37,7 @@ class RDocTopLevelTest < XrefTestCase
   def test_add_alias_nodoc
     @top_level.document_self = false
 
-    a = RDoc::Alias.new nil, 'old', 'new', nil
+    a = RDoc::Alias.new 'old', 'new', nil
     @top_level.add_alias a
 
     object = @store.find_class_named('Object')
@@ -86,7 +86,7 @@ class RDocTopLevelTest < XrefTestCase
   end
 
   def test_add_method
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
     @top_level.add_method method
 
     object = @store.find_class_named 'Object'
@@ -97,7 +97,7 @@ class RDocTopLevelTest < XrefTestCase
   def test_add_method_stopdoc
     @top_level.document_self = false
 
-    method = RDoc::AnyMethod.new nil, 'm'
+    method = RDoc::AnyMethod.new 'm'
     @top_level.add_method method
 
     object = @store.find_class_named('Object')

--- a/test/rdoc/ri/driver_test.rb
+++ b/test/rdoc/ri/driver_test.rb
@@ -358,7 +358,7 @@ class RDocRIDriverTest < RDoc::TestCase
 
     out = doc()
 
-    missing = RDoc::AnyMethod.new nil, 'missing'
+    missing = RDoc::AnyMethod.new 'missing'
     @cFoo.add_method missing
 
     @driver.add_method_documentation out, @cFoo
@@ -1222,12 +1222,12 @@ Foo::Bar#bother
   def test_list_methods_matching_regexp
     util_store
 
-    index = RDoc::AnyMethod.new nil, '[]'
+    index = RDoc::AnyMethod.new '[]'
     index.record_location @top_level
     @cFoo.add_method index
     @store1.save_method @cFoo, index
 
-    c_index = RDoc::AnyMethod.new nil, '[]', singleton: true
+    c_index = RDoc::AnyMethod.new '[]', singleton: true
     c_index.record_location @top_level
     @cFoo.add_method c_index
     @store1.save_method @cFoo, c_index
@@ -1539,10 +1539,10 @@ Foo::Bar#bother
     @cBar = @top_level.add_class RDoc::NormalClass, 'Bar', 'Foo'
     @cFoo_Baz = @cFoo.add_class RDoc::NormalClass, 'Baz'
 
-    @baz = @cBar.add_method RDoc::AnyMethod.new(nil, 'baz')
+    @baz = @cBar.add_method RDoc::AnyMethod.new('baz')
     @baz.record_location @top_level
 
-    @override = @cBar.add_method RDoc::AnyMethod.new(nil, 'override')
+    @override = @cBar.add_method RDoc::AnyMethod.new('override')
     @override.comment = 'must be displayed'
     @override.record_location @top_level
 
@@ -1576,43 +1576,43 @@ Foo::Bar#bother
     @cFoo_Bar.add_comment "See also {Doc}[rdoc-ref:README.md]", @top_level
     @cFoo_Bar.record_location @top_level
 
-    @blah = @cFoo_Bar.add_method RDoc::AnyMethod.new(nil, 'blah')
+    @blah = @cFoo_Bar.add_method RDoc::AnyMethod.new('blah')
     @blah.call_seq = "blah(5) => 5\nblah(6) => 6\n"
     @blah.record_location @top_level
 
-    @blah_with_rdoc_ref = @cFoo_Bar.add_method RDoc::AnyMethod.new(nil, 'blah_with_rdoc_ref')
+    @blah_with_rdoc_ref = @cFoo_Bar.add_method RDoc::AnyMethod.new('blah_with_rdoc_ref')
     @blah_with_rdoc_ref.call_seq = "blah(5) => 5\nSee also {Doc}[rdoc-ref:README.md]"
     @blah_with_rdoc_ref.record_location @top_level
 
-    @bother = @cFoo_Bar.add_method RDoc::AnyMethod.new(nil, 'bother')
+    @bother = @cFoo_Bar.add_method RDoc::AnyMethod.new('bother')
     @bother.block_params = "stuff"
     @bother.params = "(things)"
     @bother.record_location @top_level
 
-    @new = @cFoo_Bar.add_method RDoc::AnyMethod.new nil, 'new', singleton: true
+    @new = @cFoo_Bar.add_method RDoc::AnyMethod.new 'new', singleton: true
     @new.record_location @top_level
 
-    @attr = @cFoo_Bar.add_attribute RDoc::Attr.new nil, 'attr', 'RW', ''
+    @attr = @cFoo_Bar.add_attribute RDoc::Attr.new 'attr', 'RW', ''
     @attr.record_location @top_level
 
     @cFoo_Baz = @cFoo.add_class RDoc::NormalClass, 'Baz'
     @cFoo_Baz.record_location @top_level
 
-    @inherit = @cFoo.add_method RDoc::AnyMethod.new(nil, 'inherit')
+    @inherit = @cFoo.add_method RDoc::AnyMethod.new('inherit')
     @inherit.record_location @top_level
 
     # overridden by Bar in multi_store
-    @overridden = @cFoo.add_method RDoc::AnyMethod.new(nil, 'override')
+    @overridden = @cFoo.add_method RDoc::AnyMethod.new('override')
     @overridden.comment = 'must not be displayed in Bar#override'
     @overridden.record_location @top_level
 
     @cQux = @top_level.add_class RDoc::NormalClass, 'Qux'
 
-    @original = @cQux.add_method RDoc::AnyMethod.new(nil, 'original')
+    @original = @cQux.add_method RDoc::AnyMethod.new('original')
     @original.comment = 'original comment'
     @original.record_location @top_level
 
-    @aliased = @original.add_alias RDoc::Alias.new(nil, 'original', 'aliased', 'alias comment'), @cQux
+    @aliased = @original.add_alias RDoc::Alias.new('original', 'aliased', 'alias comment'), @cQux
     @aliased.record_location @top_level
 
     @store1.save


### PR DESCRIPTION
It is unused and in majority of the cases just set to nil or the empty string