### PR TITLE
Handle old method signature in `Alias`/`AnyMethod`/`Attr`

### DIFF
--- a/lib/rdoc/code_object/alias.rb
+++ b/lib/rdoc/code_object/alias.rb
@@ -29,13 +29,23 @@ class RDoc::Alias < RDoc::CodeObject
   # Creates a new Alias that aliases +old_name+
   # to +new_name+, has +comment+ and is a +singleton+ context.
 
-  def initialize(old_name, new_name, comment, singleton: false)
+  def initialize(*args, singleton: false)
     super()
 
+    if args.size == 4
+      warn(<<~MSG, uplevel: 1, category: :deprecated)
+        Support for passing 4 arguments to RDoc::Alias.new is deprecated and will be removed. \
+        Simply drop the first argument.
+      MSG
+      args.shift
+    elsif args.size != 3
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 3)"
+    end
+
     @singleton = singleton
-    @old_name = old_name
-    @new_name = new_name
-    self.comment = comment
+    @old_name = args[0]
+    @new_name = args[1]
+    self.comment = args[2]
   end
 
   ##

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -41,8 +41,18 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   ##
   # Creates a new AnyMethod with name +name+
 
-  def initialize(name, singleton: false)
-    super(name, singleton: singleton)
+  def initialize(*args, singleton: false)
+    if args.size == 2
+      warn(<<~MSG, uplevel: 1, category: :deprecated)
+        Support for passing 2 arguments to RDoc::AnyMethod.new is deprecated and will be removed. \
+        Simply drop the first argument.
+      MSG
+      args.shift
+    elsif args.size != 1
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 1)"
+    end
+
+    super(name = args[0], singleton: singleton)
 
     @c_function = nil
     @dont_rename_initialize = false

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -24,11 +24,21 @@ class RDoc::Attr < RDoc::MethodAttr
   # Creates a new Attr with +name+, read/write status +rw+ and
   # +comment+.  +singleton+ marks this as a class attribute.
 
-  def initialize(name, rw, comment, singleton: false)
-    super(name, singleton: singleton)
+  def initialize(*args, singleton: false)
+    if args.size == 4
+      warn(<<~MSG, uplevel: 1, category: :deprecated)
+        Support for passing 4 arguments to RDoc::Attr.new is deprecated and will be removed. \
+        Simply drop the first argument.
+      MSG
+      args.shift
+    elsif args.size != 3
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 3)"
+    end
 
-    @rw = rw
-    self.comment = comment
+    super(args[0], singleton: singleton)
+
+    @rw = args[1]
+    self.comment = args[2]
   end
 
   ##


### PR DESCRIPTION
`rbs` for example uses them. This is not so pretty but can be reverted eventually. `rbs` tests pass with this.

Should I mention rdoc 8 in the warning? Not sure when you'd want to actually remove this.