### PR TITLE
Resolve markdown crash for note references in labels

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -403,7 +403,7 @@
   # the note order list for proper display at the end of the document.
 
   def note_for ref
-    raise ParseError, "invalid note reference: #{ref}" unless @note_order
+    return unless @note_order
 
     @note_order << ref
 

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -403,6 +403,8 @@
   # the note order list for proper display at the end of the document.
 
   def note_for ref
+    raise ParseError, "invalid note reference: #{ref}" unless @note_order
+
     @note_order << ref
 
     label = @note_order.length

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -788,7 +788,7 @@ class RDoc::Markdown
   # the note order list for proper display at the end of the document.
 
   def note_for ref
-    raise ParseError, "invalid note reference: #{ref}" unless @note_order
+    return unless @note_order
 
     @note_order << ref
 

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -788,6 +788,8 @@ class RDoc::Markdown
   # the note order list for proper display at the end of the document.
 
   def note_for ref
+    raise ParseError, "invalid note reference: #{ref}" unless @note_order
+
     @note_order << ref
 
     label = @note_order.length

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1005,11 +1005,24 @@ Some text. ^[With a footnote]
   def test_parse_note_invalid_reference
     @parser.notes = true
 
-    error = assert_raise RDoc::Markdown::ParseError do
-      parse "[[^0]\n"
-    end
+    assert_kind_of RDoc::Markup::Document, parse("[[^0]\n")
+  end
 
-    assert_equal "invalid note reference: 0", error.message
+  def test_parse_note_reference_in_reference_label
+    @parser.notes = true
+
+    doc = parse <<~MD
+      [foo[^1]bar]
+
+      [^1]: footnote
+    MD
+
+    expected = doc(
+      para("[foo{*1}[rdoc-label:foottext-1:footmark-1]bar]"),
+      rule(1),
+      para("{^1}[rdoc-label:footmark-1:foottext-1] footnote"))
+
+    assert_equal expected, doc
   end
 
   def test_parse_note_no_notes

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1002,6 +1002,16 @@ Some text. ^[With a footnote]
     assert_equal expected, doc
   end
 
+  def test_parse_note_invalid_reference
+    @parser.notes = true
+
+    error = assert_raise RDoc::Markdown::ParseError do
+      parse "[[^0]\n"
+    end
+
+    assert_equal "invalid note reference: 0", error.message
+  end
+
   def test_parse_note_no_notes
     @parser.notes = false
 


### PR DESCRIPTION
Fixes #654.

Note references can be parsed during the reference-gathering pass, before footnote ordering is initialized. Previously this could crash with a NoMethodError for malformed reference labels.

`RDoc::Markdown.parse("[[^0]\n")`

Before the fix, it raised:
```ruby
NoMethodError: undefined method `<<' for nil
.../lib/rdoc/markdown.rb:...:in `note_for'
```
Or:
`RDoc::Markdown.parse("[foo[^1]bar]\n\n[^1]: footnote\n")`