### PR TITLE
Ignore inline notes during Markdown reference parsing

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -439,6 +439,8 @@
   def parse markdown
     @references          = {}
     @unlinked_references = {}
+    @footnotes           = nil
+    @note_order          = nil
 
     markdown += "\n\n"
 
@@ -1236,7 +1238,9 @@ InlineNote = &{ notes? }
              @StartList:a
              ( !"]" Inline:l { a << l } )+
              "]"
-             { ref = [:inline, @note_order.length]
+             { raise ParseError, 'invalid inline note' unless @note_order
+
+               ref = [:inline, @note_order.length]
                @footnotes[ref] = paragraph a
 
                note_for ref

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -439,8 +439,6 @@
   def parse markdown
     @references          = {}
     @unlinked_references = {}
-    @footnotes           = nil
-    @note_order          = nil
 
     markdown += "\n\n"
 
@@ -1238,12 +1236,12 @@ InlineNote = &{ notes? }
              @StartList:a
              ( !"]" Inline:l { a << l } )+
              "]"
-             { raise ParseError, 'invalid inline note' unless @note_order
+             { if @note_order
+                 ref = [:inline, @note_order.length]
+                 @footnotes[ref] = paragraph a
 
-               ref = [:inline, @note_order.length]
-               @footnotes[ref] = paragraph a
-
-               note_for ref
+                 note_for ref
+               end
              }
 
 Notes = ( Note | SkipBlock )*

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -824,6 +824,8 @@ class RDoc::Markdown
   def parse markdown
     @references          = {}
     @unlinked_references = {}
+    @footnotes           = nil
+    @note_order          = nil
 
     markdown += "\n\n"
 
@@ -15478,7 +15480,7 @@ class RDoc::Markdown
     return _tmp
   end
 
-  # InlineNote = &{ notes? } "^[" @StartList:a (!"]" Inline:l { a << l })+ "]" { ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }
+  # InlineNote = &{ notes? } "^[" @StartList:a (!"]" Inline:l { a << l })+ "]" { raise ParseError, 'invalid inline note' unless @note_order                 ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }
   def _InlineNote
 
     _save = self.pos
@@ -15569,7 +15571,9 @@ class RDoc::Markdown
         self.pos = _save
         break
       end
-      @result = begin;  ref = [:inline, @note_order.length]
+      @result = begin;  raise ParseError, 'invalid inline note' unless @note_order
+
+               ref = [:inline, @note_order.length]
                @footnotes[ref] = paragraph a
 
                note_for ref
@@ -16843,7 +16847,7 @@ class RDoc::Markdown
   Rules[:_NoteReference] = rule_info("NoteReference", "&{ notes? } RawNoteReference:ref { note_for ref }")
   Rules[:_RawNoteReference] = rule_info("RawNoteReference", "\"[^\" < (!@Newline !\"]\" .)+ > \"]\" { text }")
   Rules[:_Note] = rule_info("Note", "&{ notes? } @NonindentSpace RawNoteReference:ref \":\" @Sp @StartList:a RawNoteBlock:i { a.concat i } (&Indent RawNoteBlock:i { a.concat i })* { @footnotes[ref] = paragraph a                    nil                 }")
-  Rules[:_InlineNote] = rule_info("InlineNote", "&{ notes? } \"^[\" @StartList:a (!\"]\" Inline:l { a << l })+ \"]\" { ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }")
+  Rules[:_InlineNote] = rule_info("InlineNote", "&{ notes? } \"^[\" @StartList:a (!\"]\" Inline:l { a << l })+ \"]\" { raise ParseError, 'invalid inline note' unless @note_order                 ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }")
   Rules[:_Notes] = rule_info("Notes", "(Note | SkipBlock)*")
   Rules[:_RawNoteBlock] = rule_info("RawNoteBlock", "@StartList:a (!@BlankLine !RawNoteReference OptionallyIndentedLine:l { a << l })+ < @BlankLine* > { a << text } { a }")
   Rules[:_CodeFence] = rule_info("CodeFence", "&{ github? } Ticks3 (@Sp StrChunk:format)? @Sp @Newline? < ((!\"`\" Nonspacechar)+ | !Ticks3 /`+/ | Spacechar | @Newline)+ > Ticks3 @Sp @Newline* { verbatim = RDoc::Markup::Verbatim.new text               verbatim.format = format.intern if format.instance_of?(String)               verbatim             }")

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -824,8 +824,6 @@ class RDoc::Markdown
   def parse markdown
     @references          = {}
     @unlinked_references = {}
-    @footnotes           = nil
-    @note_order          = nil
 
     markdown += "\n\n"
 
@@ -15480,7 +15478,7 @@ class RDoc::Markdown
     return _tmp
   end
 
-  # InlineNote = &{ notes? } "^[" @StartList:a (!"]" Inline:l { a << l })+ "]" { raise ParseError, 'invalid inline note' unless @note_order                 ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }
+  # InlineNote = &{ notes? } "^[" @StartList:a (!"]" Inline:l { a << l })+ "]" { if @note_order                  ref = [:inline, @note_order.length]                  @footnotes[ref] = paragraph a                   note_for ref                end              }
   def _InlineNote
 
     _save = self.pos
@@ -15571,12 +15569,12 @@ class RDoc::Markdown
         self.pos = _save
         break
       end
-      @result = begin;  raise ParseError, 'invalid inline note' unless @note_order
+      @result = begin;  if @note_order
+                 ref = [:inline, @note_order.length]
+                 @footnotes[ref] = paragraph a
 
-               ref = [:inline, @note_order.length]
-               @footnotes[ref] = paragraph a
-
-               note_for ref
+                 note_for ref
+               end
              ; end
       _tmp = true
       unless _tmp
@@ -16847,7 +16845,7 @@ class RDoc::Markdown
   Rules[:_NoteReference] = rule_info("NoteReference", "&{ notes? } RawNoteReference:ref { note_for ref }")
   Rules[:_RawNoteReference] = rule_info("RawNoteReference", "\"[^\" < (!@Newline !\"]\" .)+ > \"]\" { text }")
   Rules[:_Note] = rule_info("Note", "&{ notes? } @NonindentSpace RawNoteReference:ref \":\" @Sp @StartList:a RawNoteBlock:i { a.concat i } (&Indent RawNoteBlock:i { a.concat i })* { @footnotes[ref] = paragraph a                    nil                 }")
-  Rules[:_InlineNote] = rule_info("InlineNote", "&{ notes? } \"^[\" @StartList:a (!\"]\" Inline:l { a << l })+ \"]\" { raise ParseError, 'invalid inline note' unless @note_order                 ref = [:inline, @note_order.length]                @footnotes[ref] = paragraph a                 note_for ref              }")
+  Rules[:_InlineNote] = rule_info("InlineNote", "&{ notes? } \"^[\" @StartList:a (!\"]\" Inline:l { a << l })+ \"]\" { if @note_order                  ref = [:inline, @note_order.length]                  @footnotes[ref] = paragraph a                   note_for ref                end              }")
   Rules[:_Notes] = rule_info("Notes", "(Note | SkipBlock)*")
   Rules[:_RawNoteBlock] = rule_info("RawNoteBlock", "@StartList:a (!@BlankLine !RawNoteReference OptionallyIndentedLine:l { a << l })+ < @BlankLine* > { a << text } { a }")
   Rules[:_CodeFence] = rule_info("CodeFence", "&{ github? } Ticks3 (@Sp StrChunk:format)? @Sp @Newline? < ((!\"`\" Nonspacechar)+ | !Ticks3 /`+/ | Spacechar | @Newline)+ > Ticks3 @Sp @Newline* { verbatim = RDoc::Markup::Verbatim.new text               verbatim.format = format.intern if format.instance_of?(String)               verbatim             }")

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1025,16 +1025,10 @@ Some text. ^[With a footnote]
     assert_equal expected, doc
   end
 
-  def test_parse_note_inline_in_reference_label_after_reuse
+  def test_parse_note_inline_in_reference_label
     @parser.notes = true
 
-    parse "Some text. ^[With a footnote]"
-
-    error = assert_raise RDoc::Markdown::ParseError do
-      parse "[foo ^[note]]: /url\n"
-    end
-
-    assert_equal 'invalid inline note', error.message
+    assert_kind_of RDoc::Markup::Document, parse("[foo ^[note]]: /url\n")
   end
 
   def test_parse_note_no_notes

--- a/test/rdoc/rdoc_markdown_test.rb
+++ b/test/rdoc/rdoc_markdown_test.rb
@@ -1025,6 +1025,18 @@ Some text. ^[With a footnote]
     assert_equal expected, doc
   end
 
+  def test_parse_note_inline_in_reference_label_after_reuse
+    @parser.notes = true
+
+    parse "Some text. ^[With a footnote]"
+
+    error = assert_raise RDoc::Markdown::ParseError do
+      parse "[foo ^[note]]: /url\n"
+    end
+
+    assert_equal 'invalid inline note', error.message
+  end
+
   def test_parse_note_no_notes
     @parser.notes = false
 


### PR DESCRIPTION
Inline notes inside reference labels can be parsed during the reference-gathering pass, before footnote ordering is initialized. 

`RDoc::Markdown.parse("[foo ^[note]]: /url\n")`

This will crash a Markdown parser with a `NoMethodError`.

This change treats inline-note creation as a no-op until note ordering exists.