### PR TITLE
Change "check syntax" message when it isn't a ruby file

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -357,13 +357,25 @@ it or perhaps the original author's permissions are to restrictive.  If the
 this is not your library please report a bug to the author.
     EOF
   rescue => e
-    $stderr.puts <<-EOF
+    syntax_check_command = syntax_check_command_for filename, parser&.class
+    syntax_check_message = if syntax_check_command
+      <<~MESSAGE
 Before reporting this, could you check that the file you're documenting
 has proper syntax:
 
-  #{Gem.ruby} -c #{filename}
+  #{syntax_check_command}
+      MESSAGE
+    else
+      <<~MESSAGE
+Before reporting this, could you check that the file you're documenting
+has proper syntax for its language?
+      MESSAGE
+    end
 
-RDoc is not a full Ruby parser and will fail when fed invalid ruby programs.
+    $stderr.puts <<-EOF
+#{syntax_check_message}
+RDoc's parsers are not full language parsers and may fail when fed invalid
+source files.
 
 The internal error was:
 
@@ -374,6 +386,16 @@ The internal error was:
     $stderr.puts e.backtrace.join("\n\t") if $DEBUG_RDOC
 
     raise e
+  end
+
+  def syntax_check_command_for(filename, parser_class = RDoc::Parser.can_parse_by_name(filename))
+    if parser_class == RDoc::Parser::Ruby
+      "#{Gem.ruby} -c #{filename}"
+    elsif parser_class == RDoc::Parser::C
+      cc = ENV['CC']
+      cc = 'cc' if cc.nil? || cc.empty?
+      "#{cc} -fsyntax-only #{filename}"
+    end
   end
 
   ##

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -493,6 +493,23 @@ class RDocRDocTest < RDoc::TestCase
     tf.close!
   end
 
+  def test_syntax_check_command_for_c_file
+    command = @rdoc.syntax_check_command_for 'extension.c'
+
+    assert_includes command, ' -fsyntax-only extension.c'
+    refute_includes command, "#{Gem.ruby} -c"
+  end
+
+  def test_syntax_check_command_for_ruby_file
+    command = @rdoc.syntax_check_command_for 'library.rb'
+
+    assert_equal "#{Gem.ruby} -c library.rb", command
+  end
+
+  def test_syntax_check_command_for_unknown_file_type
+    assert_nil @rdoc.syntax_check_command_for('README')
+  end
+
   def test_remove_unparseable
     file_list = %w[
       blah.class


### PR DESCRIPTION
I saw this message and wanted to track down where it was coming from.

> Before reporting this, could you check that the file you're documenting
> has proper syntax:
>
>   /nix/store/67c99rck1l5z07968ffnxi9ksg3jfvn9-ruby-4.0.4/bin/ruby -c object.c

It probably isn't helpful to suggest "ruby -c" on a C file.

Should we suggest something else?