### PR TITLE
Change author of Aliki theme

### DIFF
--- a/lib/rdoc/generator/aliki.rb
+++ b/lib/rdoc/generator/aliki.rb
@@ -9,6 +9,8 @@ require 'uri'
 #
 
 class RDoc::Generator::Aliki < RDoc::Generator::Darkfish
+  DESCRIPTION = 'HTML generator, written by Stan Lo'
+
   RDoc::RDoc.add_generator self
 
   def initialize(store, options)

--- a/test/rdoc/rdoc_options_test.rb
+++ b/test/rdoc/rdoc_options_test.rb
@@ -137,10 +137,12 @@ class RDocOptionsTest < RDoc::TestCase
   def test_generator_descriptions
     # HACK autotest/isolate should take care of this
     RDoc::RDoc::GENERATORS.clear
+    RDoc::RDoc::GENERATORS['aliki']    = RDoc::Generator::Aliki
     RDoc::RDoc::GENERATORS['darkfish'] = RDoc::Generator::Darkfish
     RDoc::RDoc::GENERATORS['ri']       = RDoc::Generator::RI
 
     expected = <<-EXPECTED.chomp
+  aliki    - HTML generator, written by Stan Lo
   darkfish - HTML generator, written by Michael Granger
   ri       - creates ri data files
     EXPECTED


### PR DESCRIPTION
## Issue

when running `rdoc --help` i'm seeing following descriptions for formatters:

```bash
Available formatters:

  aliki    - HTML generator, written by Michael Granger
  darkfish - HTML generator, written by Michael Granger
  pot      - creates .pot file
  ri       - creates ri data files
```

aliki was not written by Michael Granger, but darkfish was.

## Solution
I suggest to change to actual author.

```bash
Available formatters:

  aliki    - HTML generator, written by Stan Lo
  darkfish - HTML generator, written by Michael Granger
  pot      - creates .pot file
  ri       - creates ri data files
```

 