### PR TITLE
Drop psych dependency

### DIFF
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -100,7 +100,14 @@ module RDoc
     %w[arg args yield yields notnew not-new not_new doc]
 
   ##
-  # Loads the best available YAML library.
+  # Loads the YAML backend used for <tt>.rdoc_options</tt>.
+  #
+  # Psych is preferred and used whenever it can be required. Requiring +yaml+
+  # is not attempted as a fallback because +yaml+ is merely a thin wrapper that
+  # loads Psych anyway. When Psych is genuinely unavailable, a minimal
+  # serializer shipped with RubyGems or Bundler is loaded instead, so that RDoc
+  # does not need a runtime dependency on Psych. Callers branch on whether
+  # Psych is defined and use ::yaml_serializer otherwise.
 
   def self.load_yaml
     begin
@@ -113,9 +120,23 @@ module RDoc
     begin
       require 'psych'
     rescue ::LoadError
-    ensure
-      require 'yaml'
+      # Psych is unavailable; load the stub serializer shipped with RubyGems,
+      # or Bundler's copy on RubyGems older than 3.5 (Ruby 3.2) where
+      # rubygems/yaml_serializer does not exist yet.
+      begin
+        require 'rubygems/yaml_serializer'
+      rescue ::LoadError
+        require 'bundler/yaml_serializer'
+      end
     end
+  end
+
+  ##
+  # The minimal YAML serializer module loaded by ::load_yaml as a fallback.
+  # Only meaningful when Psych is not defined.
+
+  def self.yaml_serializer
+    defined?(Gem::YAMLSerializer) ? Gem::YAMLSerializer : Bundler::YAMLSerializer
   end
 
   ##

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -599,7 +599,12 @@ class RDoc::Options
     ivars.sort.each do |ivar|
       yaml[ivar] = instance_variable_get("@#{ivar}")
     end
-    yaml.to_yaml
+
+    if yaml.respond_to?(:to_yaml)
+      yaml.to_yaml
+    else
+      RDoc.yaml_serializer.dump(yaml)
+    end
   end
 
   ##
@@ -1379,10 +1384,16 @@ Usage: #{opt.program_name} [options] [names...]
 
     RDoc.load_yaml
 
-    begin
-      options = YAML.safe_load File.read('.rdoc_options'), permitted_classes: [RDoc::Options, Symbol]
-    rescue Psych::SyntaxError
-      raise RDoc::Error, "#{options_file} is not a valid rdoc options file"
+    content = File.read('.rdoc_options')
+
+    if defined?(Psych)
+      begin
+        options = Psych.safe_load content, permitted_classes: [RDoc::Options, Symbol]
+      rescue Psych::SyntaxError
+        raise RDoc::Error, "#{options_file} is not a valid rdoc options file"
+      end
+    else
+      options = RDoc.yaml_serializer.load(content)
     end
 
     return RDoc::Options.new unless options # Allow empty file.

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -66,7 +66,6 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2")
 
-  s.add_dependency 'psych', '>= 4.0.0'
   s.add_dependency 'erb'
   s.add_dependency 'tsort'
   s.add_dependency 'prism', '>= 1.6.0'


### PR DESCRIPTION
Fixes https://github.com/ruby/rubygems/issues/9553

Psych is always provided Ruby 3.2+ becuase that is the default gem.

And, `YAML` is now `Psych` only. We should use `Gem::YAMLSerializer` instead of that when `psych` is not available.