### PR TITLE
Fix alias detection for multiple `rb_define_singleton_method`

### DIFF
--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -239,7 +239,7 @@ class RDoc::Parser::C < RDoc::Parser
       if comment.to_s.empty? and existing_method = class_obj.method_list.find { |m| m.name == old_name}
         comment = existing_method.comment
       end
-      add_alias(var_name, class_obj, old_name, new_name, comment)
+      add_alias(var_name, class_obj, old_name, new_name, comment, singleton: @singleton_classes.key?(var_name))
     end
   end
 
@@ -247,8 +247,8 @@ class RDoc::Parser::C < RDoc::Parser
   # Add alias, either from a direct alias definition, or from two
   # method that reference the same function.
 
-  def add_alias(var_name, class_obj, old_name, new_name, comment)
-    al = RDoc::Alias.new old_name, new_name, comment, singleton: @singleton_classes.key?(var_name)
+  def add_alias(var_name, class_obj, old_name, new_name, comment, singleton:)
+    al = RDoc::Alias.new old_name, new_name, comment, singleton: singleton
     al.record_location @top_level
     class_obj.add_alias al
     @stats.add_alias al
@@ -987,7 +987,7 @@ class RDoc::Parser::C < RDoc::Parser
   def handle_method(type, var_name, meth_name, function, param_count,
                     source_file = nil)
     class_name = @known_classes[var_name]
-    singleton  = @singleton_classes.key? var_name
+    singleton  = @singleton_classes.key?(var_name) || %w[singleton_method module_function].include?(type)
 
     @methods[var_name][function] << meth_name
 
@@ -996,7 +996,7 @@ class RDoc::Parser::C < RDoc::Parser
     class_obj = find_class var_name, class_name
 
     if existing_method = class_obj.method_list.find { |m| m.c_function == function }
-      add_alias(var_name, class_obj, existing_method.name, meth_name, existing_method.comment)
+      add_alias(var_name, class_obj, existing_method.name, meth_name, existing_method.comment, singleton: singleton)
     end
 
     if class_obj then
@@ -1006,7 +1006,6 @@ class RDoc::Parser::C < RDoc::Parser
         type = 'method' # force public
       end
 
-      singleton = singleton || %w[singleton_method module_function].include?(type)
       meth_obj = RDoc::AnyMethod.new meth_name, singleton: singleton
       meth_obj.c_function = function
 

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -995,7 +995,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     class_obj = find_class var_name, class_name
 
-    if existing_method = class_obj.method_list.find { |m| m.c_function == function }
+    if existing_method = class_obj.method_list.find { |m| m.c_function == function && m.singleton == singleton }
       add_alias(var_name, class_obj, existing_method.name, meth_name, existing_method.comment, singleton: singleton)
     end
 

--- a/test/rdoc/parser/c_test.rb
+++ b/test/rdoc/parser/c_test.rb
@@ -331,6 +331,28 @@ class RDocParserCTest < RDoc::TestCase
     assert_equal @top_level, methods.last.file
   end
 
+  def test_singleton_and_instance_methods_not_aliases
+    content = <<~C
+      VALUE blah(VALUE klass, VALUE year) {
+      }
+
+      void Init_Blah(void) {
+        cDate = rb_define_class("Date", rb_cObject);
+
+        rb_define_method(cDate, "blah", blah, 1);
+
+        rb_define_singleton_method(cDate, "bleh", blah, 1);
+      }
+    C
+
+    klass = util_get_class content, 'cDate'
+
+    methods = klass.method_list
+    assert_equal 2,      methods.length
+    refute               methods[0].is_alias_for
+    refute               methods[1].is_alias_for
+  end
+
   def test_do_aliases_missing_class
     content = <<~C
       void Init_Blah(void) {

--- a/test/rdoc/parser/c_test.rb
+++ b/test/rdoc/parser/c_test.rb
@@ -218,7 +218,7 @@ class RDocParserCTest < RDoc::TestCase
     end
   end
 
-  def test_do_aliases
+  def test_do_instance_define_alias
     content = <<~C
       /*
        * This should show up as an alias with documentation
@@ -241,12 +241,39 @@ class RDocParserCTest < RDoc::TestCase
     assert_equal 2,      methods.length
     assert_equal 'bleh', methods.last.name
     assert_equal 'blah', methods.last.is_alias_for.name
+    refute               methods.last.singleton
 
     assert_equal @top_level, methods.last.is_alias_for.file
     assert_equal @top_level, methods.last.file
   end
 
-  def test_do_aliases_singleton
+  def test_do_instance_duplicate_define_method
+    content = <<~C
+      VALUE blah(VALUE klass, VALUE year) {
+      }
+
+      void Init_Blah(void) {
+        cDate = rb_define_class("Date", rb_cObject);
+
+        rb_define_method(cDate, "blah", blah, 1);
+
+        rb_define_method(cDate, "bleh", blah, 1);
+      }
+    C
+
+    klass = util_get_class content, 'cDate'
+
+    methods = klass.method_list
+    assert_equal 2,      methods.length
+    assert_equal 'bleh', methods.last.name
+    assert_equal 'blah', methods.last.is_alias_for.name
+    refute               methods.last.singleton
+
+    assert_equal @top_level, methods.last.is_alias_for.file
+    assert_equal @top_level, methods.last.file
+  end
+
+  def test_do_singleton_define_alias
     content = <<~C
       /*
        * This should show up as a method with documentation
@@ -276,6 +303,32 @@ class RDocParserCTest < RDoc::TestCase
     assert               methods.last.singleton
     assert_equal 'blah', methods.last.is_alias_for.name
     assert_equal 'This should show up as an alias', methods.last.comment.text
+  end
+
+  def test_do_singleton_duplicate_define_method
+    content = <<~C
+      VALUE blah(VALUE klass, VALUE year) {
+      }
+
+      void Init_Blah(void) {
+        cDate = rb_define_class("Date", rb_cObject);
+
+        rb_define_singleton_method(cDate, "blah", blah, 1);
+
+        rb_define_singleton_method(cDate, "bleh", blah, 1);
+      }
+    C
+
+    klass = util_get_class content, 'cDate'
+
+    methods = klass.method_list
+    assert_equal 2,      methods.length
+    assert_equal 'bleh', methods.last.name
+    assert               methods.last.singleton
+    assert_equal 'blah', methods.last.is_alias_for.name
+
+    assert_equal @top_level, methods.last.is_alias_for.file
+    assert_equal @top_level, methods.last.file
   end
 
   def test_do_aliases_missing_class


### PR DESCRIPTION
They were not detected because `singleton_classes` doesn't contain the variable. Fix this simply by moving the check for `singleton_method` further up.

Closes #1722

<details><summary>List of affected classes</summary>
<p>

```
Complex
Date
DateTime
Dir
ENV
File
Pathname
Process
Regexp
Socket
Thread
UNIXSocket
Fiddle::Handle
RubyVM::InstructionSequence
```

</p>
</details> 

<img width="769" height="290" alt="grafik" src="https://github.com/user-attachments/assets/9dbc7457-39ea-40c4-b319-d9b96fe555fe" />
<img width="786" height="157" alt="grafik" src="https://github.com/user-attachments/assets/4c869808-9ca0-407c-aa89-2909d9910e34" />
