### PR TITLE
Add RDoc logo to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 - GitHub: [https://github.com/ruby/rdoc](https://github.com/ruby/rdoc)
 - Issues: [https://github.com/ruby/rdoc/issues](https://github.com/ruby/rdoc/issues)
 
+<p align="center" class="rdoc-logo">
+  <img src="rdoc-logo.svg" alt="RDoc" width="168" height="198">
+</p>
+
 ## Description
 
 RDoc produces HTML and command-line documentation for Ruby projects.  RDoc includes the `rdoc` and `ri` tools for generating and displaying documentation from the command-line.

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ task rdoc: :generate
 RDoc::Task.new do |doc|
   # RDoc task defaults to /html and overrides the op_dir option in .rdoc_options
   doc.rdoc_dir = "_site" # for GitHub Pages
+  doc.options << "--copy-files" << "rdoc-logo.svg"
 end
 
 task "coverage" do

--- a/lib/rdoc/generator/template/aliki/css/rdoc.css
+++ b/lib/rdoc/generator/template/aliki/css/rdoc.css
@@ -1107,6 +1107,22 @@ main p {
   margin-bottom: var(--space-4);
 }
 
+main .rdoc-logo {
+  margin: var(--space-6) 0 var(--space-8);
+  text-align: center;
+}
+
+main .rdoc-logo img {
+  display: inline-block;
+  width: clamp(120px, 14vw, 168px);
+  height: auto;
+  filter: drop-shadow(0 8px 18px rgb(230 41 35 / 8%));
+}
+
+[data-theme="dark"] main .rdoc-logo img {
+  filter: saturate(0.58) brightness(1.4) drop-shadow(0 8px 22px rgb(235 84 79 / 16%));
+}
+
 /* Preformatted Text */
 main pre {
   margin: 1.2em 0.5em;

--- a/rdoc-logo.svg
+++ b/rdoc-logo.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="198" viewBox="298 140 712 840" role="img" aria-labelledby="title desc">
+  <title id="title">RDoc</title>
+  <desc id="desc">A red document outline with a folded corner and a Ruby gem.</desc>
+  <style>
+    .surface {
+      fill: transparent;
+    }
+
+    .stroke {
+      stroke: url(#rdoc-red);
+    }
+
+    .solid {
+      fill: url(#rdoc-red);
+    }
+  </style>
+  <defs>
+    <linearGradient id="rdoc-red" x1="338" y1="178" x2="973" y2="938" gradientUnits="userSpaceOnUse">
+      <stop id="rdoc-red-start" offset="0" stop-color="#e62923"/>
+      <stop id="rdoc-red-mid" offset="0.56" stop-color="#e62923"/>
+      <stop id="rdoc-red-end" offset="1" stop-color="#e62923"/>
+    </linearGradient>
+    <filter id="soft-red-shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="#e62923" flood-opacity="0.1"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#soft-red-shadow)" fill="none" class="stroke" stroke-linecap="round" stroke-linejoin="round">
+    <path class="surface" d="M382 178h326l149 149v499c0 24-20 44-44 44H382c-24 0-44-20-44-44V222c0-24 20-44 44-44Z" stroke="none"/>
+    <path d="M685 870H382c-24 0-44-20-44-44V222c0-24 20-44 44-44h326l149 149v246" stroke-width="26"/>
+    <path class="solid" d="M708 178v126c0 24 19 43 43 43h106" stroke="none"/>
+    <path d="M708 178 857 327" stroke-width="26"/>
+
+    <path d="M440 411h216" stroke-width="26"/>
+    <path d="M440 506h216" stroke-width="26"/>
+    <path d="M440 605h145" stroke-width="26"/>
+
+    <path class="surface" d="M668 609h224l81 97-195 232-191-232 81-97Z" stroke-width="26"/>
+    <path d="M668 609 700 706 778 609 858 706 892 609" stroke-width="20"/>
+    <path d="M587 706h386" stroke-width="20"/>
+    <path d="M700 706 778 938 858 706" stroke-width="20"/>
+  </g>
+</svg>

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -51,6 +51,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     "exe/rdoc",
     "exe/ri",
     "man/ri.1",
+    "rdoc-logo.svg",
     "rdoc.gemspec",
   ]
   base = __dir__
@@ -60,7 +61,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
 
   s.files = (non_lib_files + template_files + lib_files).uniq
 
-  s.rdoc_options = ["--main", "README.md"]
+  s.rdoc_options = ["--main", "README.md", "--copy-files", "rdoc-logo.svg"]
   s.extra_rdoc_files += s.files.grep(%r[\A[^\/]+\.(?:rdoc|md)\z])
 
   s.required_ruby_version = Gem::Requirement.new(">= 3.2.0")


### PR DESCRIPTION
On official website:

<img width="50%" alt="Screenshot 2026-06-16 at 17 54 31" src="https://github.com/user-attachments/assets/5dd6ff70-0530-4ca1-9f7c-60d6f27e929b" />
<img width="50%" alt="Screenshot 2026-06-16 at 17 54 28" src="https://github.com/user-attachments/assets/492904c8-4c2a-4f96-b8cf-f8514334aec5" />

On GitHub:

<img width="50%" height="995" alt="Screenshot 2026-06-16 at 17 55 29" src="https://github.com/user-attachments/assets/96883fe4-bf92-42fe-9c2d-8cf3007eb51e" />
