### PR TITLE
Fix incorrect method visibility when merging with existing store cache

### DIFF
--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -538,6 +538,7 @@ class RDoc::ClassModule < RDoc::Context
 
     merge_collections method_list, cm.method_list, other_files do |add, meth|
       if add then
+        @visibility = meth.visibility
         add_method meth
       else
         @method_list.delete meth

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -951,6 +951,14 @@ class RDocStoreTest < XrefTestCase
     assert_empty result.constants
   end
 
+  def test_save_class_merge_method_visibility
+    @s.save_class @klass
+    assert_equal :public, @meth.visibility
+
+    @s.save_class @klass # save again to trigger ClassModule#merge
+    assert_equal :public, @meth.visibility
+  end
+
   def test_save_class_methods
     @s.save_class @klass
 


### PR DESCRIPTION
Running `Store#save` with already [existing](https://github.com/ruby/rdoc/blob/bb8b2d4587d64df8cd70924fb52021c0941e728a/lib/rdoc/store.rb#L1014) cache incorrectly sets method visibility to `:private` on all methods. `@visibility` gets set during marshal_load:

https://github.com/ruby/rdoc/blob/bb8b2d4587d64df8cd70924fb52021c0941e728a/lib/rdoc/code_object/class_module.rb#L440-L448

and is reused during `merge` -> `add_method`:

https://github.com/ruby/rdoc/blob/bb8b2d4587d64df8cd70924fb52021c0941e728a/lib/rdoc/code_object/class_module.rb#L539-L542

https://github.com/ruby/rdoc/blob/bb8b2d4587d64df8cd70924fb52021c0941e728a/lib/rdoc/code_object/context.rb#L494

Example:

```rb
# rdoc v7.2.0
Dir.mktmpdir do |op_dir|
  store = RDoc::Store.new(RDoc::Options.new.tap { it.op_dir = op_dir })
  top = store.add_file("file.rb")
  meth = RDoc::AnyMethod.new(nil, "method") rescue RDoc::AnyMethod.new("method")
  meth.record_location(top)
  klass = top.add_class(RDoc::NormalClass, "Object").tap { it.add_method(meth) }
  store.save # new cache
  p meth.visibility # => :public
  store.save # merge
  p meth.visibility # => :private
end
```

Fixes #346 