### PR TITLE
Test RBS 4.1.0.pre.2 with JRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       min_version: 3.2
       versions: '["mswin"]'
-      engine: cruby-truffleruby
+      engine: all
 
   test:
     needs: ruby-versions
@@ -30,6 +30,10 @@ jobs:
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head
+          - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
+            ruby: jruby-head
           - os: macos-latest
             ruby: mswin
           - os: ubuntu-latest

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -70,5 +70,5 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
   s.add_dependency 'erb'
   s.add_dependency 'tsort'
   s.add_dependency 'prism', '>= 1.6.0'
-  s.add_dependency 'rbs', '>= 4.0.0'
+  s.add_dependency 'rbs', '4.1.0.pre.2'
 end


### PR DESCRIPTION
## Summary

- pin RBS to 4.1.0.pre.2
- restore JRuby coverage in the CI Ruby matrix
- keep Windows exclusions for runtimes that are not exercised there
