### PR TITLE
Encapsulate superclass method link rendering

### DIFF
--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -83,6 +83,23 @@ class RDoc::CodeObject
 
 end
 
+class RDoc::AnyMethod
+
+  ##
+  # Creates an HTML link to the superclass method called by this method.
+
+  def superclass_method_link
+    target = superclass_method
+    return unless target
+
+    html_formatter = formatter
+    name = target.full_name
+
+    html_formatter.link name, html_formatter.convert_string(name)
+  end
+
+end
+
 class RDoc::MethodAttr
 
   ##

--- a/lib/rdoc/generator/template/aliki/class.rhtml
+++ b/lib/rdoc/generator/template/aliki/class.rhtml
@@ -185,10 +185,7 @@
           <%- if method.calls_super %>
             <div class="method-calls-super">
               Calls superclass method
-              <%=
-                  method.superclass_method ?
-                  method.formatter.link(method.superclass_method.full_name, method.superclass_method.full_name) : nil
-              %>
+              <%= method.superclass_method_link %>
             </div>
           <%- end %>
         </div>

--- a/lib/rdoc/generator/template/darkfish/class.rhtml
+++ b/lib/rdoc/generator/template/darkfish/class.rhtml
@@ -185,10 +185,7 @@
           <%- if method.calls_super %>
             <div class="method-calls-super">
               Calls superclass method
-              <%=
-                  method.superclass_method ?
-                  method.formatter.link(method.superclass_method.full_name, method.superclass_method.full_name) : nil
-              %>
+              <%= method.superclass_method_link %>
             </div>
           <%- end %>
         </div>

--- a/test/rdoc/generator/markup_test.rb
+++ b/test/rdoc/generator/markup_test.rb
@@ -48,10 +48,45 @@ class RDocGeneratorMarkupTest < RDoc::TestCase
     assert_same self, formatter.context
   end
 
+  def test_superclass_method_link
+    method = method_calling_super 'foo'
+
+    expected = '<a href="Outer.html#method-i-foo"><code>Outer#foo</code></a>'
+    assert_equal expected, method.superclass_method_link
+
+    assert_nil RDoc::AnyMethod.new('bar').superclass_method_link
+  end
+
+  def test_superclass_method_link_escapes_name
+    method = method_calling_super '<<'
+
+    link = method.superclass_method_link
+
+    expected = '<a href="Outer.html#method-i-3C-3C"><code>Outer#&lt;&lt;</code></a>'
+    assert_equal expected, link
+    refute_match %r{<code>Outer#<<</code>}, link
+  end
+
   attr_reader :path
 
   def find_symbol(name)
     @symbols[name]
+  end
+
+  def method_calling_super(name)
+    top_level = @store.add_file 'superclass_method_link.rb'
+    parent_method = RDoc::AnyMethod.new name
+
+    method = RDoc::AnyMethod.new name
+    method.calls_super = true
+
+    parent = top_level.add_class RDoc::NormalClass, 'Outer'
+    parent.add_method parent_method
+
+    child = top_level.add_class RDoc::NormalClass, 'Inner', parent.full_name
+    child.add_method method
+
+    method
   end
 
 end


### PR DESCRIPTION
## Problem

While reviewing #1571, I noticed a small follow-up refactoring opportunity in the superclass-method notice rendered by the HTML templates.

Both Aliki and Darkfish were reaching through `method.formatter` directly to build the superclass method link. That leaves template code responsible for formatter details and makes the escaping boundary less explicit.

## Solution

- Add `RDoc::AnyMethod#superclass_method_link` as the generator-facing helper for rendering the superclass method link.
- Escape the visible link text inside that helper while preserving the raw method name for cross-reference lookup.
- Update the Aliki and Darkfish templates to call the new helper instead of constructing formatter links directly.
- Cover the helper behavior with a generator markup unit test, including operator method names such as `<<`.
