### PR TITLE
Bump RDoc to 8.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ lib/rdoc/
 ├── server.rb                  # Live-reloading preview server (rdoc --server)
 ├── generator/                 # Documentation generators
 │   ├── aliki.rb               # HTML generator (default theme)
-│   ├── darkfish.rb            # HTML generator (deprecated, will be removed in v8.0)
+│   ├── darkfish.rb            # HTML generator (deprecated, will be removed in v9.0)
 │   ├── markup.rb              # Markup format generator
 │   ├── ri.rb                  # RI command generator
 │   └── template/              # ERB templates (.rhtml files)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ bundle exec rake coverage
 RDoc ships with two HTML themes:
 
 - **Aliki** (default) - Modern theme with improved styling and navigation
-- **Darkfish** (deprecated) - Classic theme, will be removed in v8.0
+- **Darkfish** (deprecated) - Classic theme, will be removed in v9.0
 
 New feature development should focus on the Aliki theme. Darkfish will continue to receive bug fixes but no new features.
 
@@ -165,7 +165,7 @@ lib/rdoc/
 │   └── ...
 ├── generator/                 # Documentation generators
 │   ├── aliki.rb               # HTML generator (default theme)
-│   ├── darkfish.rb            # HTML generator (deprecated, will be removed in v8.0)
+│   ├── darkfish.rb            # HTML generator (deprecated, will be removed in v9.0)
 │   ├── markup.rb              # Markup format generator
 │   ├── ri.rb                  # RI command generator
 │   └── template/              # ERB templates

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To determine how well your project is documented run `rdoc -C lib` to get a docu
 RDoc ships with two built-in themes:
 
 - **Aliki** (default) - A modern, clean theme with improved navigation and search
-- **Darkfish** (deprecated) - The classic theme, will be removed in v8.0
+- **Darkfish** (deprecated) - The classic theme, will be removed in v9.0
 
 To use the Darkfish theme instead of the default Aliki theme:
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -255,7 +255,7 @@ Each group below renders as a table with these columns:
 | Option | `.rdoc_options` | `RDoc::Task` | Effective default | Notes |
 |---|---|---|---|---|
 | `--output DIR` / `-o` / `--op` | `op_dir` | `rdoc.rdoc_dir` | CLI: `'doc'`; `RDoc::Task`: `'html'` | Output directory. RDoc also writes a `created.rid` marker here. |
-| `--format FORMAT` / `-f` / `--fmt` | `generator_name` | `rdoc.generator` | `'aliki'` | Generator name. Installed generators: `aliki` (HTML, default), `darkfish` *(deprecated, removal in v8.0)*, `ri`, `pot`. |
+| `--format FORMAT` / `-f` / `--fmt` | `generator_name` | `rdoc.generator` | `'aliki'` | Generator name. Installed generators: `aliki` (HTML, default), `darkfish` *(deprecated, removal in v9.0)*, `ri`, `pot`. |
 | `--ri` / `-r` | *(sets `generator_name: ri`)* | — | — | Shortcut: generate `ri` output into `~/.rdoc`. |
 | `--ri-site` / `-R` | *(sets `generator_name: ri`)* | — | — | Shortcut: generate `ri` output into the site-wide directory. |
 

--- a/lib/rdoc/version.rb
+++ b/lib/rdoc/version.rb
@@ -5,6 +5,6 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '7.2.0'
+  VERSION = '8.0.0'
 
 end


### PR DESCRIPTION
Prepare RDoc 8.0.0 by bumping the version constant from 7.2.0 to 8.0.0.

Darkfish stays available in 8.0; the deprecation docs now target removal in 9.0 instead.

Changes since 7.2.0: https://github.com/ruby/rdoc/compare/v7.2.0..master