### PR TITLE
Fix NoMethodError in MethodAttr#inspect for cache-loaded aliases

### DIFF
--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -297,7 +297,12 @@ class RDoc::MethodAttr < RDoc::CodeObject
   end
 
   def inspect # :nodoc:
-    alias_for = @is_alias_for ? " (alias for #{@is_alias_for.name})" : nil
+    alias_for =
+      if @is_alias_for.respond_to? :name then
+        " (alias for #{@is_alias_for.name})"
+      elsif Array === @is_alias_for then
+        " (alias for #{@is_alias_for.last})"
+      end
     visibility = self.visibility
     visibility = "forced #{visibility}" if force_documentation
     "#<%s:0x%x %s (%s)%s>" % [

--- a/test/rdoc/code_object/method_attr_test.rb
+++ b/test/rdoc/code_object/method_attr_test.rb
@@ -201,6 +201,30 @@ class RDocMethodAttrTest < XrefTestCase
     end
   end
 
+  def test_inspect_alias_from_store
+    temp_dir do |tmpdir|
+      s = RDoc::RI::Store.new(RDoc::Options.new, path: tmpdir)
+
+      top_level = s.add_file 'file.rb'
+      meth_bang = RDoc::AnyMethod.new 'method!'
+      meth_bang.record_location top_level
+
+      meth_bang_alias = RDoc::Alias.new 'method!', 'method_bang', ''
+      meth_bang_alias.record_location top_level
+
+      klass = top_level.add_class RDoc::NormalClass, 'Object'
+      klass.add_method meth_bang
+
+      meth_bang.add_alias meth_bang_alias, klass
+
+      s.save
+
+      meth_alias_from_store = s.load_method 'Object', '#method_bang'
+
+      assert_includes meth_alias_from_store.inspect, 'alias for method!'
+    end
+  end
+
   def test_to_s
     assert_equal 'RDoc::AnyMethod: C1#m',  @c1_m.to_s
     assert_equal 'RDoc::AnyMethod: C2#b',  @c2_b.to_s


### PR DESCRIPTION
`MethodAttr#inspect` calls `@is_alias_for.name` directly, but for a method loaded from the ri cache `@is_alias_for` is still the unresolved `[class, singleton, name]` tuple, so calling `inspect` (e.g. `p driver.stores.first.load_method("Array", "#append")`) raises `NoMethodError: undefined method 'name' for an instance of Array`.

This mirrors the guard `pretty_print` already uses in the same file: use the resolved object's name when available, otherwise fall back to the method name from the tuple.

Closes #1737.