### PR TITLE
Regression: Parse methods inside ActiveSupport::Concern included blocks

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -893,11 +893,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
         when :extend
           _visit_call_extend(node)
         when :included
-          if node.block
-            node.block.body&.accept(self)
-          else
-            super
-          end
+          node.block ? node.block.body&.accept(self) : super
         when :public
           super
           _visit_call_public_private_protected(node, :public)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -892,6 +892,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
           _visit_call_include(node)
         when :extend
           _visit_call_extend(node)
+        when :included
+          if node.block
+            node.block.body&.accept(self)
+          else
+            super
+          end
         when :public
           super
           _visit_call_public_private_protected(node, :public)

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -739,6 +739,9 @@ class RDocParserRubyTest < RDoc::TestCase
           # :method: bar
           # comment bar
           add_my_method :bar
+
+          # Returns the configuration.
+          def self.configurations; end
         end
 
         metaprogramming do
@@ -753,24 +756,8 @@ class RDocParserRubyTest < RDoc::TestCase
     RUBY
     mod = @store.find_module_named 'A'
     methods = mod.method_list
-    assert_equal ['A::foo', 'A#bar', 'A::baz2', 'A#baz3'], methods.map(&:full_name)
-    assert_equal ['comment foo', 'comment bar'], methods.take(2).map { |m| m.comment.text.strip }
-  end
-
-  def test_method_definition_inside_active_support_concern_included_block
-    util_parser <<~RUBY
-      module A
-        extend ActiveSupport::Concern
-        included do
-          # Returns the configuration.
-          def self.configurations; end
-        end
-      end
-    RUBY
-
-    mod = @store.find_module_named 'A'
-    assert_equal ['A::configurations'], mod.method_list.map(&:full_name)
-    assert_equal ['Returns the configuration.'], mod.method_list.map { |method| method.comment.text.strip }
+    assert_equal ['A::foo', 'A#bar', 'A::configurations', 'A::baz2', 'A#baz3'], methods.map(&:full_name)
+    assert_equal ['comment foo', 'comment bar', 'Returns the configuration.'], methods.take(3).map { |m| m.comment.text.strip }
   end
 
   def test_method_yields_directive

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -757,6 +757,22 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal ['comment foo', 'comment bar'], methods.take(2).map { |m| m.comment.text.strip }
   end
 
+  def test_method_definition_inside_active_support_concern_included_block
+    util_parser <<~RUBY
+      module A
+        extend ActiveSupport::Concern
+        included do
+          # Returns the configuration.
+          def self.configurations; end
+        end
+      end
+    RUBY
+
+    mod = @store.find_module_named 'A'
+    assert_equal ['A::configurations'], mod.method_list.map(&:full_name)
+    assert_equal ['Returns the configuration.'], mod.method_list.map { |method| method.comment.text.strip }
+  end
+
   def test_method_yields_directive
     util_parser <<~RUBY
       class Foo


### PR DESCRIPTION
## Issue
When generating documentation for rails, i'm seeing a following error:

```bash
ActiveRecord/ConnectionHandling.html:
`rdoc-ref:Core.configurations` can't be resolved for ``
```
RDoc does not add ActiveRecord::Core.configurations to its object store. Resulting documentation renders label as plain text instead of linking to the method documentation.

## Context
Rails defines some documented methods inside concern inclusion blocks:

```ruby
module ActiveRecord
  module Core
    extend ActiveSupport::Concern

    included do
      # Returns a fully resolved ActiveRecord::DatabaseConfigurations object.
      def self.configurations
        @@configurations
      end
    end
  end
end
```

Previously this block could be parsed, support for ActiveSupport::Concern#included was originally added in #819. During the migration to the Prism parser and subsequent removal of the Ripper parser, this special handling was not carried over.

## Solution

Handle special-case receiverless `included` calls that have a block.

Their block body is visited directly, without marking it as a generic proc block. Calls without a block continue through the normal visitor path.

Ordinary metaprogramming blocks remain unchanged and method definitions inside them are still ignored.

## Follow-up

@zzak voiced a valid question:

https://github.com/ruby/rdoc/pull/819#issuecomment-871782267


This deserves a follow-up PR's. 

- [ ] `prepended` is analogous and could be a small follow-up using `when :included, :prepended`.
- [ ] `class_methods` needs separate handling.