### PR TITLE
Document classes and modules defined by Struct.new, Data.define, Class.new and Module.new

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1005,9 +1005,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
       when Prism::ConstantWriteNode
         # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module.
         # When visiting the expression defined a class or module (`class << (X = Struct.new)`), reuse it.
+        # The constant belongs to the cref, which differs from the current container
+        # inside a class-body-like block.
         name = expression.name.to_s
-        mod = @scanner.container.classes_hash[name] || @scanner.container.modules_hash[name] ||
-              @scanner.container.add_module(RDoc::NormalModule, name)
+        owner, = @scanner.find_or_create_lexical_constant_owner_name(name)
+        owner ||= @scanner.container
+        mod = owner.classes_hash[name] || owner.modules_hash[name] || owner.add_module(RDoc::NormalModule, name)
       when Prism::ConstantPathNode, Prism::ConstantReadNode
         expression_name = constant_path_string(expression)
         # If a constant_path does not exist, RDoc creates a module

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -132,7 +132,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
   RBS_SIG_LINE = /\A#:\s/ # :nodoc:
 
   attr_accessor :visibility
-  attr_reader :container, :singleton, :in_proc_block
+  attr_reader :container, :singleton, :in_unknown_definee_block
 
   def initialize(top_level, content, options, stats)
     super
@@ -151,39 +151,47 @@ class RDoc::Parser::Ruby < RDoc::Parser
     @container = top_level
     @visibility = :public
     @singleton = false
-    @in_proc_block = false
+    @in_unknown_definee_block = false
   end
 
-  # Suppress `extend` and `include` within block
-  # because they might be a metaprogramming block
-  # example: `Module.new { include M }` `M.module_eval { include N }`
+  # A method can evaluate its block with any receiver (`instance_eval`,
+  # `module_eval` etc.), so self and the default definee inside a block are
+  # unknown. Definitions targeting them (`def`, `include`, `extend`, `attr_*`,
+  # visibility changes and aliases) are suppressed while visiting the block.
+  # Constant assignments stay documentable because the cref is lexical.
+  # example: `M.module_eval { include N }` `configure { def f; end }`
 
-  def with_in_proc_block
-    in_proc_block = @in_proc_block
-    @in_proc_block = true
+  def with_unknown_definee_block
+    in_unknown_definee_block = @in_unknown_definee_block
+    @in_unknown_definee_block = true
     yield
-    @in_proc_block = in_proc_block
+    @in_unknown_definee_block = in_unknown_definee_block
   end
 
-  # Dive into another container
+  # Dive into another container.
+  #
+  # `push_nesting: false` switches the default definee without changing the
+  # cref (`@module_nesting`). Class-body-like blocks (`X = Struct.new do ... end`)
+  # need this: `def` belongs to the new class while constant assignments and
+  # `class`/`module` keywords belong to the outer lexical scope.
 
-  def with_container(container, singleton: false)
+  def with_container(container, singleton: false, push_nesting: true)
     old_container = @container
     old_visibility = @visibility
     old_singleton = @singleton
-    old_in_proc_block = @in_proc_block
+    old_in_unknown_definee_block = @in_unknown_definee_block
     @visibility = :public
     @container = container
     @singleton = singleton
-    @in_proc_block = false
-    @module_nesting.push([container, singleton])
+    @in_unknown_definee_block = false
+    @module_nesting.push([container, singleton]) if push_nesting
     yield container
   ensure
     @container = old_container
     @visibility = old_visibility
     @singleton = old_singleton
-    @in_proc_block = old_in_proc_block
-    @module_nesting.pop
+    @in_unknown_definee_block = old_in_unknown_definee_block
+    @module_nesting.pop if push_nesting
   end
 
   # Records the location of this +container+ in the file for this parser and
@@ -740,10 +748,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
   def find_or_create_lexical_constant_owner_name(constant_path)
     const_path, colon, name = constant_path.rpartition('::')
     if colon.empty? # class Foo
-      # Within `class C` or `module C`, owner is C(== current container)
+      # Owner is the cref (innermost module nesting), not `@container`.
+      # They differ inside a class-body-like block: `A = Struct.new { C = 1 }`
+      # defines ::C, not A::C.
       # Within `class <<C`, owner is C.singleton_class
       # but RDoc don't track constants of a singleton class of module
-      [(@singleton ? nil : @container), name]
+      container, singleton = @module_nesting.last
+      [(singleton ? nil : container), name]
     elsif const_path.empty? # class ::Foo
       [@top_level, name]
     else # `class Foo::Bar` or `class ::Foo::Bar`
@@ -927,15 +938,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
 
     def visit_block_node(node)
-      @scanner.with_in_proc_block do
-        # include, extend and method definition inside block are not documentable.
-        # visibility methods and attribute definition methods should be ignored inside block.
+      @scanner.with_unknown_definee_block do
         super
       end
     end
 
     def visit_alias_method_node(node)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
       @scanner.process_comments_until(node.location.start_line - 1)
       return unless node.old_name.is_a?(Prism::SymbolNode) && node.new_name.is_a?(Prism::SymbolNode)
       @scanner.add_alias_method(node.old_name.value.to_s, node.new_name.value.to_s, node.location.start_line)
@@ -986,10 +995,14 @@ class RDoc::Parser::Ruby < RDoc::Parser
       expression = node.expression
       expression = expression.body.body.first if expression.is_a?(Prism::ParenthesesNode) && expression.body&.body&.size == 1
 
+      expression.accept(self)
       case expression
       when Prism::ConstantWriteNode
-        # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module
-        mod = @scanner.container.add_module(RDoc::NormalModule, expression.name.to_s)
+        # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module.
+        # When visiting the expression defined a class or module (`class << (X = Struct.new)`), reuse it.
+        name = expression.name.to_s
+        mod = @scanner.container.classes_hash[name] || @scanner.container.modules_hash[name] ||
+              @scanner.container.add_module(RDoc::NormalModule, name)
       when Prism::ConstantPathNode, Prism::ConstantReadNode
         expression_name = constant_path_string(expression)
         # If a constant_path does not exist, RDoc creates a module
@@ -997,7 +1010,6 @@ class RDoc::Parser::Ruby < RDoc::Parser
       when Prism::SelfNode
         mod = @scanner.container if @scanner.container != @top_level
       end
-      expression.accept(self)
       if mod
         @scanner.with_container(mod, singleton: true) do
           node.body&.accept(self)
@@ -1014,7 +1026,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
       end_line = node.location.end_line
       @scanner.process_comments_until(start_line - 1)
 
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
 
       case node.receiver
       when Prism::NilNode, Prism::TrueNode, Prism::FalseNode
@@ -1075,30 +1087,14 @@ class RDoc::Parser::Ruby < RDoc::Parser
       path = constant_path_string(node.target)
       return unless path
 
-      alias_path = constant_path_string(node.value)
-      @scanner.add_constant(
-        path,
-        alias_path || node.value.slice,
-        node.location.start_line,
-        node.location.end_line,
-        alias_path: alias_path
-      )
+      _visit_constant_write(path, node.value, node.location)
       @scanner.skip_comments_until(node.location.end_line)
-      # Do not traverse rhs not to document `A::B = Struct.new{def undocumentable_method; end}`
     end
 
     def visit_constant_write_node(node)
       @scanner.process_comments_until(node.location.start_line - 1)
-      alias_path = constant_path_string(node.value)
-      @scanner.add_constant(
-        node.name.to_s,
-        alias_path || node.value.slice,
-        node.location.start_line,
-        node.location.end_line,
-        alias_path: alias_path
-      )
+      _visit_constant_write(node.name.to_s, node.value, node.location)
       @scanner.skip_comments_until(node.location.end_line)
-      # Do not traverse rhs not to document `A = Struct.new{def undocumentable_method; end}`
     end
 
     private
@@ -1149,6 +1145,72 @@ class RDoc::Parser::Ruby < RDoc::Parser
       end
     end
 
+    def _visit_constant_write(path, value_node, location)
+      if (info = anonymous_module_or_class_info(value_node))
+        mod = @scanner.add_module_or_class(
+          path,
+          location.start_line,
+          location.end_line,
+          is_class: info[:is_class],
+          superclass_name: info[:superclass_name],
+          superclass_expr: info[:superclass_expr]
+        )
+        return unless mod
+
+        @scanner.with_container(mod, push_nesting: false) do
+          members = info[:members]
+          @scanner.add_attributes(members, info[:rw], location.start_line) if members && !members.empty?
+          info[:block]&.body&.accept(self)
+          @scanner.process_comments_until(location.end_line)
+        end
+      else
+        alias_path = constant_path_string(value_node)
+        @scanner.add_constant(
+          path,
+          alias_path || value_node.slice,
+          location.start_line,
+          location.end_line,
+          alias_path: alias_path
+        )
+        # Do not traverse rhs not to document `A = some_dsl { def undocumentable_method; end }`
+      end
+    end
+
+    # Returns add_module_or_class arguments if the expression creates an
+    # anonymous class or module (`Struct.new`, `Data.define`, `Class.new`,
+    # `Module.new`) which the constant assignment will name, otherwise nil.
+
+    def anonymous_module_or_class_info(expression)
+      return unless expression.is_a?(Prism::CallNode)
+
+      receiver_name =
+        case (receiver = expression.receiver)
+        when Prism::ConstantReadNode
+          receiver.name
+        when Prism::ConstantPathNode
+          receiver.name if receiver.parent.nil? # `::Struct.new`
+        end
+
+      block = expression.block
+      block = nil unless block.is_a?(Prism::BlockNode)
+      arguments = expression.arguments&.arguments || []
+
+      case [receiver_name, expression.name]
+      when [:Struct, :new], [:Data, :define]
+        # In `Struct.new('Name', :member)`, the string argument is a class name under Struct, not a member
+        members = arguments.grep(Prism::SymbolNode).map(&:value)
+        rw = receiver_name == :Struct ? 'RW' : 'R'
+        { is_class: true, superclass_name: receiver_name.to_s, members: members, rw: rw, block: block }
+      when [:Class, :new]
+        superclass = arguments.first
+        superclass_name = constant_path_string(superclass) if superclass
+        superclass_expr = superclass.slice if superclass && !superclass_name
+        { is_class: true, superclass_name: superclass_name, superclass_expr: superclass_expr, block: block }
+      when [:Module, :new]
+        { is_class: false, block: block }
+      end
+    end
+
     def _visit_call_require(call_node)
       return unless call_node.arguments&.arguments&.size == 1
       arg = call_node.arguments.arguments.first
@@ -1157,19 +1219,19 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
 
     def _visit_call_module_function(call_node)
-      return if @scanner.in_proc_block || @scanner.singleton
+      return if @scanner.in_unknown_definee_block || @scanner.singleton
       names = visibility_method_arguments(call_node, singleton: false)&.map(&:to_s)
       @scanner.change_method_to_module_function(names) if names
     end
 
     def _visit_call_public_private_class_method(call_node, visibility)
-      return if @scanner.in_proc_block || @scanner.singleton
+      return if @scanner.in_unknown_definee_block || @scanner.singleton
       names = visibility_method_arguments(call_node, singleton: true)
       @scanner.change_method_visibility(names, visibility, singleton: true) if names
     end
 
     def _visit_call_public_private_protected(call_node, visibility)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
       arguments_node = call_node.arguments
       if arguments_node.nil? # `public` `private`
         @scanner.visibility = visibility
@@ -1180,7 +1242,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
 
     def _visit_call_alias_method(call_node)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
 
       new_name, old_name, *rest = symbol_arguments(call_node)
       return unless old_name && new_name && rest.empty?
@@ -1188,7 +1250,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
 
     def _visit_call_include(call_node)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
 
       names = constant_arguments_names(call_node)
       line_no = call_node.location.start_line
@@ -1202,26 +1264,26 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
 
     def _visit_call_extend(call_node)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
 
       names = constant_arguments_names(call_node)
       @scanner.add_extends(names, call_node.location.start_line) if names && !@scanner.singleton
     end
 
     def _visit_call_public_constant(call_node)
-      return if @scanner.in_proc_block || @scanner.singleton
+      return if @scanner.in_unknown_definee_block || @scanner.singleton
       names = symbol_arguments(call_node)
       @scanner.container.set_constant_visibility_for(names.map(&:to_s), :public) if names
     end
 
     def _visit_call_private_constant(call_node)
-      return if @scanner.in_proc_block || @scanner.singleton
+      return if @scanner.in_unknown_definee_block || @scanner.singleton
       names = symbol_arguments(call_node)
       @scanner.container.set_constant_visibility_for(names.map(&:to_s), :private) if names
     end
 
     def _visit_call_attr_reader_writer_accessor(call_node, rw)
-      return if @scanner.in_proc_block
+      return if @scanner.in_unknown_definee_block
       names = symbol_arguments(call_node)
       @scanner.add_attributes(names.map(&:to_s), rw, call_node.location.start_line) if names
     end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -975,6 +975,11 @@ class RDoc::Parser::Ruby < RDoc::Parser
       klass = @scanner.add_module_or_class(class_name, node.location.start_line, node.location.end_line, is_class: true, superclass_name: superclass_name, superclass_expr: superclass_expr) if class_name
       if klass
         @scanner.with_container(klass) do
+          # `class A < Struct.new(:foo)` inherits member accessors
+          superclass_info = anonymous_module_or_class_info(node.superclass)
+          if (members = superclass_info&.dig(:members)) && !members.empty?
+            @scanner.add_attributes(members, superclass_info[:rw], node.superclass.location.start_line)
+          end
           node.body&.accept(self)
           @scanner.process_comments_until(node.location.end_line)
         end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1112,9 +1112,12 @@ module RDoc
           when Prism::ConstantWriteNode
             # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module.
             # When visiting the expression defined a class or module (`class << (X = Struct.new)`), reuse it.
+            # The constant belongs to the cref, which differs from the current container
+            # inside a class-body-like block.
             name = expression.name.to_s
-            mod = @scanner.container.classes_hash[name] || @scanner.container.modules_hash[name] ||
-                  @scanner.container.add_module(NormalModule, name)
+            owner, = @scanner.find_or_create_lexical_constant_owner_name(name)
+            owner ||= @scanner.container
+            mod = owner.classes_hash[name] || owner.modules_hash[name] || owner.add_module(NormalModule, name)
             mod.ignore if @scanner.document_suppressed? && mod.in_files.empty?
           when Prism::ConstantPathNode, Prism::ConstantReadNode
             expression_name = constant_path_string(expression)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1080,6 +1080,11 @@ module RDoc
           klass = @scanner.add_module_or_class(class_name, node.location.start_line, node.location.end_line, is_class: true, superclass_name: superclass_name, superclass_expr: superclass_expr) if class_name
           if klass
             @scanner.with_container(klass) do
+              # `class A < Struct.new(:foo)` inherits member accessors
+              superclass_info = anonymous_module_or_class_info(node.superclass)
+              if (members = superclass_info&.dig(:members)) && !members.empty?
+                @scanner.add_attributes(members, superclass_info[:rw], node.superclass.location.start_line)
+              end
               node.body&.accept(self)
               @scanner.process_comments_until(node.location.end_line)
             end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -134,7 +134,7 @@ module RDoc
       RBS_SIG_LINE = /\A#:\s/ # :nodoc:
 
       attr_accessor :visibility
-      attr_reader :container, :singleton, :in_proc_block
+      attr_reader :container, :singleton, :in_unknown_definee_block
 
       def initialize(top_level, content, options, stats)
         super
@@ -154,7 +154,7 @@ module RDoc
         @container = top_level
         @visibility = :public
         @singleton = false
-        @in_proc_block = false
+        @in_unknown_definee_block = false
         @doc_state = :startdoc
       end
 
@@ -204,38 +204,46 @@ module RDoc
         mark_container_documentable(container.parent) if container.parent.is_a?(ClassModule)
       end
 
-      # Suppress `extend` and `include` within block
-      # because they might be a metaprogramming block
-      # example: `Module.new { include M }` `M.module_eval { include N }`
+      # A method can evaluate its block with any receiver (`instance_eval`,
+      # `module_eval` etc.), so self and the default definee inside a block are
+      # unknown. Definitions targeting them (`def`, `include`, `extend`, `attr_*`,
+      # visibility changes and aliases) are suppressed while visiting the block.
+      # Constant assignments stay documentable because the cref is lexical.
+      # example: `M.module_eval { include N }` `configure { def f; end }`
 
-      def with_in_proc_block
-        in_proc_block = @in_proc_block
-        @in_proc_block = true
+      def with_unknown_definee_block
+        in_unknown_definee_block = @in_unknown_definee_block
+        @in_unknown_definee_block = true
         yield
-        @in_proc_block = in_proc_block
+        @in_unknown_definee_block = in_unknown_definee_block
       end
 
-      # Dive into another container
+      # Dive into another container.
+      #
+      # `push_nesting: false` switches the default definee without changing the
+      # cref (`@module_nesting`). Class-body-like blocks (`X = Struct.new do ... end`)
+      # need this: `def` belongs to the new class while constant assignments and
+      # `class`/`module` keywords belong to the outer lexical scope.
 
-      def with_container(container, singleton: false)
+      def with_container(container, singleton: false, push_nesting: true)
         old_container = @container
         old_visibility = @visibility
         old_singleton = @singleton
-        old_in_proc_block = @in_proc_block
+        old_in_unknown_definee_block = @in_unknown_definee_block
         old_doc_state = @doc_state
         @visibility = :public
         @container = container
         @singleton = singleton
-        @in_proc_block = false
-        @module_nesting.push([container, singleton])
+        @in_unknown_definee_block = false
+        @module_nesting.push([container, singleton]) if push_nesting
         yield container
       ensure
         @container = old_container
         @visibility = old_visibility
         @singleton = old_singleton
-        @in_proc_block = old_in_proc_block
+        @in_unknown_definee_block = old_in_unknown_definee_block
         @doc_state = old_doc_state
-        @module_nesting.pop
+        @module_nesting.pop if push_nesting
       end
 
       # Records the location of this +container+ in the file for this parser and
@@ -813,10 +821,13 @@ module RDoc
       def find_or_create_lexical_constant_owner_name(constant_path)
         const_path, colon, name = constant_path.rpartition('::')
         if colon.empty? # class Foo
-          # Within `class C` or `module C`, owner is C(== current container)
+          # Owner is the cref (innermost module nesting), not `@container`.
+          # They differ inside a class-body-like block: `A = Struct.new { C = 1 }`
+          # defines ::C, not A::C.
           # Within `class <<C`, owner is C.singleton_class
           # but RDoc don't track constants of a singleton class of module
-          [(@singleton ? nil : @container), name]
+          container, singleton = @module_nesting.last
+          [(singleton ? nil : container), name]
         elsif const_path.empty? # class ::Foo
           [@top_level, name]
         else # `class Foo::Bar` or `class ::Foo::Bar`
@@ -1032,15 +1043,13 @@ module RDoc
         end
 
         def visit_block_node(node)
-          @scanner.with_in_proc_block do
-            # include, extend and method definition inside block are not documentable.
-            # visibility methods and attribute definition methods should be ignored inside block.
+          @scanner.with_unknown_definee_block do
             super
           end
         end
 
         def visit_alias_method_node(node)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
           @scanner.process_comments_until(node.location.start_line - 1)
           return unless node.old_name.is_a?(Prism::SymbolNode) && node.new_name.is_a?(Prism::SymbolNode)
           @scanner.add_alias_method(node.old_name.value.to_s, node.new_name.value.to_s, node.location.start_line)
@@ -1093,10 +1102,14 @@ module RDoc
           expression = node.expression
           expression = expression.body.body.first if expression.is_a?(Prism::ParenthesesNode) && expression.body&.body&.size == 1
 
+          expression.accept(self)
           case expression
           when Prism::ConstantWriteNode
-            # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module
-            mod = @scanner.container.add_module(NormalModule, expression.name.to_s)
+            # Accept `class << (NameErrorCheckers = Object.new)` as a module which is not actually a module.
+            # When visiting the expression defined a class or module (`class << (X = Struct.new)`), reuse it.
+            name = expression.name.to_s
+            mod = @scanner.container.classes_hash[name] || @scanner.container.modules_hash[name] ||
+                  @scanner.container.add_module(NormalModule, name)
             mod.ignore if @scanner.document_suppressed? && mod.in_files.empty?
           when Prism::ConstantPathNode, Prism::ConstantReadNode
             expression_name = constant_path_string(expression)
@@ -1105,7 +1118,6 @@ module RDoc
           when Prism::SelfNode
             mod = @scanner.container if @scanner.container != @top_level
           end
-          expression.accept(self)
           if mod
             @scanner.with_container(mod, singleton: true) do
               node.body&.accept(self)
@@ -1122,7 +1134,7 @@ module RDoc
           end_line = node.location.end_line
           @scanner.process_comments_until(start_line - 1)
 
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
 
           case node.receiver
           when Prism::NilNode, Prism::TrueNode, Prism::FalseNode
@@ -1181,30 +1193,14 @@ module RDoc
           path = constant_path_string(node.target)
           return unless path
 
-          alias_path = constant_path_string(node.value)
-          @scanner.add_constant(
-            path,
-            alias_path || node.value.slice,
-            node.location.start_line,
-            node.location.end_line,
-            alias_path: alias_path
-          )
+          _visit_constant_write(path, node.value, node.location)
           @scanner.skip_comments_until(node.location.end_line)
-          # Do not traverse rhs not to document `A::B = Struct.new{def undocumentable_method; end}`
         end
 
         def visit_constant_write_node(node)
           @scanner.process_comments_until(node.location.start_line - 1)
-          alias_path = constant_path_string(node.value)
-          @scanner.add_constant(
-            node.name.to_s,
-            alias_path || node.value.slice,
-            node.location.start_line,
-            node.location.end_line,
-            alias_path: alias_path
-          )
+          _visit_constant_write(node.name.to_s, node.value, node.location)
           @scanner.skip_comments_until(node.location.end_line)
-          # Do not traverse rhs not to document `A = Struct.new{def undocumentable_method; end}`
         end
 
         private
@@ -1255,6 +1251,72 @@ module RDoc
           end
         end
 
+        def _visit_constant_write(path, value_node, location)
+          if (info = anonymous_module_or_class_info(value_node))
+            mod = @scanner.add_module_or_class(
+              path,
+              location.start_line,
+              location.end_line,
+              is_class: info[:is_class],
+              superclass_name: info[:superclass_name],
+              superclass_expr: info[:superclass_expr]
+            )
+            return unless mod
+
+            @scanner.with_container(mod, push_nesting: false) do
+              members = info[:members]
+              @scanner.add_attributes(members, info[:rw], location.start_line) if members && !members.empty?
+              info[:block]&.body&.accept(self)
+              @scanner.process_comments_until(location.end_line)
+            end
+          else
+            alias_path = constant_path_string(value_node)
+            @scanner.add_constant(
+              path,
+              alias_path || value_node.slice,
+              location.start_line,
+              location.end_line,
+              alias_path: alias_path
+            )
+            # Do not traverse rhs not to document `A = some_dsl { def undocumentable_method; end }`
+          end
+        end
+
+        # Returns add_module_or_class arguments if the expression creates an
+        # anonymous class or module (`Struct.new`, `Data.define`, `Class.new`,
+        # `Module.new`) which the constant assignment will name, otherwise nil.
+
+        def anonymous_module_or_class_info(expression)
+          return unless expression.is_a?(Prism::CallNode)
+
+          receiver_name =
+            case (receiver = expression.receiver)
+            when Prism::ConstantReadNode
+              receiver.name
+            when Prism::ConstantPathNode
+              receiver.name if receiver.parent.nil? # `::Struct.new`
+            end
+
+          block = expression.block
+          block = nil unless block.is_a?(Prism::BlockNode)
+          arguments = expression.arguments&.arguments || []
+
+          case [receiver_name, expression.name]
+          when [:Struct, :new], [:Data, :define]
+            # In `Struct.new('Name', :member)`, the string argument is a class name under Struct, not a member
+            members = arguments.grep(Prism::SymbolNode).map(&:value)
+            rw = receiver_name == :Struct ? 'RW' : 'R'
+            { is_class: true, superclass_name: receiver_name.to_s, members: members, rw: rw, block: block }
+          when [:Class, :new]
+            superclass = arguments.first
+            superclass_name = constant_path_string(superclass) if superclass
+            superclass_expr = superclass.slice if superclass && !superclass_name
+            { is_class: true, superclass_name: superclass_name, superclass_expr: superclass_expr, block: block }
+          when [:Module, :new]
+            { is_class: false, block: block }
+          end
+        end
+
         def _visit_call_require(call_node)
           return if @scanner.document_suppressed?
           return unless call_node.arguments&.arguments&.size == 1
@@ -1264,19 +1326,19 @@ module RDoc
         end
 
         def _visit_call_module_function(call_node)
-          return if @scanner.in_proc_block || @scanner.singleton
+          return if @scanner.in_unknown_definee_block || @scanner.singleton
           names = visibility_method_arguments(call_node, singleton: false)&.map(&:to_s)
           @scanner.change_method_to_module_function(names) if names
         end
 
         def _visit_call_public_private_class_method(call_node, visibility)
-          return if @scanner.in_proc_block || @scanner.singleton
+          return if @scanner.in_unknown_definee_block || @scanner.singleton
           names = visibility_method_arguments(call_node, singleton: true)
           @scanner.change_method_visibility(names, visibility, singleton: true) if names
         end
 
         def _visit_call_public_private_protected(call_node, visibility)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
           arguments_node = call_node.arguments
           if arguments_node.nil? # `public` `private`
             @scanner.visibility = visibility
@@ -1287,7 +1349,7 @@ module RDoc
         end
 
         def _visit_call_alias_method(call_node)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
 
           new_name, old_name, *rest = symbol_arguments(call_node)
           return unless old_name && new_name && rest.empty?
@@ -1295,7 +1357,7 @@ module RDoc
         end
 
         def _visit_call_include(call_node)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
 
           names = constant_arguments_names(call_node)
           line_no = call_node.location.start_line
@@ -1309,26 +1371,26 @@ module RDoc
         end
 
         def _visit_call_extend(call_node)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
 
           names = constant_arguments_names(call_node)
           @scanner.add_extends(names, call_node.location.start_line) if names && !@scanner.singleton
         end
 
         def _visit_call_public_constant(call_node)
-          return if @scanner.in_proc_block || @scanner.singleton
+          return if @scanner.in_unknown_definee_block || @scanner.singleton
           names = symbol_arguments(call_node)
           @scanner.container.set_constant_visibility_for(names.map(&:to_s), :public) if names
         end
 
         def _visit_call_private_constant(call_node)
-          return if @scanner.in_proc_block || @scanner.singleton
+          return if @scanner.in_unknown_definee_block || @scanner.singleton
           names = symbol_arguments(call_node)
           @scanner.container.set_constant_visibility_for(names.map(&:to_s), :private) if names
         end
 
         def _visit_call_attr_reader_writer_accessor(call_node, rw)
-          return if @scanner.in_proc_block
+          return if @scanner.in_unknown_definee_block
           names = symbol_arguments(call_node)
           @scanner.add_attributes(names.map(&:to_s), rw, call_node.location.start_line) if names
         end

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2340,6 +2340,25 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal 'Struct.new(:a)', @store.find_class_named('Expr').superclass
   end
 
+  def test_class_with_struct_new_superclass
+    util_parser <<~RUBY
+      class A < Struct.new(:foo, :bar)
+        def m; end
+      end
+      class B < Data.define(:baz)
+      end
+      class C < Class.new(StandardError)
+      end
+    RUBY
+    a = @store.find_class_named('A')
+    assert_equal 'Struct.new(:foo, :bar)', a.superclass
+    assert_equal [['foo', 'RW'], ['bar', 'RW']], a.attributes.map { |attr| [attr.name, attr.rw] }
+    assert_equal ['m'], a.method_list.map(&:name)
+    b = @store.find_class_named('B')
+    assert_equal [['baz', 'R']], b.attributes.map { |attr| [attr.name, attr.rw] }
+    assert_empty @store.find_class_named('C').attributes
+  end
+
   def test_constant_assignment_with_module_new
     util_parser <<~RUBY
       Helpers = Module.new do

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -437,6 +437,19 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal ['DidYouMean::NameErrorCheckers::new'], mod.method_list.map(&:full_name)
   end
 
+  def test_parenthesized_cdecl_anonymous_class
+    util_parser <<~RUBY
+      class << (B = Struct.new(:y))
+        def sm; end
+      end
+    RUBY
+
+    klass = @store.find_class_named('B')
+    assert_equal 'Struct', klass.superclass
+    assert_equal ['y'], klass.attributes.map(&:name)
+    assert_equal ['sm'], klass.class_method_list.map(&:name)
+  end
+
   def test_ghost_method
     util_parser <<~RUBY
       class Foo
@@ -2231,16 +2244,17 @@ class RDocParserRubyTest < RDoc::TestCase
   end
 
   def test_ignore_constant_assign_rhs
-    # Struct is not supported yet. Right hand side of constant assignment should be ignored.
+    # Right hand side of constant assignment should be ignored
+    # unless it is Struct.new, Data.define, Class.new or Module.new.
     util_parser <<~RUBY
       module Foo
         def a; end
-        Bar = Struct.new do
+        Bar = some_dsl do
           def b; end
           ##
           # :method: c
         end
-        Bar::Baz = Struct.new do
+        Baz = Other::Thing.new do
           def d; end
           ##
           # :method: e
@@ -2251,6 +2265,123 @@ class RDocParserRubyTest < RDoc::TestCase
     RUBY
     mod = @top_level.modules.first
     assert_equal ['a', 'f'], mod.method_list.map(&:name)
+  end
+
+  def test_constant_assignment_with_struct_new
+    util_parser <<~RUBY
+      module Foo
+        # Point comment
+        Point = Struct.new(:x, :y) do
+          include Comparable
+
+          # area comment
+          def area; end
+
+          def self.origin; end
+
+          private
+
+          def secret; end
+
+          ##
+          # :method: ghost
+        end
+        KeywordInit = Struct.new(:a, keyword_init: true)
+        Named = Struct.new('Name', :b)
+      end
+    RUBY
+    mod = @top_level.modules.first
+    assert_empty mod.method_list
+
+    klass = @store.find_class_named('Foo::Point')
+    assert_equal 'Struct', klass.superclass
+    assert_equal 'Point comment', klass.comment.text.strip
+    assert_equal [['x', 'RW'], ['y', 'RW']], klass.attributes.map { |a| [a.name, a.rw] }
+    assert_equal ['Comparable'], klass.includes.map(&:name)
+    assert_equal 'area comment', klass.find_method_named('area').comment.text.strip
+    assert_equal :private, klass.find_method_named('secret').visibility
+    assert klass.find_class_method_named('origin')
+    assert klass.find_method_named('ghost')
+
+    assert_equal ['a'], @store.find_class_named('Foo::KeywordInit').attributes.map(&:name)
+    assert_equal ['b'], @store.find_class_named('Foo::Named').attributes.map(&:name)
+  end
+
+  def test_constant_assignment_with_data_define
+    util_parser <<~RUBY
+      # Coord comment
+      Coord = Data.define(:lat, :lng)
+      Name = Data.define(:first, :last) do
+        def full_name; end
+      end
+    RUBY
+    coord = @store.find_class_named('Coord')
+    assert_equal 'Data', coord.superclass
+    assert_equal 'Coord comment', coord.comment.text.strip
+    assert_equal [['lat', 'R'], ['lng', 'R']], coord.attributes.map { |a| [a.name, a.rw] }
+    name = @store.find_class_named('Name')
+    assert name.find_method_named('full_name')
+  end
+
+  def test_constant_assignment_with_class_new
+    util_parser <<~RUBY
+      MyError = Class.new(StandardError)
+      Base = Class.new do
+        def foo; end
+      end
+      Deep::Error = Class.new(Base)
+      Expr = Class.new(Struct.new(:a))
+    RUBY
+    assert_equal 'StandardError', @store.find_class_named('MyError').superclass
+    base = @store.find_class_named('Base')
+    assert_equal 'Object', base.superclass
+    assert base.find_method_named('foo')
+    assert_equal 'Base', @store.find_class_named('Deep::Error').superclass.full_name
+    assert_equal 'Struct.new(:a)', @store.find_class_named('Expr').superclass
+  end
+
+  def test_constant_assignment_with_module_new
+    util_parser <<~RUBY
+      Helpers = Module.new do
+        # help comment
+        def help; end
+      end
+      Empty = Module.new
+    RUBY
+    helpers = @store.find_module_named('Helpers')
+    assert_equal 'help comment', helpers.find_method_named('help').comment.text.strip
+    assert @store.find_module_named('Empty')
+  end
+
+  def test_constant_assignment_anonymous_class_block_constant_scope
+    # Blocks don't change the cref: constant assignments and class/module
+    # keywords inside the block belong to the outer lexical scope
+    util_parser <<~RUBY
+      class A
+        B = Struct.new(:x) do
+          C = 1
+          class D; end
+          E = Struct.new(:y) do
+            def m; end
+          end
+        end
+      end
+    RUBY
+    a = @store.find_class_named('A')
+    assert_equal ['A::B', 'A::D', 'A::E'], a.classes.map(&:full_name).sort
+    assert_equal ['C'], a.constants.map(&:name)
+    assert @store.find_class_named('A::E').find_method_named('m')
+    assert_nil @store.find_class_named('A::B::D')
+  end
+
+  def test_constant_assignment_anonymous_class_nodoc
+    util_parser <<~RUBY
+      Point = Struct.new(:x) do # :nodoc:
+        def m; end
+      end
+      Visible = Struct.new(:y)
+    RUBY
+    assert_equal ['Visible'], @store.all_classes_and_modules.select(&:document_self).map(&:full_name)
   end
 
   def test_include_extend_suppressed_within_block

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -450,6 +450,27 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal ['sm'], klass.class_method_list.map(&:name)
   end
 
+  def test_parenthesized_cdecl_inside_anonymous_class_block
+    # Constants assigned inside the block belong to the cref (A), not to A::B
+    util_parser <<~RUBY
+      class A
+        B = Struct.new(:x) do
+          class << (Y = Struct.new(:z))
+            def sm; end
+          end
+          class << (W = Object.new)
+            def wm; end
+          end
+        end
+      end
+    RUBY
+
+    assert_equal ['sm'], @store.find_class_named('A::Y').class_method_list.map(&:name)
+    assert_equal ['wm'], @store.find_class_or_module('A::W').class_method_list.map(&:name)
+    assert_nil @store.find_class_or_module('A::B::Y')
+    assert_nil @store.find_class_or_module('A::B::W')
+  end
+
   def test_ghost_method
     util_parser <<~RUBY
       class Foo
@@ -2305,6 +2326,21 @@ class RDocParserRubyTest < RDoc::TestCase
 
     assert_equal ['a'], @store.find_class_named('Foo::KeywordInit').attributes.map(&:name)
     assert_equal ['b'], @store.find_class_named('Foo::Named').attributes.map(&:name)
+  end
+
+  def test_constant_path_assignment_with_struct_new
+    util_parser <<~RUBY
+      A::B = Struct.new(:x) do
+        def m; end
+      end
+    RUBY
+    klass = @store.find_class_named('A::B')
+    assert_equal 'Struct', klass.superclass
+    assert_equal ['x'], klass.attributes.map(&:name)
+    assert_equal ['m'], klass.method_list.map(&:name)
+    mod = @store.find_module_named('A')
+    assert_empty mod.method_list
+    assert_empty mod.attributes
   end
 
   def test_constant_assignment_with_data_define

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -753,6 +753,19 @@ end
     assert_equal ['DidYouMean::NameErrorCheckers::new'], mod.method_list.map(&:full_name)
   end
 
+  def test_parenthesized_cdecl_anonymous_class
+    util_parser <<~RUBY
+      class << (B = Struct.new(:y))
+        def sm; end
+      end
+    RUBY
+
+    klass = @store.find_class_named('B')
+    assert_equal 'Struct', klass.superclass
+    assert_equal ['y'], klass.attributes.map(&:name)
+    assert_equal ['sm'], klass.class_method_list.map(&:name)
+  end
+
   def test_ghost_method
     util_parser <<~RUBY
       class Foo
@@ -2547,16 +2560,17 @@ end
   end
 
   def test_ignore_constant_assign_rhs
-    # Struct is not supported yet. Right hand side of constant assignment should be ignored.
+    # Right hand side of constant assignment should be ignored
+    # unless it is Struct.new, Data.define, Class.new or Module.new.
     util_parser <<~RUBY
       module Foo
         def a; end
-        Bar = Struct.new do
+        Bar = some_dsl do
           def b; end
           ##
           # :method: c
         end
-        Bar::Baz = Struct.new do
+        Baz = Other::Thing.new do
           def d; end
           ##
           # :method: e
@@ -2567,6 +2581,123 @@ end
     RUBY
     mod = @top_level.modules.first
     assert_equal ['a', 'f'], mod.method_list.map(&:name)
+  end
+
+  def test_constant_assignment_with_struct_new
+    util_parser <<~RUBY
+      module Foo
+        # Point comment
+        Point = Struct.new(:x, :y) do
+          include Comparable
+
+          # area comment
+          def area; end
+
+          def self.origin; end
+
+          private
+
+          def secret; end
+
+          ##
+          # :method: ghost
+        end
+        KeywordInit = Struct.new(:a, keyword_init: true)
+        Named = Struct.new('Name', :b)
+      end
+    RUBY
+    mod = @top_level.modules.first
+    assert_empty mod.method_list
+
+    klass = @store.find_class_named('Foo::Point')
+    assert_equal 'Struct', klass.superclass
+    assert_equal 'Point comment', klass.comment.text.strip
+    assert_equal [['x', 'RW'], ['y', 'RW']], klass.attributes.map { |a| [a.name, a.rw] }
+    assert_equal ['Comparable'], klass.includes.map(&:name)
+    assert_equal 'area comment', klass.find_method_named('area').comment.text.strip
+    assert_equal :private, klass.find_method_named('secret').visibility
+    assert klass.find_class_method_named('origin')
+    assert klass.find_method_named('ghost')
+
+    assert_equal ['a'], @store.find_class_named('Foo::KeywordInit').attributes.map(&:name)
+    assert_equal ['b'], @store.find_class_named('Foo::Named').attributes.map(&:name)
+  end
+
+  def test_constant_assignment_with_data_define
+    util_parser <<~RUBY
+      # Coord comment
+      Coord = Data.define(:lat, :lng)
+      Name = Data.define(:first, :last) do
+        def full_name; end
+      end
+    RUBY
+    coord = @store.find_class_named('Coord')
+    assert_equal 'Data', coord.superclass
+    assert_equal 'Coord comment', coord.comment.text.strip
+    assert_equal [['lat', 'R'], ['lng', 'R']], coord.attributes.map { |a| [a.name, a.rw] }
+    name = @store.find_class_named('Name')
+    assert name.find_method_named('full_name')
+  end
+
+  def test_constant_assignment_with_class_new
+    util_parser <<~RUBY
+      MyError = Class.new(StandardError)
+      Base = Class.new do
+        def foo; end
+      end
+      Deep::Error = Class.new(Base)
+      Expr = Class.new(Struct.new(:a))
+    RUBY
+    assert_equal 'StandardError', @store.find_class_named('MyError').superclass
+    base = @store.find_class_named('Base')
+    assert_equal 'Object', base.superclass
+    assert base.find_method_named('foo')
+    assert_equal 'Base', @store.find_class_named('Deep::Error').superclass.full_name
+    assert_equal 'Struct.new(:a)', @store.find_class_named('Expr').superclass
+  end
+
+  def test_constant_assignment_with_module_new
+    util_parser <<~RUBY
+      Helpers = Module.new do
+        # help comment
+        def help; end
+      end
+      Empty = Module.new
+    RUBY
+    helpers = @store.find_module_named('Helpers')
+    assert_equal 'help comment', helpers.find_method_named('help').comment.text.strip
+    assert @store.find_module_named('Empty')
+  end
+
+  def test_constant_assignment_anonymous_class_block_constant_scope
+    # Blocks don't change the cref: constant assignments and class/module
+    # keywords inside the block belong to the outer lexical scope
+    util_parser <<~RUBY
+      class A
+        B = Struct.new(:x) do
+          C = 1
+          class D; end
+          E = Struct.new(:y) do
+            def m; end
+          end
+        end
+      end
+    RUBY
+    a = @store.find_class_named('A')
+    assert_equal ['A::B', 'A::D', 'A::E'], a.classes.map(&:full_name).sort
+    assert_equal ['C'], a.constants.map(&:name)
+    assert @store.find_class_named('A::E').find_method_named('m')
+    assert_nil @store.find_class_named('A::B::D')
+  end
+
+  def test_constant_assignment_anonymous_class_nodoc
+    util_parser <<~RUBY
+      Point = Struct.new(:x) do # :nodoc:
+        def m; end
+      end
+      Visible = Struct.new(:y)
+    RUBY
+    assert_equal ['Visible'], @store.all_classes_and_modules.select(&:document_self).map(&:full_name)
   end
 
   def test_include_extend_suppressed_within_block

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2656,6 +2656,25 @@ end
     assert_equal 'Struct.new(:a)', @store.find_class_named('Expr').superclass
   end
 
+  def test_class_with_struct_new_superclass
+    util_parser <<~RUBY
+      class A < Struct.new(:foo, :bar)
+        def m; end
+      end
+      class B < Data.define(:baz)
+      end
+      class C < Class.new(StandardError)
+      end
+    RUBY
+    a = @store.find_class_named('A')
+    assert_equal 'Struct.new(:foo, :bar)', a.superclass
+    assert_equal [['foo', 'RW'], ['bar', 'RW']], a.attributes.map { |attr| [attr.name, attr.rw] }
+    assert_equal ['m'], a.method_list.map(&:name)
+    b = @store.find_class_named('B')
+    assert_equal [['baz', 'R']], b.attributes.map { |attr| [attr.name, attr.rw] }
+    assert_empty @store.find_class_named('C').attributes
+  end
+
   def test_constant_assignment_with_module_new
     util_parser <<~RUBY
       Helpers = Module.new do

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -766,6 +766,27 @@ end
     assert_equal ['sm'], klass.class_method_list.map(&:name)
   end
 
+  def test_parenthesized_cdecl_inside_anonymous_class_block
+    # Constants assigned inside the block belong to the cref (A), not to A::B
+    util_parser <<~RUBY
+      class A
+        B = Struct.new(:x) do
+          class << (Y = Struct.new(:z))
+            def sm; end
+          end
+          class << (W = Object.new)
+            def wm; end
+          end
+        end
+      end
+    RUBY
+
+    assert_equal ['sm'], @store.find_class_named('A::Y').class_method_list.map(&:name)
+    assert_equal ['wm'], @store.find_class_or_module('A::W').class_method_list.map(&:name)
+    assert_nil @store.find_class_or_module('A::B::Y')
+    assert_nil @store.find_class_or_module('A::B::W')
+  end
+
   def test_ghost_method
     util_parser <<~RUBY
       class Foo
@@ -2621,6 +2642,21 @@ end
 
     assert_equal ['a'], @store.find_class_named('Foo::KeywordInit').attributes.map(&:name)
     assert_equal ['b'], @store.find_class_named('Foo::Named').attributes.map(&:name)
+  end
+
+  def test_constant_path_assignment_with_struct_new
+    util_parser <<~RUBY
+      A::B = Struct.new(:x) do
+        def m; end
+      end
+    RUBY
+    klass = @store.find_class_named('A::B')
+    assert_equal 'Struct', klass.superclass
+    assert_equal ['x'], klass.attributes.map(&:name)
+    assert_equal ['m'], klass.method_list.map(&:name)
+    mod = @store.find_module_named('A')
+    assert_empty mod.method_list
+    assert_empty mod.attributes
   end
 
   def test_constant_assignment_with_data_define


### PR DESCRIPTION
Closes #1375

## Summary

Constant assignments whose right-hand side creates an anonymous class or module now
define a documented class/module named by the constant, instead of a plain constant:

- `Point = Struct.new(:x, :y) do ... end` → `class Point < Struct` with RW attributes `x`, `y`
- `Coord = Data.define(:lat, :lng)` → `class Coord < Data` with R attributes
- `MyError = Class.new(StandardError)` → `class MyError < StandardError`
- `Helpers = Module.new do ... end` → `module Helpers`
- `A::B = ...` (constant path) works the same way

The block is documented as a class body: `def`, `def self.f`, `include`/`extend`,
`attr_*`, visibility methods, aliases and `# :method:` directives all work as in a
regular `class` body.

Additionally, `class A < Struct.new(:foo, :bar)` (common in lrama, net-imap, rbs, ...)
now documents the struct members as attributes of `A`.

## Design: default definee vs cref

A block does not change the cref, so inside `A = Struct.new do ... end`:

```ruby
class Outer
  A = Struct.new(:x) do
    def m; end   # => Outer::A#m
    C = 1        # => Outer::C (not Outer::A::C — blocks don't create a new constant scope)
    class D; end # => Outer::D
  end
end
```

To express this, the parser now distinguishes the *default definee* (`@container`,
where `def`/`attr_*`/`include` go) from the *cref* (`@module_nesting`, which owns
constant assignments and `class`/`module` keywords). `with_container(mod,
push_nesting: false)` switches only the definee, and the constant owner is derived
from `@module_nesting` instead of `@container` (identical in all previously existing
code paths).

Also renamed `in_proc_block` to `in_unknown_definee_block`: definitions inside a
block are suppressed because self and the default definee are statically unknown
there, not merely because it is a block. Anonymous-class blocks are still blocks,
but their definee is known, so they are documented.

## Notes

- `A = Struct.new(:x)` (no block) previously appeared in the Constants section;
  it is now a class page. `# :nodoc:` on the assignment suppresses it as before.
- Detection is name-based, consistent with how `include`, `attr_accessor` etc. are
  interpreted. Shadowed `Struct`/`Data`/`Class`/`Module` constants can misfire;
  writing the qualified name (`Types::Class.new`) or `# :nodoc:` avoids it.
- `Struct.new("Name", :a)` string argument and `keyword_init: true` are excluded
  from members. `&block` arguments and `A ||= Struct.new` are not treated specially.
- Fixed an interaction with the `class << (X = Object.new)` handling:
  `class << (X = Struct.new)` now documents `X` as a class including its singleton
  methods instead of silently dropping them.