### PR TITLE
Speed up the Markdown parser

### DIFF
--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -452,8 +452,12 @@
     if notes? then
       @footnotes       = {}
 
-      setup_parser markdown, @debug
-      peg_parse 'Notes'
+      # A note definition must contain "[^", so documents without one
+      # have nothing for the collecting pass to find
+      if markdown.include? '[^' then
+        setup_parser markdown, @debug
+        peg_parse 'Notes'
+      end
 
       # using note_order on the first pass would be a bug
       @note_order      = []

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -192,6 +192,10 @@
   require_relative 'markdown/entities'
 
   require_relative 'markdown/literals'
+  require_relative 'markdown/byte_runtime'
+
+  prepend ByteRuntime
+  Literals.prepend ByteRuntime
 
   ##
   # Supported extensions

--- a/lib/rdoc/markdown.kpeg
+++ b/lib/rdoc/markdown.kpeg
@@ -871,7 +871,7 @@ HtmlBlockInTags = HtmlAnchor
                 | HtmlBlockScript
                 | HtmlBlockHead
 
-HtmlBlock = < ( HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) >
+HtmlBlock = &"<" < ( HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) >
             @BlankLine+
             { if html? then
                 RDoc::Markup::Raw.new text

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -577,6 +577,10 @@ class RDoc::Markdown
   require_relative 'markdown/entities'
 
   require_relative 'markdown/literals'
+  require_relative 'markdown/byte_runtime'
+
+  prepend ByteRuntime
+  Literals.prepend ByteRuntime
 
   ##
   # Supported extensions

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -837,8 +837,12 @@ class RDoc::Markdown
     if notes? then
       @footnotes       = {}
 
-      setup_parser markdown, @debug
-      peg_parse 'Notes'
+      # A note definition must contain "[^", so documents without one
+      # have nothing for the collecting pass to find
+      if markdown.include? '[^' then
+        setup_parser markdown, @debug
+        peg_parse 'Notes'
+      end
 
       # using note_order on the first pass would be a bug
       @note_order      = []

--- a/lib/rdoc/markdown.rb
+++ b/lib/rdoc/markdown.rb
@@ -8975,27 +8975,34 @@ class RDoc::Markdown
     return _tmp
   end
 
-  # HtmlBlock = < (HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) > @BlankLine+ { if html? then                 RDoc::Markup::Raw.new text               end }
+  # HtmlBlock = &"<" < (HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) > @BlankLine+ { if html? then                 RDoc::Markup::Raw.new text               end }
   def _HtmlBlock
 
     _save = self.pos
     while true # sequence
+      _save1 = self.pos
+      _tmp = match_string("<")
+      self.pos = _save1
+      unless _tmp
+        self.pos = _save
+        break
+      end
       _text_start = self.pos
 
-      _save1 = self.pos
+      _save2 = self.pos
       while true # choice
         _tmp = apply(:_HtmlBlockInTags)
         break if _tmp
-        self.pos = _save1
+        self.pos = _save2
         _tmp = apply(:_HtmlComment)
         break if _tmp
-        self.pos = _save1
+        self.pos = _save2
         _tmp = apply(:_HtmlBlockSelfClosing)
         break if _tmp
-        self.pos = _save1
+        self.pos = _save2
         _tmp = apply(:_HtmlUnclosed)
         break if _tmp
-        self.pos = _save1
+        self.pos = _save2
         break
       end # end choice
 
@@ -9006,7 +9013,7 @@ class RDoc::Markdown
         self.pos = _save
         break
       end
-      _save2 = self.pos
+      _save3 = self.pos
       _tmp = _BlankLine()
       if _tmp
         while true
@@ -9015,7 +9022,7 @@ class RDoc::Markdown
         end
         _tmp = true
       else
-        self.pos = _save2
+        self.pos = _save3
       end
       unless _tmp
         self.pos = _save
@@ -16753,7 +16760,7 @@ class RDoc::Markdown
   Rules[:_HtmlBlockCloseHead] = rule_info("HtmlBlockCloseHead", "\"<\" Spnl \"/\" (\"head\" | \"HEAD\") Spnl \">\"")
   Rules[:_HtmlBlockHead] = rule_info("HtmlBlockHead", "HtmlBlockOpenHead (!HtmlBlockCloseHead .)* HtmlBlockCloseHead")
   Rules[:_HtmlBlockInTags] = rule_info("HtmlBlockInTags", "(HtmlAnchor | HtmlBlockAddress | HtmlBlockBlockquote | HtmlBlockCenter | HtmlBlockDir | HtmlBlockDiv | HtmlBlockDl | HtmlBlockFieldset | HtmlBlockForm | HtmlBlockH1 | HtmlBlockH2 | HtmlBlockH3 | HtmlBlockH4 | HtmlBlockH5 | HtmlBlockH6 | HtmlBlockMenu | HtmlBlockNoframes | HtmlBlockNoscript | HtmlBlockOl | HtmlBlockP | HtmlBlockPre | HtmlBlockTable | HtmlBlockUl | HtmlBlockDd | HtmlBlockDt | HtmlBlockFrameset | HtmlBlockLi | HtmlBlockTbody | HtmlBlockTd | HtmlBlockTfoot | HtmlBlockTh | HtmlBlockThead | HtmlBlockTr | HtmlBlockScript | HtmlBlockHead)")
-  Rules[:_HtmlBlock] = rule_info("HtmlBlock", "< (HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) > @BlankLine+ { if html? then                 RDoc::Markup::Raw.new text               end }")
+  Rules[:_HtmlBlock] = rule_info("HtmlBlock", "&\"<\" < (HtmlBlockInTags | HtmlComment | HtmlBlockSelfClosing | HtmlUnclosed) > @BlankLine+ { if html? then                 RDoc::Markup::Raw.new text               end }")
   Rules[:_HtmlUnclosed] = rule_info("HtmlUnclosed", "\"<\" Spnl HtmlUnclosedType Spnl HtmlAttribute* Spnl \">\"")
   Rules[:_HtmlUnclosedType] = rule_info("HtmlUnclosedType", "(\"HR\" | \"hr\")")
   Rules[:_HtmlBlockSelfClosing] = rule_info("HtmlBlockSelfClosing", "\"<\" Spnl HtmlBlockType Spnl HtmlAttribute* \"/\" Spnl \">\"")

--- a/lib/rdoc/markdown/byte_runtime.rb
+++ b/lib/rdoc/markdown/byte_runtime.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'strscan'
+
+class RDoc::Markdown
+
+  ##
+  # Byte-offset replacements for the position helpers of the kpeg-generated
+  # parser runtime.
+  #
+  # The generated runtime addresses +@string+ by character index, which makes
+  # every position lookup scan the string from its beginning when the input
+  # contains non-ASCII characters, so parse time becomes quadratic in the
+  # input size.  Generated rule bodies only save and restore +pos+ without
+  # inspecting it, so replacing these helpers is enough to switch the whole
+  # parser to byte offsets.
+  #
+  # get_byte (the grammar's `.`) consumes one character and returns its
+  # codepoint, exactly like the character-index runtime, so positions always
+  # stay on character boundaries and the only observable difference is the
+  # position values themselves.  The input must be validly encoded in an
+  # ASCII-compatible encoding.
+  #
+  # The error-reporting helpers of the generated runtime (+current_line+,
+  # +current_column+, ...) are left as-is and would misreport locations when
+  # given byte offsets.  They are unreachable: markdown is deliberately
+  # designed to parse any input somehow rather than fail (the root rule
+  # `Doc = BOM? Block*` cannot fail), so a parse failure means a bug in the
+  # grammar itself, and nothing in RDoc invokes +raise_error+ or
+  # +show_error+.  Make these helpers byte-aware before using them for
+  # anything.
+
+  module ByteRuntime
+    def set_string(string, pos)
+      @string = string
+      @string_size = string ? string.bytesize : 0
+      @pos = pos
+      @position_line_offsets = nil
+      @scanner = string ? StringScanner.new(string) : nil
+    end
+
+    def scan(reg)
+      @scanner.pos = @pos
+      if @scanner.skip(reg)
+        @pos = @scanner.pos
+        true
+      end
+    end
+
+    def match_string(str)
+      len = str.bytesize
+      if @string.byteslice(@pos, len) == str
+        @pos += len
+        str
+      end
+    end
+
+    def get_byte
+      byte = @string.getbyte(@pos)
+      return nil unless byte
+
+      if byte < 0x80
+        @pos += 1
+        byte
+      else
+        @scanner.pos = @pos
+        # /./ interprets the character in the string's own encoding
+        char = @scanner.scan(/./m)
+        @pos = @scanner.pos
+        char.ord
+      end
+    end
+
+    def get_text(start)
+      @string.byteslice(start, @pos - start)
+    end
+  end
+end


### PR DESCRIPTION
The kpeg-generated Markdown parser addresses the input string by character index, so on non-ASCII input every position lookup scans the string from the start and parsing becomes **quadratic** in the input size — real changelogs (contributor names etc.) always contain some non-ASCII, so this is the default path for large `.md` files. There were also two smaller costs paid by every document.

Three changes, one per commit:

- **Address positions by byte offset.** Generated rule bodies only save and restore `pos` without inspecting it, and all generated regexps are `\G`-anchored, so overriding the five position helpers (`set_string`, `scan`, `match_string`, `get_byte`, `get_text`) with byte-offset versions backed by StringScanner is enough. `get_byte` (the grammar's `.`) still consumes one character and returns its codepoint, so the only observable change is the position representation. The override lives in a hand-written file (`lib/rdoc/markdown/byte_runtime.rb`) prepended from the grammar, so regeneration is unaffected.
- **Guard `HtmlBlock` with a `&"<"` lookahead.** Previously every block position tried ~50 memoized per-tag HTML rules before falling through to `Para`.
- **Skip the Notes pass when the document contains no `"[^"`.** `parse` always ran up to three full passes; a note definition must contain `[^`, which is rare (11 of 594 sampled markdown files). The References pass is left unconditional: `[` appears in almost every real document.

Benchmarks (M-series, Ruby 4.0):

| input | before | after |
|---|---|---|
| `bundle exec rdoc bundler/CHANGELOG.md` (5,526 lines) | 14.5s | 1.5s |
| 300 Japanese paragraphs | 2,911ms | 40ms |
| 1,000 one-word ASCII paragraphs | 160ms | 77ms |

