### PR TITLE
Remove the unmatched constant alias queue

### DIFF
--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -407,10 +407,6 @@ class RDoc::Context < RDoc::CodeObject
       # this must be done AFTER adding mod to its parent, so that the full
       # name is correct:
       all_hash[mod.full_name] = mod
-      if @store.unmatched_constant_alias[mod.full_name] then
-        to, file = @store.unmatched_constant_alias[mod.full_name]
-        add_module_alias mod, mod.name, to, file
-      end
     end
 
     mod
@@ -549,10 +545,10 @@ class RDoc::Context < RDoc::CodeObject
   end
 
   ##
-  # Adds an alias from +from+ (a class or module) to +name+ which was defined
-  # in +file+.
+  # Adds an alias from +from+ (a class or module) to the constant +to+ which
+  # was defined in +file+.
 
-  def add_module_alias(from, from_name, to, file)
+  def add_module_alias(from, to, file)
     return from if @done_documenting
 
     to_full_name = child_name to.name
@@ -562,11 +558,6 @@ class RDoc::Context < RDoc::CodeObject
     # where we already know BasicObject is a class when we find
     # BasicObject = BlankSlate
     return from if @store.find_class_or_module to_full_name
-
-    unless from
-      @store.unmatched_constant_alias[child_name(from_name)] = [to, file]
-      return to
-    end
 
     new_to = from.dup
     new_to.name = to.name

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -871,7 +871,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
         @store.find_class_or_module(full_name)
       end
     if mod && constant.document_self
-      a = owner.add_module_alias(mod, alias_path, constant, @top_level)
+      a = owner.add_module_alias(mod, constant, @top_level)
       a.store = @store
       a.line = start_line
       record_location(a)

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -113,11 +113,6 @@ class RDoc::Store
   attr_accessor :encoding
 
   ##
-  # The lazy constants alias will be discovered in passing
-
-  attr_reader :unmatched_constant_alias
-
-  ##
   # Creates a new Store of +type+ that will load or save to +path+
 
   def initialize(options, path: nil, type: nil)
@@ -154,8 +149,6 @@ class RDoc::Store
 
     @unique_classes = nil
     @unique_modules = nil
-
-    @unmatched_constant_alias = {}
   end
 
   ##

--- a/test/rdoc/code_object/class_module_test.rb
+++ b/test/rdoc/code_object/class_module_test.rb
@@ -1363,7 +1363,7 @@ class RDocClassModuleTest < XrefTestCase
     n1_k2 = n1.add_module RDoc::NormalClass, 'N2'
 
     a1 = RDoc::Constant.new 'A1', '', ''
-    n1.add_module_alias n1_k2, n1_k2.name, a1, @xref_data
+    n1.add_module_alias n1_k2, a1, @xref_data
 
     n1_a1_c = n1.constants.find { |c| c.name == 'A1' }
     refute_nil n1_a1_c
@@ -1388,7 +1388,7 @@ class RDocClassModuleTest < XrefTestCase
     n1_n2 = n1.add_module RDoc::NormalModule, 'N2'
 
     a1 = RDoc::Constant.new 'A1', '', ''
-    n1.add_module_alias n1_n2, n1_n2.name, a1, @xref_data
+    n1.add_module_alias n1_n2, a1, @xref_data
 
     n1_a1_c = n1.constants.find { |c| c.name == 'A1' }
     refute_nil n1_a1_c
@@ -1414,7 +1414,7 @@ class RDocClassModuleTest < XrefTestCase
     o1 = @xref_data.add_module RDoc::NormalModule, 'O1'
 
     a1 = RDoc::Constant.new 'A1', '', ''
-    o1.add_module_alias l1_l2, l1_l2.name, a1, @xref_data
+    o1.add_module_alias l1_l2, a1, @xref_data
 
     o1_a1_c = o1.constants.find { |c| c.name == 'A1' }
     refute_nil o1_a1_c
@@ -1447,7 +1447,7 @@ class RDocClassModuleTest < XrefTestCase
     const.is_alias_for = klass
 
     a = RDoc::Constant.new 'A', '', ''
-    top_level.add_module_alias klass, klass.name, a, top_level
+    top_level.add_module_alias klass, a, top_level
 
     object.add_constant const
 

--- a/test/rdoc/generator/aliki_test.rb
+++ b/test/rdoc/generator/aliki_test.rb
@@ -39,7 +39,7 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
 
     @top_level.add_constant @alias_constant
 
-    @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
+    @klass.add_module_alias @klass, @alias_constant, @top_level
 
     @meth = RDoc::AnyMethod.new 'method'
     @meth_with_html_tag_yield = RDoc::AnyMethod.new 'method_with_html_tag_yield'

--- a/test/rdoc/generator/darkfish_test.rb
+++ b/test/rdoc/generator/darkfish_test.rb
@@ -39,7 +39,7 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
 
     @top_level.add_constant @alias_constant
 
-    @klass.add_module_alias @klass, @klass.name, @alias_constant, @top_level
+    @klass.add_module_alias @klass, @alias_constant, @top_level
 
     @meth = RDoc::AnyMethod.new 'method'
     @meth_bang = RDoc::AnyMethod.new 'method!'

--- a/test/rdoc/rdoc_context_test.rb
+++ b/test/rdoc/rdoc_context_test.rb
@@ -295,7 +295,7 @@ class RDocContextTest < XrefTestCase
     tl = @store.add_file 'file.rb'
 
     c4 = RDoc::Constant.new 'C4', '', ''
-    c3_c4 = @c2.add_module_alias @c2_c3, @c2_c3.name, c4, tl
+    c3_c4 = @c2.add_module_alias @c2_c3, c4, tl
 
     alias_constant = @c2.constants.first
 
@@ -314,7 +314,7 @@ class RDocContextTest < XrefTestCase
     object = top_level.add_class RDoc::NormalClass, 'Object'
 
     a = RDoc::Constant.new 'A', '', ''
-    top_level.add_module_alias klass, klass.name, a, top_level
+    top_level.add_module_alias klass, a, top_level
 
     refute_empty object.constants
 

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -222,7 +222,7 @@ class RDocStoreTest < XrefTestCase
 
   def test_complete
     a1 = RDoc::Constant.new 'A1', '', ''
-    @c2.add_module_alias @c2_c3, @c2_c3.name, a1, @top_level
+    @c2.add_module_alias @c2_c3, a1, @top_level
 
     @store.complete :public
 


### PR DESCRIPTION
`unmatched_constant_alias` is not used anymore.

Value was set in `add_module_alias(from, from_name, to, file)` when `from` is nil, but all path that calls `add_module_alias` doesn't pass `nil` to it.

