### PR TITLE
Make markup Raw, List, and ListItem inherit from Element

### DIFF
--- a/lib/rdoc/markup/list.rb
+++ b/lib/rdoc/markup/list.rb
@@ -1,101 +1,93 @@
 # frozen_string_literal: true
-##
-# A List is a homogeneous set of ListItems.
-#
-# The supported list types include:
-#
-# :BULLET::
-#   An unordered list
-# :LABEL::
-#   An unordered definition list, but using an alternate RDoc::Markup syntax
-# :LALPHA::
-#   An ordered list using increasing lowercase English letters
-# :NOTE::
-#   An unordered definition list
-# :NUMBER::
-#   An ordered list using increasing Arabic numerals
-# :UALPHA::
-#   An ordered list using increasing uppercase English letters
-#
-# Definition lists behave like HTML definition lists.  Each list item can
-# describe multiple terms.  See RDoc::Markup::ListItem for how labels and
-# definition are stored as list items.
 
-class RDoc::Markup::List < RDoc::Markup::Element
+module RDoc
+  class Markup
+    # A List is a homogeneous set of ListItems.
+    #
+    # The supported list types include:
+    #
+    # :BULLET::
+    #   An unordered list
+    # :LABEL::
+    #   An unordered definition list, but using an alternate RDoc::Markup syntax
+    # :LALPHA::
+    #   An ordered list using increasing lowercase English letters
+    # :NOTE::
+    #   An unordered definition list
+    # :NUMBER::
+    #   An ordered list using increasing Arabic numerals
+    # :UALPHA::
+    #   An ordered list using increasing uppercase English letters
+    #
+    # Definition lists behave like HTML definition lists. Each list item can
+    # describe multiple terms. See RDoc::Markup::ListItem for how labels and
+    # definitions are stored as list items.
+    class List < Element
+      # The list's type
+      #: Symbol?
+      attr_accessor :type
 
-  ##
-  # The list's type
+      # Items in the list
+      #: Array[ListItem]
+      attr_reader :items
 
-  attr_accessor :type
+      # Creates a new list of +type+ with +items+. Valid list types are:
+      # +:BULLET+, +:LABEL+, +:LALPHA+, +:NOTE+, +:NUMBER+, +:UALPHA+
+      #: (Symbol?, *ListItem) -> void
+      def initialize(type = nil, *items)
+        @type = type
+        @items = items
+      end
 
-  ##
-  # Items in the list
+      # Appends +item+ to the list
+      #: (ListItem) -> void
+      def <<(item)
+        @items << item
+      end
 
-  attr_reader :items
+      #: (top) -> bool
+      def ==(other) # :nodoc:
+        self.class == other.class &&
+          @type == other.type &&
+          @items == other.items
+      end
 
-  ##
-  # Creates a new list of +type+ with +items+.  Valid list types are:
-  # +:BULLET+, +:LABEL+, +:LALPHA+, +:NOTE+, +:NUMBER+, +:UALPHA+
+      # Runs this list and all its #items through +visitor+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_list_start(self)
+        @items.each { |item| item.accept(visitor) }
+        visitor.accept_list_end(self)
+      end
 
-  def initialize(type = nil, *items)
-    @type = type
-    @items = []
-    @items.concat items
-  end
+      # Is the list empty?
+      #: () -> bool
+      def empty?
+        @items.empty?
+      end
 
-  ##
-  # Appends +item+ to the list
+      # Returns the last item in the list
+      #: () -> ListItem?
+      def last
+        @items.last
+      end
 
-  def <<(item)
-    @items << item
-  end
+      # @override
+      #: (PP) -> void
+      def pretty_print(q) # :nodoc:
+        q.group(2, "[list: #{@type} ", ']') do
+          q.seplist(@items) do |item|
+            q.pp(item)
+          end
+        end
+      end
 
-  def ==(other) # :nodoc:
-    self.class == other.class and
-      @type == other.type and
-      @items == other.items
-  end
-
-  ##
-  # Runs this list and all its #items through +visitor+
-
-  def accept(visitor)
-    visitor.accept_list_start self
-
-    @items.each do |item|
-      item.accept visitor
-    end
-
-    visitor.accept_list_end self
-  end
-
-  ##
-  # Is the list empty?
-
-  def empty?
-    @items.empty?
-  end
-
-  ##
-  # Returns the last item in the list
-
-  def last
-    @items.last
-  end
-
-  def pretty_print(q) # :nodoc:
-    q.group 2, "[list: #{@type} ", ']' do
-      q.seplist @items do |item|
-        q.pp item
+      # Appends +items+ to the list
+      #: (*ListItem) -> void
+      def push(*items)
+        @items.concat(items)
       end
     end
   end
-
-  ##
-  # Appends +items+ to the list
-
-  def push(*items)
-    @items.concat items
-  end
-
 end

--- a/lib/rdoc/markup/list.rb
+++ b/lib/rdoc/markup/list.rb
@@ -21,7 +21,7 @@
 # describe multiple terms.  See RDoc::Markup::ListItem for how labels and
 # definition are stored as list items.
 
-class RDoc::Markup::List
+class RDoc::Markup::List < RDoc::Markup::Element
 
   ##
   # The list's type

--- a/lib/rdoc/markup/list_item.rb
+++ b/lib/rdoc/markup/list_item.rb
@@ -1,99 +1,87 @@
 # frozen_string_literal: true
-##
-# An item within a List that contains paragraphs, headings, etc.
-#
-# For BULLET, NUMBER, LALPHA and UALPHA lists, the label will always be nil.
-# For NOTE and LABEL lists, the list label may contain:
-#
-# * a single String for a single label
-# * an Array of Strings for a list item with multiple terms
-# * nil for an extra description attached to a previously labeled list item
 
-class RDoc::Markup::ListItem < RDoc::Markup::Element
+module RDoc
+  class Markup
+    # An item within a List that contains paragraphs, headings, etc.
+    #
+    # For BULLET, NUMBER, LALPHA and UALPHA lists, the label will always be nil.
+    # For NOTE and LABEL lists, the list label may contain:
+    #
+    # * a single String for a single label
+    # * an Array of Strings for a list item with multiple terms
+    # * nil for an extra description attached to a previously labeled list item
+    class ListItem < Element
+      # The label for the ListItem
+      #: (Array[String] | String)?
+      attr_accessor :label
 
-  ##
-  # The label for the ListItem
+      # Parts of the ListItem
+      #: Array[untyped]
+      attr_reader :parts
 
-  attr_accessor :label
-
-  ##
-  # Parts of the ListItem
-
-  attr_reader :parts
-
-  ##
-  # Creates a new ListItem with an optional +label+ containing +parts+
-
-  def initialize(label = nil, *parts)
-    @label = label
-    @parts = []
-    @parts.concat parts
-  end
-
-  ##
-  # Appends +part+ to the ListItem
-
-  def <<(part)
-    @parts << part
-  end
-
-  def ==(other) # :nodoc:
-    self.class == other.class and
-      @label == other.label and
-      @parts == other.parts
-  end
-
-  ##
-  # Runs this list item and all its #parts through +visitor+
-
-  def accept(visitor)
-    visitor.accept_list_item_start self
-
-    @parts.each do |part|
-      part.accept visitor
-    end
-
-    visitor.accept_list_item_end self
-  end
-
-  ##
-  # Is the ListItem empty?
-
-  def empty?
-    @parts.empty?
-  end
-
-  ##
-  # Length of parts in the ListItem
-
-  def length
-    @parts.length
-  end
-
-  def pretty_print(q) # :nodoc:
-    q.group 2, '[item: ', ']' do
-      case @label
-      when Array then
-        q.pp @label
-        q.text ';'
-        q.breakable
-      when String then
-        q.pp @label
-        q.text ';'
-        q.breakable
+      # Creates a new ListItem with an optional +label+ containing +parts+
+      #: ((Array[String] | String)?, *untyped) -> void
+      def initialize(label = nil, *parts)
+        @label = label
+        @parts = parts
       end
 
-      q.seplist @parts do |part|
-        q.pp part
+      # Appends +part+ to the ListItem
+      #: (untyped) -> void
+      def <<(part)
+        @parts << part
+      end
+
+      #: (top) -> bool
+      def ==(other) # :nodoc:
+        self.class == other.class &&
+          @label == other.label &&
+          @parts == other.parts
+      end
+
+      # Runs this list item and all its #parts through +visitor+
+      # @override
+      #: (untyped) -> void
+      def accept(visitor)
+        visitor.accept_list_item_start(self)
+        @parts.each { |part| part.accept(visitor) }
+        visitor.accept_list_item_end(self)
+      end
+
+      # Is the ListItem empty?
+      #: () -> bool
+      def empty?
+        @parts.empty?
+      end
+
+      # Length of parts in the ListItem
+      #: () -> Integer
+      def length
+        @parts.length
+      end
+
+      # @override
+      #: (PP) -> void
+      def pretty_print(q) # :nodoc:
+        q.group(2, '[item: ', ']') do
+          case @label
+          when Array, String
+            q.pp(@label)
+            q.text(';')
+            q.breakable
+          end
+
+          q.seplist(@parts) do |part|
+            q.pp(part)
+          end
+        end
+      end
+
+      # Adds +parts+ to the ListItem
+      #: (*untyped) -> void
+      def push(*parts)
+        @parts.concat(parts)
       end
     end
   end
-
-  ##
-  # Adds +parts+ to the ListItem
-
-  def push(*parts)
-    @parts.concat parts
-  end
-
 end

--- a/lib/rdoc/markup/list_item.rb
+++ b/lib/rdoc/markup/list_item.rb
@@ -9,7 +9,7 @@
 # * an Array of Strings for a list item with multiple terms
 # * nil for an extra description attached to a previously labeled list item
 
-class RDoc::Markup::ListItem
+class RDoc::Markup::ListItem < RDoc::Markup::Element
 
   ##
   # The label for the ListItem

--- a/lib/rdoc/markup/raw.rb
+++ b/lib/rdoc/markup/raw.rb
@@ -3,7 +3,7 @@
 module RDoc
   class Markup
     # A section of text that is added to the output document as-is
-    class Raw
+    class Raw < Element
       # The component parts of the list
       #: Array[String]
       attr_reader :parts

--- a/lib/rdoc/markup/raw.rb
+++ b/lib/rdoc/markup/raw.rb
@@ -4,7 +4,7 @@ module RDoc
   class Markup
     # A section of text that is added to the output document as-is
     class Raw < Element
-      # The component parts of the list
+      # The component parts of the raw text
       #: Array[String]
       attr_reader :parts
 

--- a/test/rdoc/markup/raw_test.rb
+++ b/test/rdoc/markup/raw_test.rb
@@ -9,6 +9,10 @@ class RDocMarkupRawTest < RDoc::TestCase
     @p = @RM::Raw.new
   end
 
+  def test_inherits_markup_element
+    assert_operator @RM::Raw, :<, @RM::Element
+  end
+
   def test_push
     @p.push 'hi', 'there'
 

--- a/test/rdoc/markup/raw_test.rb
+++ b/test/rdoc/markup/raw_test.rb
@@ -9,10 +9,6 @@ class RDocMarkupRawTest < RDoc::TestCase
     @p = @RM::Raw.new
   end
 
-  def test_inherits_markup_element
-    assert_operator @RM::Raw, :<, @RM::Element
-  end
-
   def test_push
     @p.push 'hi', 'there'
 


### PR DESCRIPTION
These classes are indeed markup components and already implement the Element contract, so they should inherit from the right abstract class.