### PR TITLE
Support newer comment token

### DIFF
--- a/test/rdoc/parser/ruby_colorizer_test.rb
+++ b/test/rdoc/parser/ruby_colorizer_test.rb
@@ -21,7 +21,13 @@ class RDocParserRubyColorizerTest < RDoc::TestCase
     prism_tokens = unordered_tokens.map(&:first).sort_by! { |token| token.location.start_offset }
     def_node = program_node.statements.body[0].body.body[0]
     tokens = RDoc::Parser::RubyColorizer.partial_colorize(code, def_node, prism_tokens)
-    expected = ['  ', 'def', ' ', 'm', "\n", '    ', "# comment\n", '    ', '42', "\n", '  ', 'end']
+    expected = ['  ', 'def', ' ', 'm', "\n", '    ', "# comment", "\n", '    ', '42', "\n", '  ', 'end']
+
+    if tokens[7].text != "\n" # Prism < 2.0.0
+      expected.delete_at(7)
+      expected[6] = "#{expected[6]}\n"
+    end
+
     assert_equal(expected, tokens.map(&:text))
   end
 
@@ -39,11 +45,15 @@ class RDocParserRubyColorizerTest < RDoc::TestCase
     RUBY
     tokens = RDoc::Parser::RubyColorizer.colorize(code)
     assert_equal(code, tokens.map(&:text).join)
-    assert_include(tokens, token(:comment, "# comment1\n"))
+
+    newline = ""
+    newline = "\n" if tokens[0].text.end_with?("\n") # Prism < 2.0.0
+
+    assert_include(tokens, token(:comment, "# comment1#{newline}"))
     assert_include(tokens, token(:comment, "=begin\n"))
     assert_include(tokens, token(:comment, "comment2\n"))
     assert_include(tokens, token(:comment, "=end\n"))
-    assert_include(tokens, token(:comment, "# comment3\n"))
+    assert_include(tokens, token(:comment, "# comment3#{newline}"))
   end
 
   def test_interpolated_node


### PR DESCRIPTION
In the next major version of Prism, the comment token is going to be split up when it is a non embdoc comment and when it terminates an expression. This diff makes the tests support both.

In theory this should have no user-facing consequences because it does not matter if you colorize the newline or not.

This will let me merge https://github.com/ruby/prism/pull/4205