### PR TITLE
Support JSON 3 in JSON index generation

### DIFF
--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -143,7 +143,7 @@ class RDoc::Generator::JsonIndex
       io.set_encoding Encoding::UTF_8
       io.write 'var search_data = '
 
-      JSON.dump data, io, 0
+      JSON.dump data, io
     end
     unless ENV['SOURCE_DATE_EPOCH'].nil?
       index_file.utime index_file.atime, Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime


### PR DESCRIPTION
JSON 3 interprets the third argument as options, causing index generation to fail when it receives the previous integer depth limit.

In ruby/ruby, all test-bundled-gems tasks are failing due to this failure since merger of json 3.0.0.rc1.