### PR TITLE
Deduplicate symlinked source files before parsing

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -124,7 +124,7 @@ class RDoc::RDoc
 
     file_list = normalized_file_list files, true, @options.exclude
 
-    file_list = remove_unparseable(file_list)
+    file_list = remove_duplicate_files(remove_unparseable(file_list))
 
     if file_list.count {|name, mtime|
          file_list[name] = @last_modified[name] unless mtime
@@ -456,6 +456,13 @@ The internal error was:
         (file =~ /tags\z/i and
          /\A(\f\n[^,]+,\d+$|!_TAG_)/.match?(File.binread(file, 100)))
     end
+  end
+
+  ##
+  # Removes duplicate canonical paths while preserving the first path found.
+
+  def remove_duplicate_files(files)
+    files.uniq { |file,| File.realpath(file) }.to_h
   end
 
   ##

--- a/lib/rdoc/server.rb
+++ b/lib/rdoc/server.rb
@@ -399,7 +399,7 @@ class RDoc::Server
       @options.files.empty? ? [@options.root.to_s] : @options.files,
       true, @options.exclude
     )
-    @rdoc.remove_unparseable(file_list).keys | @rdoc.auto_discovered_rbs_signature_files
+    @rdoc.remove_duplicate_files(@rdoc.remove_unparseable(file_list)).keys | @rdoc.auto_discovered_rbs_signature_files
   end
 
   def file_changed?(file)

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -343,10 +343,12 @@ class RDocRDocTest < RDoc::TestCase
       source_dir = File.join dir, 'gem'
       symlink_dir = File.join dir, 'docs', 'gem'
       FileUtils.mkdir_p [File.dirname(symlink_dir), source_dir]
-      FileUtils.touch File.join(source_dir, 'example.rb')
+      source_file = File.join source_dir, 'example.rb'
+      FileUtils.touch source_file
       FileUtils.ln_s '../gem', symlink_dir
+      omit 'directory symlinks are not supported' unless File.directory? symlink_dir
 
-      assert_equal [File.join(symlink_dir, 'example.rb')], @rdoc.gather_files([dir])
+      assert_equal 1, @rdoc.gather_files([dir]).count { |file| File.identical?(source_file, file) }
     end
   rescue NotImplementedError, Errno::EACCES, Errno::EPERM
     omit 'symlinks are not supported'

--- a/test/rdoc/rdoc_rdoc_test.rb
+++ b/test/rdoc/rdoc_rdoc_test.rb
@@ -338,6 +338,20 @@ class RDocRDocTest < RDoc::TestCase
     assert_equal [a, b], @rdoc.gather_files([b, a, b])
   end
 
+  def test_gather_files_deduplicates_symlinked_source_tree
+    temp_dir do |dir|
+      source_dir = File.join dir, 'gem'
+      symlink_dir = File.join dir, 'docs', 'gem'
+      FileUtils.mkdir_p [File.dirname(symlink_dir), source_dir]
+      FileUtils.touch File.join(source_dir, 'example.rb')
+      FileUtils.ln_s '../gem', symlink_dir
+
+      assert_equal [File.join(symlink_dir, 'example.rb')], @rdoc.gather_files([dir])
+    end
+  rescue NotImplementedError, Errno::EACCES, Errno::EPERM
+    omit 'symlinks are not supported'
+  end
+
   def test_handle_pipe
     $stdin = StringIO.new "hello"
 

--- a/test/rdoc/rdoc_server_test.rb
+++ b/test/rdoc/rdoc_server_test.rb
@@ -131,11 +131,12 @@ class RDocServerTest < RDoc::TestCase
     source_dir = File.join @dir, 'gem'
     symlink_dir = File.join @dir, 'docs', 'gem'
     FileUtils.mkdir_p [File.dirname(symlink_dir), source_dir]
-    FileUtils.touch File.join(source_dir, 'example.rb')
+    source_file = File.join source_dir, 'example.rb'
+    FileUtils.touch source_file
     FileUtils.ln_s '../gem', symlink_dir
+    omit 'directory symlinks are not supported' unless File.directory? symlink_dir
 
-    files = @server.send :current_watch_files
-    assert_equal [File.join(symlink_dir, 'example.rb')], files.grep(/gem\/example\.rb\z/)
+    assert_equal 1, @server.send(:current_watch_files).count { |file| File.identical?(source_file, file) }
   rescue NotImplementedError, Errno::EACCES, Errno::EPERM
     omit 'symlinks are not supported'
   end

--- a/test/rdoc/rdoc_server_test.rb
+++ b/test/rdoc/rdoc_server_test.rb
@@ -126,4 +126,17 @@ class RDocServerTest < RDoc::TestCase
     greet = sample.find_method 'greet', false
     assert_equal ['() -> String'], greet.type_signature_lines
   end
+
+  def test_current_watch_files_deduplicates_symlinked_source_tree
+    source_dir = File.join @dir, 'gem'
+    symlink_dir = File.join @dir, 'docs', 'gem'
+    FileUtils.mkdir_p [File.dirname(symlink_dir), source_dir]
+    FileUtils.touch File.join(source_dir, 'example.rb')
+    FileUtils.ln_s '../gem', symlink_dir
+
+    files = @server.send :current_watch_files
+    assert_equal [File.join(symlink_dir, 'example.rb')], files.grep(/gem\/example\.rb\z/)
+  rescue NotImplementedError, Errno::EACCES, Errno::EPERM
+    omit 'symlinks are not supported'
+  end
 end


### PR DESCRIPTION
Fixes #1776 

The fix deduplicates discovered files using File.realpath while retaining the first logical path. The same filtering is applied to the live-server watcher, preventing the alternate path from being rediscovered later.