### PR TITLE
Use inherited documentation when checking alias parameter coverage

### DIFF
--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -468,7 +468,16 @@ class RDoc::Stats
 
     return 0, [] if params.empty?
 
-    document = parse method.comment
+    comment = method.comment
+
+    if comment.empty?
+      # An alias, or a method with a #see target, carries no comment of its
+      # own but inherits the documentation RDoc::MethodAttr#documented? uses.
+      inherited = method.is_alias_for || method.see
+      comment = inherited.comment if inherited
+    end
+
+    document = parse comment
 
     tts = document.accept @formatter
 

--- a/test/rdoc/rdoc_stats_test.rb
+++ b/test/rdoc/rdoc_stats_test.rb
@@ -664,6 +664,21 @@ m(a, b) { |c, d| ... }
     assert_equal %w[a], undoc
   end
 
+  def test_undoc_params_alias
+    method = RDoc::AnyMethod.new 'm'
+    method.params = '(a)'
+    method.comment = comment '+a+'
+
+    aliased = RDoc::AnyMethod.new 'n'
+    aliased.params = '(a)'
+    aliased.is_alias_for = method
+
+    total, undoc = @s.undoc_params aliased
+
+    assert_equal 1, total
+    assert_empty    undoc
+  end
+
   def test_undoc_params_block
     method = RDoc::AnyMethod.new 'm'
     method.params = '(&a)'


### PR DESCRIPTION
## Summary

Fixes #1567.

`rdoc -C1` lists the parameters of an aliased method as undocumented, even
though the alias inherits the original method's documentation. `rdoc -C` on the
same file already reports it as fully covered.

Given the file from the issue:

```ruby
##
# Instance methods

module InstanceMethods
  ##
  # Takes a +value+ or a +block+ and returns a value monad.

  def _ value = nil, &block
    # ...
  end

  alias value  _
  alias expect _
end
```

`rdoc -C1` reports:

```
The following items are not documented:
  Method:
    InstanceMethods#expect
      Undocumented params: value, block
    InstanceMethods#value
      Undocumented params: value, block

Methods:     3 (0 undocumented)
Parameters:  6 (4 undocumented)
```

`Methods: 3 (0 undocumented)` is the tell: the aliases already count as
documented, but their parameters do not.

`RDoc::MethodAttr#documented?` resolves inherited documentation through
`#is_alias_for` and `#see`, while `RDoc::Stats#undoc_params` parses
`method.comment` directly, which is empty for an alias, so every parameter comes
back undocumented.

## Changes

- `RDoc::Stats#undoc_params` falls back to the comment of `#is_alias_for` or
  `#see` when the method carries no comment of its own. A method with its own
  comment is unaffected, so the only behavior change is for objects
  `#documented?` already treats as documented.
- Regression test alongside the existing `test_undoc_params_*` cases.

## Testing

- `ruby -Ilib -Itest test/rdoc/rdoc_stats_test.rb -n /undoc_params/` — the new
  test fails without the fix (`<["a"]> was expected to be empty`) and passes
  with it.
- `rake normal_test` — 2520 tests, 6165 assertions, 0 failures, 0 errors.
- `bundle exec rubocop lib/rdoc/stats.rb test/rdoc/rdoc_stats_test.rb` — no
  offenses.
- `ruby -Ilib exe/rdoc -C1 --op /tmp/rdocout /tmp/rdoc_bug.rb` on the file above
  now reports `Parameters: 6 (0 undocumented)` and `100.00% documented`.