### PR TITLE
Fix Ruby parser to not create a class whose superclass references itself

### DIFF
--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -906,10 +906,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
         mod = owner.add_class(RDoc::NormalClass, name, superclass_name || superclass_expr || '::Object')
         mod.ignore if document_suppressed? && mod.in_files.empty?
       end
-      if superclass_name
+
+      # Superclass with the same full path and superclass for BasicObject are not allowed
+      if superclass_name && mod.full_name != superclass_full_path && mod.full_name != 'BasicObject'
         if superclass
           mod.superclass = superclass
-        elsif (mod.superclass.is_a?(String) || mod.superclass.name == 'Object') && mod.superclass != superclass_full_path
+        elsif mod.superclass.nil? || (mod.superclass.is_a?(String) || mod.superclass.name == 'Object') && mod.superclass != superclass_full_path
           mod.superclass = superclass_full_path
         end
       end

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -3023,6 +3023,29 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_match %r{:\d+: invalid RBS type signature: "\(String ->"}, err
   end
 
+  def test_nil_superclass_case
+    # Context#add_class will create a class with nil superclass when
+    # the class is a BasicObject, or a superclass has the same full_name as the class itself.
+    # Superclass overwrite should follow this rule.
+    util_parser <<~RUBY
+      class BasicObject < Super; end
+      class BasicObject < Super; end
+      class Foo < Foo; end
+      class Bar < Bar; end
+      class Bar < Super; end
+      module M
+        class Baz < Super; end
+        class Baz < Baz; end
+        class Baz < M::Baz; end
+      end
+    RUBY
+
+    assert_nil @store.find_class_named('BasicObject').superclass
+    assert_nil @store.find_class_named('Foo').superclass
+    assert_equal 'Super', @store.find_class_named('Bar').superclass
+    assert_equal 'Super', @store.find_class_named('M::Baz').superclass
+  end
+
   def util_parser(content)
     @parser = RDoc::Parser::Ruby.new @top_level, content, @options, @stats
     @parser.scan


### PR DESCRIPTION
Fixes #1781

`Context#add_class` will create a class with nil superclass in some case: BasicObject, superclass referencing itself.
Ruby parser should support handling class with nil superclass, and also superclass overwrite mechanism should also follow this rule.