### PR TITLE
Fix `Encoding::InvalidByteSequenceError` in Aliki on non-UTF-8 locales

### DIFF
--- a/lib/rdoc/generator/aliki.rb
+++ b/lib/rdoc/generator/aliki.rb
@@ -151,6 +151,10 @@ class RDoc::Generator::Aliki < RDoc::Generator::Darkfish
 
   private
 
+  def template_encoding
+    Encoding::UTF_8
+  end
+
   def build_class_module_entry(klass)
     type = case klass
            when RDoc::NormalClass then 'class'

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -599,7 +599,7 @@ class RDoc::Generator::Darkfish
   # used directly.
 
   def assemble_template(body_file)
-    body = body_file.read
+    body = body_file.read(encoding: template_encoding)
     return body if body =~ /<html/
 
     head_file = @template_dir + '_head.rhtml'
@@ -609,7 +609,7 @@ class RDoc::Generator::Darkfish
 
 <html lang="#{@options.locale&.name || 'en'}">
 <head>
-#{head_file.read}
+#{head_file.read(encoding: template_encoding)}
 
 #{body}
     TEMPLATE
@@ -693,7 +693,7 @@ class RDoc::Generator::Darkfish
       template = assemble_template file
       erbout = 'io'
     else
-      template = file.read
+      template = file.read(encoding: template_encoding)
       template = template.encode @options.encoding
 
       file_var = File.basename(file).sub(/\..*/, '')
@@ -804,6 +804,10 @@ class RDoc::Generator::Darkfish
   end
 
   private
+
+  def template_encoding
+    nil
+  end
 
   def nesting_namespaces_to_class_modules(klass)
     tree = {}

--- a/test/rdoc/generator/aliki_test.rb
+++ b/test/rdoc/generator/aliki_test.rb
@@ -266,4 +266,20 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
     content = File.binread('index.html')
     assert_include content, '<html lang="ja">'
   end
+
+  def test_generate_with_non_utf8_default_external_encoding
+    original_encoding = Encoding.default_external
+    begin
+      Encoding.default_external = Encoding::US_ASCII
+      @g.generate
+    ensure
+      Encoding.default_external = original_encoding
+    end
+
+    assert_file 'index.html'
+
+    content = File.read('index.html', encoding: Encoding::UTF_8)
+    assert content.valid_encoding?, 'index.html should be valid UTF-8'
+    refute content.ascii_only?, 'non-ASCII characters in the template should be kept'
+  end
 end


### PR DESCRIPTION
`RDoc::Generator::Darkfish` reads template files with `Encoding.default_external`. As a result, Aliki's templates, which contain non-ASCII characters such as emojis, raised `Encoding::InvalidByteSequenceError` when the external encoding was UTF-8, such as with `LANG=C`.

This adds a `#template_encoding` hook to `Generator::Darkfish` with a default value of `nil`, and lets `Generator::Aliki` override the hook with `Encoding::UTF_8`.

As a result, Aliki template files are always read with UTF-8.

Fixes #1574