### PR TITLE
Reduce memory allocations for RI and POT generators

### DIFF
--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -114,6 +114,17 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   end
 
   ##
+  # Current token stream.
+
+  def token_stream
+    unless options.store_method_source?
+      raise RDoc::Error, "method source for #{full_name} was not stored; set store_method_source? to true"
+    end
+
+    super
+  end
+
+  ##
   # Whether the method has a call-seq.
 
   def has_call_seq?

--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -138,9 +138,9 @@ class RDoc::MethodAttr
   # Prepends line numbers if +options.line_numbers+ is true.
 
   def markup_code
-    return '' if !@token_stream
+    return '' if !(tokens = token_stream)
 
-    src = RDoc::TokenStream.to_html @token_stream
+    src = RDoc::TokenStream.to_html tokens
 
     # dedent the source
     common_indent = src.length

--- a/lib/rdoc/generator/pot.rb
+++ b/lib/rdoc/generator/pot.rb
@@ -81,6 +81,8 @@ class RDoc::Generator::POT
     end
   end
 
+  def self.store_method_source? = false
+
   private
   def extract_messages
     extractor = MessageExtractor.new(@store)

--- a/lib/rdoc/generator/ri.rb
+++ b/lib/rdoc/generator/ri.rb
@@ -27,4 +27,5 @@ class RDoc::Generator::RI
     @store.save
   end
 
+  def self.store_method_source? = false
 end

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -1325,6 +1325,16 @@ Usage: #{opt.program_name} [options] [names...]
   end
 
   ##
+  # Returns whether syntax-highlighted method source should be stored.
+
+  #: () -> bool
+  def store_method_source?
+    return false if @coverage_report
+
+    !@generator.respond_to?(:store_method_source?) || @generator.store_method_source?
+  end
+
+  ##
   # Finds the template dir for +template+
 
   def template_dir_for(template)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -553,10 +553,28 @@ class RDoc::Parser::Ruby < RDoc::Parser
     comment_text
   end
 
-  # Returns syntax highlighted tokens of the given node
+  # Returns syntax-highlighted tokens for +node+, or an empty Array when
+  # method source storage is disabled.
 
   def syntax_highlighted_tokens(node)
+    return [] unless store_method_source?
+
     RDoc::Parser::RubyColorizer.partial_colorize(@content, node, @prism_tokens)
+  end
+
+  # Returns whether syntax-highlighted method source should be stored.
+  # Generators that do not render method source can disable its collection:
+  #
+  #   class RDoc::Generator::POT
+  #     def self.store_method_source? = false
+  #   end
+
+  private def store_method_source?
+    # Coverage reports inspect documentation metadata, not method bodies.
+    return false if @options.coverage_report
+
+    generator = @options.generator
+    !generator.respond_to?(:store_method_source?) || generator.store_method_source?
   end
 
   # Handles `public :foo, :bar` `private :foo, :bar` and `protected :foo, :bar`

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -557,24 +557,9 @@ class RDoc::Parser::Ruby < RDoc::Parser
   # method source storage is disabled.
 
   def syntax_highlighted_tokens(node)
-    return [] unless store_method_source?
+    return [] unless @options.store_method_source?
 
     RDoc::Parser::RubyColorizer.partial_colorize(@content, node, @prism_tokens)
-  end
-
-  # Returns whether syntax-highlighted method source should be stored.
-  # Generators that do not render method source can disable its collection:
-  #
-  #   class RDoc::Generator::POT
-  #     def self.store_method_source? = false
-  #   end
-
-  private def store_method_source?
-    # Coverage reports inspect documentation metadata, not method bodies.
-    return false if @options.coverage_report
-
-    generator = @options.generator
-    !generator.respond_to?(:store_method_source?) || generator.store_method_source?
   end
 
   # Handles `public :foo, :bar` `private :foo, :bar` and `protected :foo, :bar`

--- a/test/rdoc/code_object/any_method_test.rb
+++ b/test/rdoc/code_object/any_method_test.rb
@@ -152,6 +152,20 @@ each_line(foo)
     assert_equal '', @c2_a.markup_code
   end
 
+  def test_markup_code_raises_when_method_source_not_stored
+    @options.generator = RDoc::Generator::RI
+
+    error = assert_raise(RDoc::Error) { @c1_m.markup_code }
+    assert_equal 'method source for C1#m was not stored; set store_method_source? to true', error.message
+  end
+
+  def test_token_stream_raises_when_method_source_not_stored
+    @options.generator = RDoc::Generator::RI
+
+    error = assert_raise(RDoc::Error) { @c1_m.token_stream }
+    assert_equal 'method source for C1#m was not stored; set store_method_source? to true', error.message
+  end
+
   def test_param_seq_with_variable_expansion
     m = RDoc::AnyMethod.new 'method'
     m.parent = @c1

--- a/test/rdoc/parser/ruby_test.rb
+++ b/test/rdoc/parser/ruby_test.rb
@@ -2715,6 +2715,26 @@ class RDocParserRubyTest < RDoc::TestCase
     assert_equal(['          ', 'def', ' ', 'bar', "\n", '    ', 'baz', "\n", '  ', 'end'], bar.token_stream.map(&:text))
   end
 
+  def test_code_object_source_not_stored
+    generator = Class.new do
+      def self.store_method_source? = false
+    end
+    @options.generator = generator
+    @store.options.generator = generator
+
+    util_parser <<~RUBY
+      class Foo
+        def foo = 42
+      end
+    RUBY
+
+    method = @top_level.classes.first.method_list.first
+    error = assert_raise(RDoc::Error) { method.token_stream }
+    assert_equal 'method source for Foo#foo was not stored; set store_method_source? to true', error.message
+    error = assert_raise(RDoc::Error) { method.markup_code }
+    assert_equal 'method source for Foo#foo was not stored; set store_method_source? to true', error.message
+  end
+
   def test_markup_first_comment
     util_parser <<~RUBY
       # :markup: rd


### PR DESCRIPTION
Each documented method currently retains an array of `RDoc::Parser::RubyColorizer::ColoredToken` objects and their fragmented source strings.

This data is unnecessary for:

- RI, whose serialized method representation excludes token_stream
- POT, which extracts translatable documentation comments
- Coverage reports, which generate no method-source pages

Large generated SDKs can contain millions of tokens. Avoiding those allocations substantially reduces parsing time and memory without changing generated output.


## Implementation

Generators can declare whether they require method source:
```ruby
class RDoc::Generator::RI
  def self.store_method_source? = false
end
```

```ruby
class RDoc::Generator::POT
  def self.store_method_source? = false
end
```

The Ruby parser checks that capability before syntax highlighting a method body.

Generators without the capability default to true, preserving compatibility with existing third-party generators.

This also allows third-party generators (like rdoc-markdown) to skip this costly process if they don't have need for `method.token_stream` or `method.markup_code`.  

If `store_method_source?` was disabled, but `token_stream` was still accessed, an error will be raised. 

## Benchmark
Here is a code that was used for benchmark this fix:
https://github.com/skatkov/rdoc-store-method-source-benchmark

RDoc 8.0.0 and `google-api-client` 0.53.0 on Ruby 4.0.6:

| Variant | Parse RSS | Peak RSS | Colored tokens | Live heap slots | Time |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline | 1,069.4 MiB | 1,508.4 MiB | 3,900,930 | 10,031,484 | 61.72s |
| Optimized | 463.6 MiB | 730.0 MiB | 0 | 2,229,446 | 51.62s |

- Parse RSS reduction: 56.6%
- Peak RSS reduction: 51.6%
- Generated RI output: identical
 