### PR TITLE
POT serialization optimization (with 87% improvement)

### DIFF
--- a/lib/rdoc/generator/pot/po.rb
+++ b/lib/rdoc/generator/pot/po.rb
@@ -27,12 +27,7 @@ class RDoc::Generator::POT::PO
   # Returns PO format text for the PO.
 
   def to_s
-    po = ''
-    sort_entries.each do |entry|
-      po += "\n" unless po.empty?
-      po += entry.to_s
-    end
-    po
+    sort_entries.map(&:to_s).join("\n")
   end
 
   private


### PR DESCRIPTION
String#+ creates a new string and copies everything accumulated so far. Repeating that for tens of thousands of entries is quadratic.

I replaced the repeated concatenation with one join.

Benchmark results for a 400-file build have significantly improved:

- Before: 104.29s
- After: 13.21s
- Improvement: 87.3%

Output in both cases is identical

## Benchmark
Created git repo with the benchmark at [rdoc-pot-serialization-benchmark](https://github.com/skatkov/rdoc-pot-serialization-benchmark).

- bin/benchmark: isolated serialization, up to **566x faster**
- bin/benchmark-google: end-to-end, 201.73s → 18.32s, identical output, up to **11x faster**