### PR TITLE
Ban redundant `then` keyword via RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,12 @@ Lint/UnreachableCode:
 
 Style/MethodDefParentheses:
   Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/MultilineWhenThen:
+  Enabled: true
+
+Style/MultilineInPatternThen:
+  Enabled: true

--- a/exe/rdoc
+++ b/exe/rdoc
@@ -25,11 +25,11 @@ rescue Errno::ENOSPC
 rescue SystemExit
   raise
 rescue Exception => e
-  if $DEBUG_RDOC then
+  if $DEBUG_RDOC
     $stderr.puts e.message
     $stderr.puts "#{e.backtrace.join "\n\t"}"
     $stderr.puts
-  elsif Interrupt === e then
+  elsif Interrupt === e
     $stderr.puts
     $stderr.puts 'Interrupted'
   else

--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -134,12 +134,12 @@ class RDoc::CodeObject
                when NilClass               then ''
                when RDoc::Comment          then comment.normalize
                else
-                 if comment and not comment.empty? then
+                 if comment and not comment.empty?
                    normalize_comment comment
                  else
                    # HACK correct fix is to have #initialize create @comment
                    #      with the correct encoding
-                   if String === @comment and @comment.empty? then
+                   if String === @comment and @comment.empty?
                      @comment = RDoc::Encoding.change_encoding @comment, comment.encoding
                    end
                    @comment
@@ -289,7 +289,7 @@ class RDoc::CodeObject
     return @parent if @parent
     return nil unless @parent_name
 
-    if @parent_class == RDoc::TopLevel then
+    if @parent_class == RDoc::TopLevel
       @parent = @store.add_file @parent_name
     else
       @parent = @store.find_class_or_module @parent_name
@@ -361,7 +361,7 @@ class RDoc::CodeObject
 
     return unless @track_visibility
 
-    if :nodoc == options.visibility then
+    if :nodoc == options.visibility
       initialize_visibility
       @track_visibility = false
     end

--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -81,9 +81,9 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # Use this for displaying a method's argument lists.
 
   def arglists
-    if @call_seq then
+    if @call_seq
       @call_seq
-    elsif @params then
+    elsif @params
       "#{name}#{param_seq}"
     end
   end
@@ -126,9 +126,9 @@ class RDoc::AnyMethod < RDoc::MethodAttr
 
   def is_alias_for # :nodoc:
     case @is_alias_for
-    when RDoc::MethodAttr then
+    when RDoc::MethodAttr
       @is_alias_for
-    when Array then
+    when Array
       return nil unless @store
 
       klass_name, singleton, method_name = @is_alias_for
@@ -214,7 +214,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       add_alias RDoc::Alias.new(@name, new_name, RDoc::Comment.from_document(document), singleton: @singleton)
     end
 
-    @parent_name ||= if @full_name =~ /#/ then
+    @parent_name ||= if @full_name =~ /#/
                        $`
                      else
                        name = @full_name.split('::')
@@ -244,21 +244,21 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # are preferred over parsed method and block params.
 
   def param_list
-    if @call_seq then
+    if @call_seq
       params = @call_seq.split("\n").last
       params = params.sub(/.*?\((.*)\)/, '\1')
       params = params.sub(/(\{|do)\s*\|([^|]*)\|.*/, ',\2')
-    elsif @params then
+    elsif @params
       params = @params.sub(/\((.*)\)/, '\1')
 
       params << ",#{@block_params}" if @block_params
-    elsif @block_params then
+    elsif @block_params
       params = @block_params
     else
       return []
     end
 
-    if @block_params then
+    if @block_params
       # If this method has explicit block parameters, remove any explicit
       # &block
       params = params.sub(/,?\s*&\w+/, '')
@@ -276,11 +276,11 @@ class RDoc::AnyMethod < RDoc::MethodAttr
   # given by +call-seq+ it is preferred over the parsed values.
 
   def param_seq
-    if @call_seq then
+    if @call_seq
       params = @call_seq.split("\n").last
       params = params.sub(/[^( ]+/, '')
       params = params.sub(/(\|[^|]+\|)\s*\.\.\.\s*(end|\})/, '\1 \2')
-    elsif @params then
+    elsif @params
       params = @params.gsub(/\s*\#.*/, '')
       params = params.tr_s("\n ", " ")
       params = "(#{params})" unless params[0] == ?(
@@ -288,7 +288,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
       params = ''
     end
 
-    if @block_params then
+    if @block_params
       # If this method has explicit block parameters, remove any explicit
       # &block
       params = params.sub(/,?\s*&\w+/, '')
@@ -328,7 +328,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     return @superclass_method if @superclass_method
 
     parent.each_ancestor do |ancestor|
-      if method = ancestor.method_list.find { |m| m.name == @name } then
+      if method = ancestor.method_list.find { |m| m.name == @name }
         @superclass_method = method
         break
       end

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -153,7 +153,7 @@ class RDoc::Attr < RDoc::MethodAttr
 
   def pretty_print(q) # :nodoc:
     q.group 2, "[#{self.class.name} #{full_name} #{rw} #{visibility}", "]" do
-      unless comment.empty? then
+      unless comment.empty?
         q.breakable
         q.text "comment:"
         q.breakable

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -139,7 +139,7 @@ class RDoc::ClassModule < RDoc::Context
     original = comment
 
     comment = case comment
-              when RDoc::Comment then
+              when RDoc::Comment
                 comment.normalize
               else
                 normalize_comment comment
@@ -229,7 +229,7 @@ class RDoc::ClassModule < RDoc::Context
 
   def comment=(comment) # :nodoc:
     comment = case comment
-              when RDoc::Comment then
+              when RDoc::Comment
                 comment.normalize
               else
                 normalize_comment comment
@@ -314,7 +314,7 @@ class RDoc::ClassModule < RDoc::Context
   # Return the fully qualified name of this class or module
 
   def full_name
-    @full_name ||= if RDoc::ClassModule === parent then
+    @full_name ||= if RDoc::ClassModule === parent
                      "#{parent.full_name}::#{@name}"
                    else
                      @name
@@ -427,7 +427,7 @@ class RDoc::ClassModule < RDoc::Context
 
     array[6].each do |constant, document, file|
       case constant
-      when RDoc::Constant then
+      when RDoc::Constant
         add_constant constant
       else
         constant = add_constant RDoc::Constant.new(constant, nil, RDoc::Comment.from_document(document))
@@ -485,7 +485,7 @@ class RDoc::ClassModule < RDoc::Context
 
     other_document = parse class_module.comment_location
 
-    if other_document then
+    if other_document
       document = parse @comment_location
 
       document = document.merge other_document
@@ -503,7 +503,7 @@ class RDoc::ClassModule < RDoc::Context
     other_files = cm.in_files
 
     merge_collections attributes, cm.attributes, other_files do |add, attr|
-      if add then
+      if add
         add_attribute attr
       else
         @attributes.delete attr
@@ -512,7 +512,7 @@ class RDoc::ClassModule < RDoc::Context
     end
 
     merge_collections constants, cm.constants, other_files do |add, const|
-      if add then
+      if add
         add_constant const
       else
         @constants.delete const
@@ -521,7 +521,7 @@ class RDoc::ClassModule < RDoc::Context
     end
 
     merge_collections includes, cm.includes, other_files do |add, incl|
-      if add then
+      if add
         add_include incl
       else
         @includes.delete incl
@@ -531,7 +531,7 @@ class RDoc::ClassModule < RDoc::Context
     @includes.uniq! # clean up
 
     merge_collections extends, cm.extends, other_files do |add, ext|
-      if add then
+      if add
         add_extend ext
       else
         @extends.delete ext
@@ -541,7 +541,7 @@ class RDoc::ClassModule < RDoc::Context
     @extends.uniq! # clean up
 
     merge_collections method_list, cm.method_list, other_files do |add, meth|
-      if add then
+      if add
         add_method meth
       else
         @method_list.delete meth
@@ -562,7 +562,7 @@ class RDoc::ClassModule < RDoc::Context
   # item to be added or removed.
   #
   #   merge_collections things, other.things, other.in_files do |add, thing|
-  #     if add then
+  #     if add
   #       # add the thing
   #     else
   #       # remove the thing
@@ -602,7 +602,7 @@ class RDoc::ClassModule < RDoc::Context
           other_files = other_section.in_files
 
           merge_collections my_comments, other_comments, other_files do |add, comment|
-            if add then
+            if add
               my_section.add_comment comment
             else
               my_section.remove_comment comment
@@ -639,9 +639,9 @@ class RDoc::ClassModule < RDoc::Context
 
   def parse(comment_location)
     case comment_location
-    when String then
+    when String
       super
-    when Hash then
+    when Hash
       docs = comment_location.flat_map do |location, comments|
         comments.map do |comment|
           doc = super comment
@@ -651,11 +651,11 @@ class RDoc::ClassModule < RDoc::Context
       end
 
       RDoc::Markup::Document.new(*docs)
-    when RDoc::Comment then
+    when RDoc::Comment
       doc = super comment_location.text, comment_location.format
       doc.file = comment_location.location
       doc
-    when RDoc::Markup::Document then
+    when RDoc::Markup::Document
       return comment_location
     else
       raise ArgumentError, "unknown comment class #{comment_location.class}"
@@ -827,7 +827,7 @@ class RDoc::ClassModule < RDoc::Context
   end
 
   def to_s # :nodoc:
-    if is_alias_for then
+    if is_alias_for
       "#{self.class.name} #{self.full_name} -> #{is_alias_for}"
     else
       super
@@ -895,7 +895,7 @@ class RDoc::ClassModule < RDoc::Context
       cm_alias.aliases.clear
       cm_alias.is_alias_for = cm
 
-      if cm.module? then
+      if cm.module?
         @store.modules_hash[cm_alias.full_name] = cm_alias
         modules_hash[const.name] = cm_alias
       else

--- a/lib/rdoc/code_object/constant.rb
+++ b/lib/rdoc/code_object/constant.rb
@@ -76,7 +76,7 @@ class RDoc::Constant < RDoc::CodeObject
     return true if super
     return false unless @is_alias_for
     case @is_alias_for
-    when String then
+    when String
       found = @store.find_class_or_module @is_alias_for
       return false unless found
       @is_alias_for = found
@@ -99,7 +99,7 @@ class RDoc::Constant < RDoc::CodeObject
 
   def is_alias_for
     case @is_alias_for
-    when String then
+    when String
       found = @store.find_class_or_module @is_alias_for
       @is_alias_for = found if found
       @is_alias_for
@@ -191,7 +191,7 @@ class RDoc::Constant < RDoc::CodeObject
 
   def pretty_print(q) # :nodoc:
     q.group 2, "[#{self.class.name} #{full_name}", "]" do
-      unless comment.empty? then
+      unless comment.empty?
         q.breakable
         q.text "comment:"
         q.breakable

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -181,10 +181,10 @@ class RDoc::Context < RDoc::CodeObject
   # Currently only RDoc::Extend and RDoc::Include are supported.
 
   def add(klass, name, comment)
-    if RDoc::Extend == klass then
+    if RDoc::Extend == klass
       ext = RDoc::Extend.new name, comment
       add_extend ext
-    elsif RDoc::Include == klass then
+    elsif RDoc::Include == klass
       incl = RDoc::Include.new name, comment
       add_include incl
     else
@@ -201,7 +201,7 @@ class RDoc::Context < RDoc::CodeObject
     method_attr = find_method(an_alias.old_name, an_alias.singleton) ||
                   find_attribute(an_alias.old_name, an_alias.singleton)
 
-    if method_attr then
+    if method_attr
       method_attr.add_alias an_alias, self
     else
       add_to @external_aliases, an_alias
@@ -231,14 +231,14 @@ class RDoc::Context < RDoc::CodeObject
 
     key = nil
 
-    if attribute.rw.index 'R' then
+    if attribute.rw.index 'R'
       key = attribute.pretty_name
       known = @methods_hash[key]
 
-      if known then
+      if known
         known.comment = attribute.comment if known.comment.empty?
       elsif registered = @methods_hash[attribute.pretty_name + '='] and
-            RDoc::Attr === registered then
+            RDoc::Attr === registered
         registered.rw = 'RW'
       else
         @methods_hash[key] = attribute
@@ -246,14 +246,14 @@ class RDoc::Context < RDoc::CodeObject
       end
     end
 
-    if attribute.rw.index 'W' then
+    if attribute.rw.index 'W'
       key = attribute.pretty_name + '='
       known = @methods_hash[key]
 
-      if known then
+      if known
         known.comment = attribute.comment if known.comment.empty?
       elsif registered = @methods_hash[attribute.pretty_name] and
-            RDoc::Attr === registered then
+            RDoc::Attr === registered
         registered.rw = 'RW'
       else
         @methods_hash[key] = attribute
@@ -261,7 +261,7 @@ class RDoc::Context < RDoc::CodeObject
       end
     end
 
-    if register then
+    if register
       attribute.visibility = @visibility
       add_to @attributes, attribute
       resolve_aliases attribute
@@ -295,19 +295,19 @@ class RDoc::Context < RDoc::CodeObject
     # superclass, we must honor it.
 
     # find the name & enclosing context
-    if given_name =~ /^:+(\w+)$/ then
+    if given_name =~ /^:+(\w+)$/
       full_name = $1
       enclosing = top_level
       name = full_name.split(/:+/).last
     else
       full_name = child_name given_name
 
-      if full_name =~ /^(.+)::(\w+)$/ then
+      if full_name =~ /^(.+)::(\w+)$/
         name = $2
         ename = $1
         enclosing = @store.classes_hash[ename] || @store.modules_hash[ename]
         # HACK: crashes in actionpack/lib/action_view/helpers/form_helper.rb (metaprogramming)
-        unless enclosing then
+        unless enclosing
           # try the given name at top level (will work for the above example)
           enclosing = @store.classes_hash[given_name] ||
                       @store.modules_hash[given_name]
@@ -322,18 +322,18 @@ class RDoc::Context < RDoc::CodeObject
     end
 
     # fix up superclass
-    if full_name == 'BasicObject' then
+    if full_name == 'BasicObject'
       superclass = nil
-    elsif full_name == 'Object' then
+    elsif full_name == 'Object'
       superclass = '::BasicObject'
     end
 
     # find the superclass full name
-    if superclass then
-      if superclass =~ /^:+/ then
+    if superclass
+      if superclass =~ /^:+/
         superclass = $' #'
       else
-        if superclass =~ /^(\w+):+(.+)$/ then
+        if superclass =~ /^(\w+):+(.+)$/
           suffix = $2
           mod = find_module_named($1)
           superclass = mod.full_name + '::' + suffix if mod
@@ -354,16 +354,16 @@ class RDoc::Context < RDoc::CodeObject
 
     klass = @store.classes_hash[full_name]
 
-    if klass then
+    if klass
       # if TopLevel, it may not be registered in the classes:
       enclosing.classes_hash[name] = klass
 
       # update the superclass if needed
-      if superclass then
+      if superclass
         existing = klass.superclass
         existing = existing.full_name unless existing.is_a?(String) if existing
         if existing.nil? ||
-           (existing == 'Object' && superclass != 'Object') then
+           (existing == 'Object' && superclass != 'Object')
           klass.superclass = superclass
         end
       end
@@ -371,7 +371,7 @@ class RDoc::Context < RDoc::CodeObject
       # this is a new class
       mod = @store.modules_hash.delete full_name
 
-      if mod then
+      if mod
         klass = upgrade_to_class mod, RDoc::NormalClass, enclosing
 
         klass.superclass = superclass unless superclass.nil?
@@ -402,7 +402,7 @@ class RDoc::Context < RDoc::CodeObject
     mod.full_name = nil
     mod.store = @store
 
-    unless @done_documenting then
+    unless @done_documenting
       self_hash[mod.name] = mod
       # this must be done AFTER adding mod to its parent, so that the full
       # name is correct:
@@ -423,7 +423,7 @@ class RDoc::Context < RDoc::CodeObject
     # (this is a #ifdef: should be handled by the C parser)
     known = @constants_hash[constant.name]
 
-    if known then
+    if known
       known.comment = constant.comment if known.comment.empty?
 
       known.value = constant.value if
@@ -468,8 +468,8 @@ class RDoc::Context < RDoc::CodeObject
     key = method.pretty_name
     known = @methods_hash[key]
 
-    if known then
-      if @store then # otherwise we are loading
+    if known
+      if @store # otherwise we are loading
         known.comment = method.comment if known.comment.empty?
         previously = ", previously in #{known.file}" unless
           method.file == known.file
@@ -564,7 +564,7 @@ class RDoc::Context < RDoc::CodeObject
     new_to.full_name = nil
     new_to.is_alias_for = from
 
-    if new_to.module? then
+    if new_to.module?
       @store.modules_hash[to_full_name] = new_to
       @modules[to.name] = new_to
     else
@@ -588,7 +588,7 @@ class RDoc::Context < RDoc::CodeObject
   def add_require(require)
     return require unless @document_self
 
-    if RDoc::TopLevel === self then
+    if RDoc::TopLevel === self
       add_to @requires, require
     else
       parent.add_require require
@@ -604,7 +604,7 @@ class RDoc::Context < RDoc::CodeObject
   # See also RDoc::Context::Section
 
   def add_section(title, comment = nil)
-    if section = @sections[title] then
+    if section = @sections[title]
       section.add_comment comment if comment
     else
       section = Section.new self, title, comment, @store
@@ -652,7 +652,7 @@ class RDoc::Context < RDoc::CodeObject
   def child_name(name)
     if name =~ /^:+/
       $'  #'
-    elsif RDoc::TopLevel === self then
+    elsif RDoc::TopLevel === self
       name
     else
       "#{self.full_name}::#{name}"
@@ -692,7 +692,7 @@ class RDoc::Context < RDoc::CodeObject
   # temporary_section is available it will be used.
 
   def current_section
-    if section = @temporary_section then
+    if section = @temporary_section
       @temporary_section = nil
     else
       section = @current_section
@@ -772,9 +772,9 @@ class RDoc::Context < RDoc::CodeObject
 
   def find_attribute_named(name)
     case name
-    when /\A#/ then
+    when /\A#/
       find_attribute name[1..-1], false
-    when /\A::/ then
+    when /\A::/
       find_attribute name[2..-1], true
     else
       @attributes.find { |a| a.name == name }
@@ -819,9 +819,9 @@ class RDoc::Context < RDoc::CodeObject
 
   def find_external_alias_named(name)
     case name
-    when /\A#/ then
+    when /\A#/
       find_external_alias name[1..-1], false
-    when /\A::/ then
+    when /\A::/
       find_external_alias name[2..-1], true
     else
       @external_aliases.find { |a| a.name == name }
@@ -866,9 +866,9 @@ class RDoc::Context < RDoc::CodeObject
 
   def find_method_named(name)
     case name
-    when /\A#/ then
+    when /\A#/
       find_method name[1..-1], false
-    when /\A::/ then
+    when /\A::/
       find_method name[2..-1], true
     else
       @method_list.find { |meth| meth.name == name }
@@ -908,7 +908,7 @@ class RDoc::Context < RDoc::CodeObject
 
     # look for a class or module 'symbol'
     case symbol
-    when /^::/ then
+    when /^::/
       result = @store.find_class_or_module symbol
     when /^(\w+):+(.+)$/
       suffix = $2
@@ -1082,7 +1082,7 @@ class RDoc::Context < RDoc::CodeObject
   # Only called when min_visibility == :public or :private
 
   def remove_invisible_in(array, min_visibility) # :nodoc:
-    if min_visibility == :public then
+    if min_visibility == :public
       array.reject! { |e|
         e.visibility != :public and not e.force_documentation
       }
@@ -1182,7 +1182,7 @@ class RDoc::Context < RDoc::CodeObject
 
     if titles.length > 1 and
        TOMDOC_TITLES_SORT ==
-         (titles | TOMDOC_TITLES).sort_by { |title| title.to_s } then
+         (titles | TOMDOC_TITLES).sort_by { |title| title.to_s }
       @sections.values_at(*TOMDOC_TITLES).compact
     else
       @sections.sort_by { |title, _|

--- a/lib/rdoc/code_object/method_attr.rb
+++ b/lib/rdoc/code_object/method_attr.rb
@@ -260,7 +260,7 @@ class RDoc::MethodAttr < RDoc::CodeObject
       case $2
       when 'to_s'      then $1
       when 'const_get' then 'const'
-      when 'new' then
+      when 'new'
         $1.split('::').last.  # ClassName => class_name
           gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
           gsub(/([a-z\d])([A-Z])/, '\1_\2').
@@ -298,9 +298,9 @@ class RDoc::MethodAttr < RDoc::CodeObject
 
   def inspect # :nodoc:
     alias_for =
-      if @is_alias_for.respond_to? :name then
+      if @is_alias_for.respond_to? :name
         " (alias for #{@is_alias_for.name})"
-      elsif Array === @is_alias_for then
+      elsif Array === @is_alias_for
         " (alias for #{@is_alias_for.last})"
       end
     visibility = self.visibility
@@ -350,19 +350,19 @@ class RDoc::MethodAttr < RDoc::CodeObject
 
   def pretty_print(q) # :nodoc:
     alias_for =
-      if @is_alias_for.respond_to? :name then
+      if @is_alias_for.respond_to? :name
         "alias for #{@is_alias_for.name}"
-      elsif Array === @is_alias_for then
+      elsif Array === @is_alias_for
         "alias for #{@is_alias_for.last}"
       end
 
     q.group 2, "[#{self.class.name} #{full_name} #{visibility}", "]" do
-      if alias_for then
+      if alias_for
         q.breakable
         q.text alias_for
       end
 
-      unless comment.empty? then
+      unless comment.empty?
         q.breakable
         q.text "comment:"
         q.breakable

--- a/lib/rdoc/code_object/require.rb
+++ b/lib/rdoc/code_object/require.rb
@@ -39,7 +39,7 @@ class RDoc::Require < RDoc::CodeObject
     @top_level ||= begin
       tl = RDoc::TopLevel.all_files_hash[name + '.rb']
 
-      if tl.nil? and RDoc::TopLevel.all_files.first.full_name =~ %r(^lib/) then
+      if tl.nil? and RDoc::TopLevel.all_files.first.full_name =~ %r(^lib/)
         # second chance
         tl = RDoc::TopLevel.all_files_hash['lib/' + name + '.rb']
       end

--- a/lib/rdoc/cross_reference.rb
+++ b/lib/rdoc/cross_reference.rb
@@ -144,10 +144,10 @@ class RDoc::CrossReference
     container = nil
 
     case name
-    when /#{CLASS_REGEXP_STR}::([A-Z]\w*)\z/o then
+    when /#{CLASS_REGEXP_STR}::([A-Z]\w*)\z/o
       symbol = $2
       container = @context.find_symbol_module($1)
-    when /#{CLASS_REGEXP_STR}([.#]|::)#{METHOD_REGEXP_STR}/o then
+    when /#{CLASS_REGEXP_STR}([.#]|::)#{METHOD_REGEXP_STR}/o
       type = $2
       if '.' == type # will find either #method or ::method
         symbol = $3
@@ -155,7 +155,7 @@ class RDoc::CrossReference
         symbol = "#{type}#{$3}"
       end
       container = @context.find_symbol_module($1)
-    when /^([.#]|::)#{METHOD_REGEXP_STR}/o then
+    when /^([.#]|::)#{METHOD_REGEXP_STR}/o
       type = $1
       if '.' == type
         symbol = $2
@@ -165,10 +165,10 @@ class RDoc::CrossReference
       container = @context
     end
 
-    if container then
-      unless RDoc::TopLevel === container then
-        if '.' == type then
-          if 'new' == symbol then # AnyClassName.new will be class method
+    if container
+      unless RDoc::TopLevel === container
+        if '.' == type
+          if 'new' == symbol # AnyClassName.new will be class method
             ref = container.find_local_symbol symbol
             ref = container.find_ancestor_local_symbol symbol unless ref
           else

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -42,9 +42,9 @@ module RDoc::Encoding
       encoding ||= Encoding.default_external
       orig_encoding = content.encoding
 
-      if not orig_encoding.ascii_compatible? then
+      if not orig_encoding.ascii_compatible?
         content = content.encode encoding
-      elsif utf8 then
+      elsif utf8
         content = RDoc::Encoding.change_encoding content, Encoding::UTF_8
         content = content.encode encoding
       else
@@ -52,19 +52,19 @@ module RDoc::Encoding
         content = RDoc::Encoding.change_encoding content, encoding
       end
 
-      unless content.valid_encoding? then
+      unless content.valid_encoding?
         # revert and try to transcode
         content = RDoc::Encoding.change_encoding content, orig_encoding
         content = content.encode encoding
       end
 
-      unless content.valid_encoding? then
+      unless content.valid_encoding?
         warn "unable to convert #{filename} to #{encoding}, skipping"
         content = nil
       end
     rescue Encoding::InvalidByteSequenceError,
            Encoding::UndefinedConversionError => e
-      if force_transcode then
+      if force_transcode
         content = RDoc::Encoding.change_encoding content, orig_encoding
         content = content.encode(encoding,
                                  :invalid => :replace,

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -241,7 +241,7 @@ class RDoc::Generator::Darkfish
     fu_options = { :verbose => $DEBUG_RDOC, :noop => @dry_run }
 
     @options.static_path.each do |path|
-      unless File.directory? path then
+      unless File.directory? path
         FileUtils.install path, @outputdir, **fu_options.merge(:mode => 0644)
         next
       end
@@ -250,7 +250,7 @@ class RDoc::Generator::Darkfish
         Dir[File.join('**', '*')].each do |entry|
           dest_file = @outputdir + entry
 
-          if File.directory? entry then
+          if File.directory? entry
             FileUtils.mkdir_p entry, **fu_options
           else
             FileUtils.install entry, dest_file, **fu_options.merge(:mode => 0644)
@@ -390,7 +390,7 @@ class RDoc::Generator::Darkfish
 
       next if file.text? && file.full_name == @options.main_page
 
-      if file.text? and page_file.exist? then
+      if file.text? and page_file.exist?
         generate_page file
         next
       end
@@ -404,8 +404,8 @@ class RDoc::Generator::Darkfish
 
       asset_rel_prefix = rel_prefix + @asset_rel_path
 
-      unless filepage_file then
-        if file.text? then
+      unless filepage_file
+        if file.text?
           next unless page_file.exist?
           template_file = page_file
           @title = file.page_name
@@ -643,7 +643,7 @@ class RDoc::Generator::Darkfish
 
     template = template_for template_file, true, erb_klass
 
-    if io_output then
+    if io_output
       debug_msg "Outputting to %s" % [out_file.expand_path]
 
       out_file.dirname.mkpath
@@ -689,7 +689,7 @@ class RDoc::Generator::Darkfish
 
     return template if template
 
-    if page then
+    if page
       template = assemble_template file
       erbout = 'io'
     else

--- a/lib/rdoc/generator/markup.rb
+++ b/lib/rdoc/generator/markup.rb
@@ -56,7 +56,7 @@ module RDoc::Generator::Markup
   # will replace the %s using sprintf on the +url+.
 
   def cvs_url(url, full_path)
-    if /%s/ =~ url then
+    if /%s/ =~ url
       sprintf url, full_path
     else
       url + full_path
@@ -186,7 +186,7 @@ class RDoc::TopLevel
   def cvs_url
     url = @store.options.webcvs
 
-    if /%s/ =~ url then
+    if /%s/ =~ url
       url % @relative_name
     else
       url + @relative_name

--- a/lib/rdoc/markup.rb
+++ b/lib/rdoc/markup.rb
@@ -171,7 +171,7 @@ https://github.com/ruby/rdoc/issues
 
   def convert(input, formatter)
     document = case input
-               when RDoc::Markup::Document then
+               when RDoc::Markup::Document
                  input
                else
                  RDoc::Markup::Parser.parse input

--- a/lib/rdoc/markup/document.rb
+++ b/lib/rdoc/markup/document.rb
@@ -39,12 +39,12 @@ class RDoc::Markup::Document
 
   def <<(part)
     case part
-    when RDoc::Markup::Document then
-      unless part.empty? then
+    when RDoc::Markup::Document
+      unless part.empty?
         parts.concat part.parts
         parts << RDoc::Markup::BlankLine.new
       end
-    when String then
+    when String
       raise ArgumentError,
             "expected RDoc::Markup::Document and friends, got String" unless
         part.empty?
@@ -96,7 +96,7 @@ class RDoc::Markup::Document
 
   def file=(location)
     @file = case location
-            when RDoc::TopLevel then
+            when RDoc::TopLevel
               location.relative_name
             else
               location
@@ -112,7 +112,7 @@ class RDoc::Markup::Document
   # The information in +other+ is preferred over the receiver
 
   def merge(other)
-    if empty? then
+    if empty?
       @parts = other.parts
       return self
     end

--- a/lib/rdoc/markup/formatter.rb
+++ b/lib/rdoc/markup/formatter.rb
@@ -53,7 +53,7 @@ class RDoc::Markup::Formatter
   def accept_document(document)
     document.parts.each do |item|
       case item
-      when RDoc::Markup::Document then # HACK
+      when RDoc::Markup::Document # HACK
         accept_document item
       else
         item.accept self
@@ -250,22 +250,22 @@ class RDoc::Markup::Formatter
 
   def parse_url(url)
     case url
-    when /^rdoc-label:([^:]*)(?::(.*))?/ then
+    when /^rdoc-label:([^:]*)(?::(.*))?/
       scheme = 'link'
       path   = "##{$1}"
       id     = " id=\"#{$2}\"" if $2
-    when /([A-Za-z]+):(.*)/ then
+    when /([A-Za-z]+):(.*)/
       scheme = $1.downcase
       path   = $2
-    when /^#/ then
+    when /^#/
     else
       scheme = 'http'
       path   = url
       url    = url
     end
 
-    if scheme == 'link' then
-      url = if path[0, 1] == '#' then # is this meaningful?
+    if scheme == 'link'
+      url = if path[0, 1] == '#' # is this meaningful?
               path
             else
               self.class.gen_relative_url @from_path, path

--- a/lib/rdoc/markup/indented_paragraph.rb
+++ b/lib/rdoc/markup/indented_paragraph.rb
@@ -36,7 +36,7 @@ class RDoc::Markup::IndentedParagraph < RDoc::Markup::Raw
 
   def text(hard_break = nil)
     @parts.map do |part|
-      if RDoc::Markup::HardBreak === part then
+      if RDoc::Markup::HardBreak === part
         '%1$s%3$*2$s' % [hard_break, @indent, ' '] if hard_break
       else
         part

--- a/lib/rdoc/markup/paragraph.rb
+++ b/lib/rdoc/markup/paragraph.rb
@@ -17,7 +17,7 @@ class RDoc::Markup::Paragraph < RDoc::Markup::Raw
 
   def text(hard_break = '')
     @parts.map do |part|
-      if RDoc::Markup::HardBreak === part then
+      if RDoc::Markup::HardBreak === part
         hard_break
       else
         part

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -91,7 +91,7 @@ class RDoc::Markup::Parser
     type, text, = get
 
     text = case type
-           when :TEXT then
+           when :TEXT
              skip :NEWLINE
              text
            else
@@ -115,8 +115,8 @@ class RDoc::Markup::Parser
       type, data, column, = get
 
       case type
-      when *LIST_TOKENS then
-        if column < margin || (list.type && list.type != type) then
+      when *LIST_TOKENS
+        if column < margin || (list.type && list.type != type)
           unget
           break
         end
@@ -125,10 +125,10 @@ class RDoc::Markup::Parser
         peek_type, _, column, = peek_token
 
         case type
-        when :NOTE, :LABEL then
+        when :NOTE, :LABEL
           label = [] unless label
 
-          if peek_type == :NEWLINE then
+          if peek_type == :NEWLINE
             # description not on the same line as LABEL/NOTE
             # skip the trailing newline & any blank lines below
             while peek_type == :NEWLINE
@@ -149,9 +149,9 @@ class RDoc::Markup::Parser
             #       [two]
             # In all cases, we have an empty description.
             # In the last case only, we continue.
-            if peek_type.nil? || column < margin then
+            if peek_type.nil? || column < margin
               empty = true
-            elsif column == margin then
+            elsif column == margin
               case peek_type
               when type
                 empty = :continue
@@ -164,7 +164,7 @@ class RDoc::Markup::Parser
               empty = false
             end
 
-            if empty then
+            if empty
               label << data
               next if empty == :continue
               break
@@ -174,7 +174,7 @@ class RDoc::Markup::Parser
           data = nil
         end
 
-        if label then
+        if label
           data = label << data
           label = nil
         end
@@ -191,7 +191,7 @@ class RDoc::Markup::Parser
 
     p :list_end => margin if @debug
 
-    if list.empty? then
+    if list.empty?
       return nil unless label
       return nil unless [:LABEL, :NOTE].include? list.type
 
@@ -213,7 +213,7 @@ class RDoc::Markup::Parser
     until @tokens.empty? do
       type, data, column, = get
 
-      if type == :TEXT and column == margin then
+      if type == :TEXT and column == margin
         paragraph << data
 
         break if peek_token.first == :BREAK
@@ -251,7 +251,7 @@ class RDoc::Markup::Parser
     until @tokens.empty? do
       type, data, column, = get
 
-      if type == :NEWLINE then
+      if type == :NEWLINE
         line << data
         verbatim << line
         line = ''.dup
@@ -264,7 +264,7 @@ class RDoc::Markup::Parser
         break
       end
 
-      if generate_leading_spaces then
+      if generate_leading_spaces
         indent = column - margin
         line << ' ' * indent
         min_indent = indent if min_indent.nil? || indent < min_indent
@@ -272,22 +272,22 @@ class RDoc::Markup::Parser
       end
 
       case type
-      when :HEADER then
+      when :HEADER
         line << '=' * data
         _, _, peek_column, = peek_token
         peek_column ||= column + data
         indent = peek_column - column - data
         line << ' ' * indent
-      when :RULE then
+      when :RULE
         width = 2 + data
         line << '-' * width
         _, _, peek_column, = peek_token
         peek_column ||= column + width
         indent = peek_column - column - width
         line << ' ' * indent
-      when :BREAK, :TEXT then
+      when :BREAK, :TEXT
         line << data
-      when :BLOCKQUOTE then
+      when :BLOCKQUOTE
         line << '>>>'
         peek_type, _, peek_column = peek_token
         if peek_type != :NEWLINE and peek_column
@@ -303,7 +303,7 @@ class RDoc::Markup::Parser
                       end
         line << list_marker
         peek_type, _, peek_column = peek_token
-        unless peek_type == :NEWLINE then
+        unless peek_type == :NEWLINE
           peek_column ||= column + list_marker.length
           indent = peek_column - column - list_marker.length
           line << ' ' * indent
@@ -346,11 +346,11 @@ class RDoc::Markup::Parser
       type, data, column, = get
 
       case type
-      when :BREAK then
+      when :BREAK
         parent << RDoc::Markup::BlankLine.new
         skip :NEWLINE, false
         next
-      when :NEWLINE then
+      when :NEWLINE
         # trailing newlines are skipped below, so this is a blank line
         parent << RDoc::Markup::BlankLine.new
         skip :NEWLINE, false
@@ -358,10 +358,10 @@ class RDoc::Markup::Parser
       end
 
       # indentation change: break or verbatim
-      if column < indent then
+      if column < indent
         unget
         break
-      elsif column > indent then
+      elsif column > indent
         unget
         parent << build_verbatim(indent)
         next
@@ -369,15 +369,15 @@ class RDoc::Markup::Parser
 
       # indentation is the same
       case type
-      when :HEADER then
+      when :HEADER
         parent << build_heading(data)
-      when :RULE then
+      when :RULE
         parent << RDoc::Markup::Rule.new(data)
         skip :NEWLINE
-      when :TEXT then
+      when :TEXT
         unget
         parse_text parent, indent
-      when :BLOCKQUOTE then
+      when :BLOCKQUOTE
         nil while (type, = get; type) and type != :NEWLINE
         _, _, column, = peek_token
         bq = RDoc::Markup::BlockQuote.new
@@ -385,7 +385,7 @@ class RDoc::Markup::Parser
         parse bq, column
         p :blockquote_end => indent if @debug
         parent << bq
-      when *LIST_TOKENS then
+      when *LIST_TOKENS
         unget
         parent << build_list(indent)
       else
@@ -500,16 +500,16 @@ class RDoc::Markup::Parser
 
       @tokens << case
                  # [CR]LF => :NEWLINE
-                 when @s.scan(/\r?\n/) then
+                 when @s.scan(/\r?\n/)
                    token = [:NEWLINE, @s.matched, *pos]
                    @s.newline!
                    token
                  # === text => :HEADER then :TEXT
-                 when @s.scan(/(=+)(\s*)/) then
+                 when @s.scan(/(=+)(\s*)/)
                    level = @s[1].length
                    header = [:HEADER, level, *pos]
 
-                   if @s[2] =~ /^\r?\n/ then
+                   if @s[2] =~ /^\r?\n/
                      @s.unscan(@s[2])
                      header
                    else
@@ -519,14 +519,14 @@ class RDoc::Markup::Parser
                      [:TEXT, @s.matched.sub(/\r$/, ''), *pos]
                    end
                  # --- (at least 3) and nothing else on the line => :RULE
-                 when @s.scan(/(-{3,}) *\r?$/) then
+                 when @s.scan(/(-{3,}) *\r?$/)
                    [:RULE, @s[1].length - 2, *pos]
                  # * or - followed by white space and text => :BULLET
-                 when @s.scan(/([*-]) +(\S)/) then
+                 when @s.scan(/([*-]) +(\S)/)
                    @s.unscan(@s[2])
                    [:BULLET, @s[1], *pos]
                  # A. text, a. text, 12. text => :UALPHA, :LALPHA, :NUMBER
-                 when @s.scan(/([a-z]|\d+)\. +(\S)/i) then
+                 when @s.scan(/([a-z]|\d+)\. +(\S)/i)
                    # FIXME if tab(s), the column will be wrong
                    # either support tabs everywhere by first expanding them to
                    # spaces, or assume that they will have been replaced
@@ -544,13 +544,13 @@ class RDoc::Markup::Parser
                      end
                    [list_type, list_label, *pos]
                  # [text] followed by spaces or end of line => :LABEL
-                 when @s.scan(/\[(.*?)\]( +|\r?$)/) then
+                 when @s.scan(/\[(.*?)\]( +|\r?$)/)
                    [:LABEL, @s[1], *pos]
                  # text:: followed by spaces or end of line => :NOTE
-                 when @s.scan(/(.*?)::( +|\r?$)/) then
+                 when @s.scan(/(.*?)::( +|\r?$)/)
                    [:NOTE, @s[1], *pos]
                  # >>> followed by end of line => :BLOCKQUOTE
-                 when @s.scan(/>>> *(\w+)?$/) then
+                 when @s.scan(/>>> *(\w+)?$/)
                    if word = @s[1]
                      @s.unscan(word)
                    end
@@ -560,7 +560,7 @@ class RDoc::Markup::Parser
                    @s.scan(/(.*?)(  )?\r?$/)
                    token = [:TEXT, @s[1], *pos]
 
-                   if @s[2] then
+                   if @s[2]
                      @tokens << token
                      [:BREAK, @s[2], pos[0] + @s[1].length, pos[1]]
                    else

--- a/lib/rdoc/markup/pre_process.rb
+++ b/lib/rdoc/markup/pre_process.rb
@@ -97,7 +97,7 @@ class RDoc::Markup::PreProcess
   # RDoc::CodeObject#metadata for details.
 
   def handle(text, code_object = nil, &block)
-    if RDoc::Comment === text then
+    if RDoc::Comment === text
       comment = text
       text = text.text
     end
@@ -114,7 +114,7 @@ class RDoc::Markup::PreProcess
 
       # This is not in handle_directive because I didn't want to pass another
       # argument into it
-      if comment and $3 == 'markup' then
+      if comment and $3 == 'markup'
         next "#{$1.strip}\n" unless $5
         comment.format = $5.downcase
         next "#{$1.strip}\n"
@@ -122,7 +122,7 @@ class RDoc::Markup::PreProcess
       handle_directive $1, $3, $5, code_object, text.encoding, &block
     end
 
-    if comment then
+    if comment
       comment.text = text
     else
       comment = text
@@ -180,61 +180,61 @@ class RDoc::Markup::PreProcess
     directive = directive.downcase
 
     case directive
-    when 'arg', 'args' then
+    when 'arg', 'args'
       return "#{prefix}:#{directive}: #{param}\n" unless code_object && code_object.kind_of?(RDoc::AnyMethod)
 
       code_object.params = param
 
       blankline
-    when 'category' then
-      if RDoc::Context === code_object then
+    when 'category'
+      if RDoc::Context === code_object
         section = code_object.add_section param
         code_object.temporary_section = section
-      elsif RDoc::AnyMethod === code_object then
+      elsif RDoc::AnyMethod === code_object
         code_object.section_title = param
       end
 
       blankline # ignore category if we're not on an RDoc::Context
-    when 'doc' then
+    when 'doc'
       return blankline unless code_object
       code_object.document_self = true
       code_object.force_documentation = true
 
       blankline
-    when 'enddoc' then
+    when 'enddoc'
       return blankline unless code_object
       code_object.done_documenting = true
 
       blankline
-    when 'include' then
+    when 'include'
       filename = param.split(' ', 2).first
       include_file filename, prefix, encoding
-    when 'nodoc' then
+    when 'nodoc'
       return blankline unless code_object
       code_object.document_self = nil # notify nodoc
       code_object.document_children = param !~ /all/i
 
       blankline
-    when 'notnew', 'not_new', 'not-new' then
+    when 'notnew', 'not_new', 'not-new'
       return blankline unless RDoc::AnyMethod === code_object
 
       code_object.dont_rename_initialize = true
 
       blankline
-    when 'startdoc' then
+    when 'startdoc'
       return blankline unless code_object
 
       code_object.start_doc
       code_object.force_documentation = true
 
       blankline
-    when 'stopdoc' then
+    when 'stopdoc'
       return blankline unless code_object
 
       code_object.stop_doc
 
       blankline
-    when 'yield', 'yields' then
+    when 'yield', 'yields'
       return blankline unless code_object
       # remove parameter &block
       code_object.params = code_object.params.sub(/,?\s*&\w+/, '') if code_object.params
@@ -246,16 +246,16 @@ class RDoc::Markup::PreProcess
       result = yield directive, param if block_given?
 
       case result
-      when nil then
+      when nil
         code_object.metadata[directive] = param if code_object
 
-        if RDoc::Markup::PreProcess.registered.include? directive then
+        if RDoc::Markup::PreProcess.registered.include? directive
           handler = RDoc::Markup::PreProcess.registered[directive]
           result = handler.call directive, param if handler
         else
           result = "#{prefix}:#{directive}: #{param}\n"
         end
-      when false then
+      when false
         result = "#{prefix}:#{directive}: #{param}\n"
       end
 
@@ -281,7 +281,7 @@ class RDoc::Markup::PreProcess
   def include_file(name, indent, encoding)
     full_name = find_include_file name
 
-    unless full_name then
+    unless full_name
       warn "Couldn't find file to include '#{name}' from #{@input_file_name}"
       return ''
     end
@@ -293,7 +293,7 @@ class RDoc::Markup::PreProcess
     content = content.sub(/\A# .*coding[=:].*$/, '').lstrip
 
     # strip leading '#'s, but only if all lines start with them
-    if content =~ /^[^#]/ then
+    if content =~ /^[^#]/
       content.gsub(/^/, indent)
     else
       content.gsub(/^#?/, indent)

--- a/lib/rdoc/markup/to_ansi.rb
+++ b/lib/rdoc/markup/to_ansi.rb
@@ -77,10 +77,10 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
 
   def accept_list_item_end(list_item)
     width = case @list_type.last
-            when :BULLET then
+            when :BULLET
               2
-            when :NOTE, :LABEL then
-              if @prefix then
+            when :NOTE, :LABEL
+              if @prefix
                 @res << @prefix.strip
                 @prefix = nil
               end
@@ -101,9 +101,9 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
 
   def accept_list_item_start(list_item)
     bullet = case @list_type.last
-             when :BULLET then
+             when :BULLET
                '*'
-             when :NOTE, :LABEL then
+             when :NOTE, :LABEL
                labels = Array(list_item.label).map do |label|
                  attributes(label).strip
                end.join "\n"
@@ -116,7 +116,7 @@ class RDoc::Markup::ToAnsi < RDoc::Markup::ToRdoc
              end
 
     case @list_type.last
-    when :NOTE, :LABEL then
+    when :NOTE, :LABEL
       @indent += 2
       @prefix = bullet + (' ' * @indent)
     else

--- a/lib/rdoc/markup/to_bs.rb
+++ b/lib/rdoc/markup/to_bs.rb
@@ -62,7 +62,7 @@ class RDoc::Markup::ToBs < RDoc::Markup::ToRdoc
     type = @list_type.last
 
     case type
-    when :NOTE, :LABEL then
+    when :NOTE, :LABEL
       bullets = Array(list_item.label).map do |label|
         attributes(label).strip
       end.join "\n"

--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -641,9 +641,9 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
   def list_item_start(list_item, list_type)
     case list_type
-    when :BULLET, :LALPHA, :NUMBER, :UALPHA then
+    when :BULLET, :LALPHA, :NUMBER, :UALPHA
       "<li>"
-    when :LABEL, :NOTE then
+    when :LABEL, :NOTE
       Array(list_item.label).map do |label|
         "<dt>#{to_html label}</dt>\n"
       end.join << "<dd>"
@@ -657,9 +657,9 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
 
   def list_end_for(list_type)
     case list_type
-    when :BULLET, :LALPHA, :NUMBER, :UALPHA then
+    when :BULLET, :LALPHA, :NUMBER, :UALPHA
       "</li>"
-    when :LABEL, :NOTE then
+    when :LABEL, :NOTE
       "</dd>"
     else
       raise RDoc::Error, "Invalid list type: #{list_type.inspect}"

--- a/lib/rdoc/markup/to_html_crossref.rb
+++ b/lib/rdoc/markup/to_html_crossref.rb
@@ -89,7 +89,7 @@ class RDoc::Markup::ToHtmlCrossref < RDoc::Markup::ToHtml
 
     return name if name =~ /@[\w-]+\.[\w-]/ # labels that look like emails
 
-    unless @hyperlink_all then
+    unless @hyperlink_all
       # This ensures that words entirely consisting of lowercase letters will
       # not have cross-references generated (to suppress lots of erroneous
       # cross-references to "new" in text, for instance)

--- a/lib/rdoc/markup/to_html_snippet.rb
+++ b/lib/rdoc/markup/to_html_snippet.rb
@@ -139,9 +139,9 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
     throw :done if @characters >= @character_limit
 
     case list_type
-    when :BULLET, :LALPHA, :NUMBER, :UALPHA then
+    when :BULLET, :LALPHA, :NUMBER, :UALPHA
       "<p>"
-    when :LABEL, :NOTE then
+    when :LABEL, :NOTE
       labels = Array(list_item.label).map do |label|
         to_html label
       end.join ', '
@@ -161,16 +161,16 @@ class RDoc::Markup::ToHtmlSnippet < RDoc::Markup::ToHtml
   # type.
 
   def gen_url(url, text)
-    if url =~ /^rdoc-label:([^:]*)(?::(.*))?/ then
+    if url =~ /^rdoc-label:([^:]*)(?::(.*))?/
       type = "link"
-    elsif url =~ /([A-Za-z]+):(.*)/ then
+    elsif url =~ /([A-Za-z]+):(.*)/
       type = $1
     else
       type = "http"
     end
 
     if (type == "http" or type == "https" or type == "link") and
-       url =~ /\.(gif|png|jpg|jpeg|bmp)$/ then
+       url =~ /\.(gif|png|jpg|jpeg|bmp)$/
       ''
     else
       text.sub(%r%^#{type}:/*%, '')

--- a/lib/rdoc/markup/to_markdown.rb
+++ b/lib/rdoc/markup/to_markdown.rb
@@ -36,9 +36,9 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
 
   def accept_list_item_end(list_item)
     width = case @list_type.last
-            when :BULLET then
+            when :BULLET
               4
-            when :NOTE, :LABEL then
+            when :NOTE, :LABEL
               use_prefix
 
               @res << "\n"
@@ -59,7 +59,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
     type = @list_type.last
 
     case type
-    when :NOTE, :LABEL then
+    when :NOTE, :LABEL
       bullets = Array(list_item.label).map do |label|
         attributes(label).strip
       end.join "\n"
@@ -99,7 +99,7 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
   end
 
   def handle_TIDYLINK(label_part, url)
-    if url =~ /^rdoc-label:foot/ then
+    if url =~ /^rdoc-label:foot/
       emit_inline(handle_rdoc_link(url))
     else
       emit_inline('[')
@@ -141,9 +141,9 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
 
   def accept_list_start(list)
     case list.type
-    when :BULLET, :LABEL, :NOTE then
+    when :BULLET, :LABEL, :NOTE
       @list_index << nil
-    when :LALPHA, :NUMBER, :UALPHA then
+    when :LALPHA, :NUMBER, :UALPHA
       @list_index << 1
     else
       raise RDoc::Error, "invalid list type #{list.type}"
@@ -190,17 +190,17 @@ class RDoc::Markup::ToMarkdown < RDoc::Markup::ToRdoc
 
   def handle_rdoc_link(url)
     case url
-    when /^rdoc-ref:/ then
+    when /^rdoc-ref:/
       $'
-    when /^rdoc-label:footmark-(\d+)/ then
+    when /^rdoc-label:footmark-(\d+)/
       "[^#{$1}]:"
-    when /^rdoc-label:foottext-(\d+)/ then
+    when /^rdoc-label:foottext-(\d+)/
       "[^#{$1}]"
-    when /^rdoc-label:label-/ then
+    when /^rdoc-label:label-/
       gen_url url, $'
-    when /^rdoc-image:/ then
+    when /^rdoc-image:/
       "![](#{$'})"
-    when /^rdoc-[a-z]+:/ then
+    when /^rdoc-[a-z]+:/
       $'
     end
   end

--- a/lib/rdoc/markup/to_rdoc.rb
+++ b/lib/rdoc/markup/to_rdoc.rb
@@ -109,10 +109,10 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
 
   def accept_list_item_end(list_item)
     width = case @list_type.last
-            when :BULLET then
+            when :BULLET
               2
-            when :NOTE, :LABEL then
-              if @prefix then
+            when :NOTE, :LABEL
+              if @prefix
                 @res << @prefix.strip
                 @prefix = nil
               end
@@ -135,7 +135,7 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
     type = @list_type.last
 
     case type
-    when :NOTE, :LABEL then
+    when :NOTE, :LABEL
       stripped_labels = Array(list_item.label).map do |label|
         attributes(label).strip
       end
@@ -166,19 +166,19 @@ class RDoc::Markup::ToRdoc < RDoc::Markup::Formatter
 
   def accept_list_start(list)
     case list.type
-    when :BULLET then
+    when :BULLET
       @list_index << nil
       @list_width << 1
-    when :LABEL, :NOTE then
+    when :LABEL, :NOTE
       @list_index << nil
       @list_width << 2
-    when :LALPHA then
+    when :LALPHA
       @list_index << 'a'
       @list_width << list.items.length.to_s.length
-    when :NUMBER then
+    when :NUMBER
       @list_index << 1
       @list_width << list.items.length.to_s.length
-    when :UALPHA then
+    when :UALPHA
       @list_index << 'A'
       @list_width << list.items.length.to_s.length
     else

--- a/lib/rdoc/markup/to_test.rb
+++ b/lib/rdoc/markup/to_test.rb
@@ -40,9 +40,9 @@ class RDoc::Markup::ToTest < RDoc::Markup::Formatter
 
   def accept_list_start(list)
     @list << case list.type
-             when :BULLET then
+             when :BULLET
                '*'
-             when :NUMBER then
+             when :NUMBER
                '1'
              else
                list.type

--- a/lib/rdoc/markup/to_tt_only.rb
+++ b/lib/rdoc/markup/to_tt_only.rb
@@ -41,7 +41,7 @@ class RDoc::Markup::ToTtOnly < RDoc::Markup::Formatter
 
   def accept_list_item_start(list_item)
     case @list_type.last
-    when :NOTE, :LABEL then
+    when :NOTE, :LABEL
       Array(list_item.label).map do |label|
         tt_sections label
       end.flatten

--- a/lib/rdoc/markup/verbatim.rb
+++ b/lib/rdoc/markup/verbatim.rb
@@ -36,7 +36,7 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
 
     @parts.each do |part|
       case part
-      when /^\s*\n/ then
+      when /^\s*\n/
         newlines += 1
         parts << part if newlines == 1
       else
@@ -54,7 +54,7 @@ class RDoc::Markup::Verbatim < RDoc::Markup::Raw
     self.class.name =~ /.*::(\w{1,4})/i
 
     q.group 2, "[#{$1.downcase}: ", ']' do
-      if @format then
+      if @format
         q.text "format: #{@format}"
         q.breakable
       end

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -546,8 +546,8 @@ class RDoc::Options
 
   def check_files
     @files.delete_if do |file|
-      if File.exist? file then
-        if File.readable? file then
+      if File.exist? file
+        if File.readable? file
           false
         else
           warn "file '#{file}' not readable"
@@ -566,7 +566,7 @@ class RDoc::Options
   # Ensure only one generator is loaded
 
   def check_generator
-    if @generator then
+    if @generator
       raise OptionParser::InvalidOption,
         "generator already set to #{@generator_name}"
     end
@@ -611,10 +611,10 @@ class RDoc::Options
   # Create a regexp for #exclude
 
   def exclude
-    if @exclude.nil? or Regexp === @exclude then
+    if @exclude.nil? or Regexp === @exclude
       # done, #finish is being re-run
       @exclude
-    elsif !@apply_default_exclude and @exclude.empty? then
+    elsif !@apply_default_exclude and @exclude.empty?
       nil
     else
       exclude = @exclude
@@ -629,7 +629,7 @@ class RDoc::Options
   # #template.
 
   def finish
-    if @write_options then
+    if @write_options
       write_options
       exit
     end
@@ -650,7 +650,7 @@ class RDoc::Options
     # If no template was specified, use the default template for the output
     # formatter
 
-    unless @template then
+    unless @template
       @template     = @generator_name
       @template_dir = template_dir_for @template
     end
@@ -703,7 +703,7 @@ class RDoc::Options
     longest = lengths.max
 
     generators.sort.map do |name, description|
-      if description then
+      if description
         "  %-*s - %s" % [longest, name, description]
       else
         "  #{name}"
@@ -767,7 +767,7 @@ Usage: #{opt.program_name} [options] [names...]
       opt.accept Template do |template|
         template_dir = template_dir_for template
 
-        unless template_dir then
+        unless template_dir
           $stderr.puts "could not find template #{template}"
           nil
         else
@@ -792,7 +792,7 @@ Usage: #{opt.program_name} [options] [names...]
       end
 
       opt.accept PathArray do |paths,|
-        paths = if paths then
+        paths = if paths
                   paths.split(',').map { |d| d unless d.empty? }
                 end
 
@@ -865,11 +865,11 @@ Usage: #{opt.program_name} [options] [names...]
              "cause xxx.cgi to be parsed as a Ruby file.") do |value|
         new, old = value.split(/=/, 2)
 
-        unless new and old then
+        unless new and old
           raise OptionParser::InvalidArgument, "Invalid parameter to '-E'"
         end
 
-        unless RDoc::Parser.alias_extension old, new then
+        unless RDoc::Parser.alias_extension old, new
           raise OptionParser::InvalidArgument, "Unknown extension .#{old} to -E"
         end
       end
@@ -1223,7 +1223,7 @@ Usage: #{opt.program_name} [options] [names...]
     begin
       opts.parse! argv
     rescue OptionParser::ParseError => e
-      if %w[--format --ri -r --ri-site -R].include? e.args.first then
+      if %w[--format --ri -r --ri-site -R].include? e.args.first
         raise
       else
         invalid << e.args.join(' ')
@@ -1234,21 +1234,21 @@ Usage: #{opt.program_name} [options] [names...]
 
     setup_generator unless @generator
 
-    if @pipe and not argv.empty? then
+    if @pipe and not argv.empty?
       @pipe = false
       invalid << '-p (with files)'
     end
 
-    unless invalid.empty? then
+    unless invalid.empty?
       invalid = "invalid options: #{invalid.join ', '}"
 
-      if ignore_invalid then
-        unless quiet then
+      if ignore_invalid
+        unless quiet
           $stderr.puts invalid
           $stderr.puts '(invalid options are ignored)'
         end
       else
-        unless quiet then
+        unless quiet
           $stderr.puts opts
         end
         $stderr.puts invalid
@@ -1308,7 +1308,7 @@ Usage: #{opt.program_name} [options] [names...]
   def setup_generator(generator_name = @generator_name)
     @generator = @generators[generator_name]
 
-    unless @generator then
+    unless @generator
       raise OptionParser::InvalidArgument,
             "Invalid output formatter #{generator_name}"
     end
@@ -1318,7 +1318,7 @@ Usage: #{opt.program_name} [options] [names...]
     @generator_name = generator_name
     @generator_options << @generator
 
-    if @generator.respond_to? :setup_options then
+    if @generator.respond_to? :setup_options
       @option_parser ||= OptionParser.new
       @generator.setup_options self
     end

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -124,9 +124,9 @@ class RDoc::Parser
     ext_name = File.extname file_name
     return parser if ext_name.empty?
 
-    if parser == RDoc::Parser::Simple and ext_name !~ /txt|rdoc/ then
+    if parser == RDoc::Parser::Simple and ext_name !~ /txt|rdoc/
       case mode = check_modeline(file_name)
-      when nil, 'rdoc' then # continue
+      when nil, 'rdoc' # continue
       else
         RDoc::Parser.parsers.find { |_, p| return p if mode.casecmp?(p.name[/\w+\z/]) }
         return nil
@@ -149,7 +149,7 @@ class RDoc::Parser
 
     return nil unless type = $1
 
-    if /;/ =~ type then
+    if /;/ =~ type
       return nil unless /(?:\s|\A)mode:\s*([^\s;]+)/i =~ type
       type = $1
     end
@@ -172,11 +172,11 @@ class RDoc::Parser
 
     parser = use_markup content
 
-    unless parser then
+    unless parser
       parse_name = file_name
 
       # If no extension, look for shebang
-      if file_name !~ /\.\w+$/ && content =~ %r{\A#!(.+)} then
+      if file_name !~ /\.\w+$/ && content =~ %r{\A#!(.+)}
         shebang = $1
         case shebang
         when %r{env\s+ruby}, %r{/ruby}

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -227,7 +227,7 @@ class RDoc::Parser::C < RDoc::Parser
                    \s*\)/xm) do |var_name, new_name, old_name|
       class_name = @known_classes[var_name]
 
-      unless class_name then
+      unless class_name
         @options.warn "Enclosing class or module %p for alias %s %s is not known" % [
           var_name, new_name, old_name]
         next
@@ -540,7 +540,7 @@ class RDoc::Parser::C < RDoc::Parser
   def find_attr_comment(var_name, attr_name, read = nil, write = nil)
     attr_name = Regexp.escape attr_name
 
-    rw = if read and write then
+    rw = if read and write
            /\s*#{read}\s*,\s*#{write}\s*/xm
          else
            /.*?/m
@@ -549,16 +549,16 @@ class RDoc::Parser::C < RDoc::Parser
     comment = if @content =~ %r%((?>/\*.*?\*/\s+))
                                 rb_define_attr\((?:\s*#{var_name},)?\s*
                                                 "#{attr_name}"\s*,
-                                                #{rw}\)\s*;%xm then
+                                                #{rw}\)\s*;%xm
                 $1
               elsif @content =~ %r%((?>/\*.*?\*/\s+))
                                    rb_attr\(\s*#{var_name}\s*,
                                             \s*#{attr_name}\s*,
-                                            #{rw},.*?\)\s*;%xm then
+                                            #{rw},.*?\)\s*;%xm
                 $1
               elsif @content =~ %r%(/\*.*?(?:\s*\*\s*)?)
                                    Document-attr:\s#{attr_name}\s*?\n
-                                   ((?>(.|\n)*?\*/))%x then
+                                   ((?>(.|\n)*?\*/))%x
                 "#{$1}\n#{$2}"
               else
                 ''
@@ -658,7 +658,7 @@ class RDoc::Parser::C < RDoc::Parser
     else # No body, but might still have an override comment
       comment = find_override_comment class_name, meth_obj
 
-      if comment then
+      if comment
         find_modifiers comment, meth_obj
         meth_obj.comment = comment
 
@@ -722,16 +722,16 @@ class RDoc::Parser::C < RDoc::Parser
         ((?>/\*.*?\*/\s+))
         (static\s+)?
         void\s+
-        Init(?:VM)?_(?i:#{class_name})\s*(?:_\(\s*)?\(\s*(?:void\s*)?\)%xm then
+        Init(?:VM)?_(?i:#{class_name})\s*(?:_\(\s*)?\(\s*(?:void\s*)?\)%xm
       comment = $1.sub(%r%Document-(?:class|module):\s+#{class_name}%, '')
     elsif @content =~ %r%Document-(?:class|module):\s+#{class_name}\s*?
-                         (?:<\s+[:,\w]+)?\n((?>.*?\*/))%xm then
+                         (?:<\s+[:,\w]+)?\n((?>.*?\*/))%xm
       comment = "/*\n#{$1}"
     elsif @content =~ %r%((?>/\*.*?\*/\s+))
-                         ([\w\.\s]+\s* = \s+)?rb_define_(class|module)[\t (]*?"(#{class_name})"%xm then
+                         ([\w\.\s]+\s* = \s+)?rb_define_(class|module)[\t (]*?"(#{class_name})"%xm
       comment = $1
     elsif @content =~ %r%((?>/\*.*?\*/\s+))
-                         ([\w\. \t]+ = \s+)?rb_define_(class|module)_under[\t\w, (]*?"(#{class_name.split('::').last})"%xm then
+                         ([\w\. \t]+ = \s+)?rb_define_(class|module)_under[\t\w, (]*?"(#{class_name.split('::').last})"%xm
       comment = $1
     else
       comment = ''
@@ -814,10 +814,10 @@ class RDoc::Parser::C < RDoc::Parser
 
     comment = if @content =~ %r%Document-method:
                                 \s+#{class_name}#{prefix}#{name}
-                                \s*?\n((?>.*?\*/))%xm then
+                                \s*?\n((?>.*?\*/))%xm
                 "/*\n#{$1}"
               elsif @content =~ %r%Document-method:
-                                   \s#{name}\s*?\n((?>.*?\*/))%xm then
+                                   \s#{name}\s*?\n((?>.*?\*/))%xm
                 "/*\n#{$1}"
               end
 
@@ -862,16 +862,16 @@ class RDoc::Parser::C < RDoc::Parser
   def handle_class_module(var_name, type, class_name, parent, in_module)
     parent_name = @known_classes[parent] || parent
 
-    if in_module then
+    if in_module
       enclosure = @classes[in_module] || @store.find_c_enclosure(in_module)
 
-      if enclosure.nil? and enclosure = @known_classes[in_module] then
+      if enclosure.nil? and enclosure = @known_classes[in_module]
         enc_type = /^rb_m/ =~ in_module ? :module : :class
         handle_class_module in_module, enc_type, enclosure, nil, nil
         enclosure = @classes[in_module]
       end
 
-      unless enclosure then
+      unless enclosure
         @enclosure_dependencies[in_module] << var_name
         @missing_dependencies[var_name] =
           [var_name, type, class_name, parent, in_module]
@@ -882,14 +882,14 @@ class RDoc::Parser::C < RDoc::Parser
       enclosure = @top_level
     end
 
-    if type == :class then
-      full_name = if RDoc::ClassModule === enclosure then
+    if type == :class
+      full_name = if RDoc::ClassModule === enclosure
                     enclosure.full_name + "::#{class_name}"
                   else
                     class_name
                   end
 
-      if @content =~ %r%Document-class:\s+#{full_name}\s*<\s+([:,\w]+)% then
+      if @content =~ %r%Document-class:\s+#{full_name}\s*<\s+([:,\w]+)%
         parent_name = $1
       end
 
@@ -932,7 +932,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     class_obj = find_class var_name, class_name, class_name[/::\K[^:]+\z/]
 
-    unless class_obj then
+    unless class_obj
       @options.warn 'Enclosing class or module %p is not known' % [const_name]
       return
     end
@@ -943,7 +943,7 @@ class RDoc::Parser::C < RDoc::Parser
     # In the case of rb_define_const, the definition and comment are in
     # "/* definition: comment */" form.  The literal ':' and '\' characters
     # can be escaped with a backslash.
-    if type.downcase == 'const' then
+    if type.downcase == 'const'
       if /\A(.+?)?:(?!\S)/ =~ comment.text
         new_definition, new_comment = $1, $'
 
@@ -999,8 +999,8 @@ class RDoc::Parser::C < RDoc::Parser
       add_alias(var_name, class_obj, existing_method.name, meth_name, existing_method.comment, singleton: singleton)
     end
 
-    if class_obj then
-      if meth_name == 'initialize' then
+    if class_obj
+      if meth_name == 'initialize'
         meth_name = 'new'
         singleton = true
         type = 'method' # force public
@@ -1011,10 +1011,10 @@ class RDoc::Parser::C < RDoc::Parser
 
       p_count = Integer(param_count) rescue -1
 
-      if source_file then
+      if source_file
         file_name = File.join @file_dir, source_file
 
-        if File.exist? file_name then
+        if File.exist? file_name
           file_content = RDoc::Encoding.read_file file_name, @options.encoding
         else
           @options.warn "unknown source #{source_file} for #{meth_name} in #{@file_name}"
@@ -1025,10 +1025,10 @@ class RDoc::Parser::C < RDoc::Parser
 
       body = find_body class_name, function, meth_obj, file_content
 
-      if body and meth_obj.document_self then
-        meth_obj.params = if p_count < -1 then # -2 is Array
+      if body and meth_obj.document_self
+        meth_obj.params = if p_count < -1 # -2 is Array
                             '(*args)'
-                          elsif p_count == -1 then # argc, argv
+                          elsif p_count == -1 # argc, argv
                             rb_scan_args body
                           else
                             args = (1..p_count).map { |i| "p#{i}" }
@@ -1075,7 +1075,7 @@ class RDoc::Parser::C < RDoc::Parser
     name_map.each do |variable, name|
       next unless mod = @store.find_class_or_module(name)
 
-      class_map[variable] = if map_name == :c_class_variables then
+      class_map[variable] = if map_name == :c_class_variables
                               mod
                             else
                               name
@@ -1116,13 +1116,13 @@ class RDoc::Parser::C < RDoc::Parser
 
     lead = opt = trail = 0
 
-    if format.first =~ /\d/ then
+    if format.first =~ /\d/
       lead = $&.to_i
       format.shift
-      if format.first =~ /\d/ then
+      if format.first =~ /\d/
         opt = $&.to_i
         format.shift
-        if format.first =~ /\d/ then
+        if format.first =~ /\d/
           trail = $&.to_i
           format.shift
           block_arg = true
@@ -1130,21 +1130,21 @@ class RDoc::Parser::C < RDoc::Parser
       end
     end
 
-    if format.first == '*' and not block_arg then
+    if format.first == '*' and not block_arg
       var = true
       format.shift
-      if format.first =~ /\d/ then
+      if format.first =~ /\d/
         trail = $&.to_i
         format.shift
       end
     end
 
-    if format.first == ':' then
+    if format.first == ':'
       hash = true
       format.shift
     end
 
-    if format.first == '&' then
+    if format.first == '&'
       block = true
       format.shift
     end
@@ -1166,7 +1166,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     position += opt
 
-    if var then
+    if var
       args << '*args'
       position += 1
     end
@@ -1177,7 +1177,7 @@ class RDoc::Parser::C < RDoc::Parser
 
     position += trail
 
-    if hash then
+    if hash
       args << "p#{position} = {}"
     end
 

--- a/lib/rdoc/parser/changelog.rb
+++ b/lib/rdoc/parser/changelog.rb
@@ -26,12 +26,12 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
   def continue_entry_body(entry_body, continuation)
     return unless last = entry_body.last
 
-    if last =~ /\)\s*\z/ and continuation =~ /\A\(/ then
+    if last =~ /\)\s*\z/ and continuation =~ /\A\(/
       last.sub!(/\)\s*\z/, ',')
       continuation = continuation.sub(/\A\(/, '')
     end
 
-    if last =~ /\s\z/ then
+    if last =~ /\s\z/
       last << continuation
     else
       last << ' ' + continuation
@@ -161,9 +161,9 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
 
     @content.each_line do |line|
       case line
-      when /^\s*$/ then
+      when /^\s*$/
         next
-      when /^\w.*/ then
+      when /^\w.*/
         entries << [entry_name, entry_body] if entry_name
 
         entry_name = $&
@@ -176,17 +176,17 @@ class RDoc::Parser::ChangeLog < RDoc::Parser
         end
 
         entry_body = []
-      when /^(\t| {8})?\*\s*(.*)/ then # "\t* file.c (func): ..."
+      when /^(\t| {8})?\*\s*(.*)/ # "\t* file.c (func): ..."
         entry_body << $2.dup
-      when /^(\t| {8})?\s*(\(.*)/ then # "\t(func): ..."
+      when /^(\t| {8})?\s*(\(.*)/ # "\t(func): ..."
         entry = $2
 
-        if entry_body.last =~ /:/ then
+        if entry_body.last =~ /:/
           entry_body << entry.dup
         else
           continue_entry_body entry_body, entry
         end
-      when /^(\t| {8})?\s*(.*)/ then
+      when /^(\t| {8})?\s*(.*)/
         continue_entry_body entry_body, $2
       end
     end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -240,7 +240,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
   def record_location(container) # :nodoc:
     case container
-    when RDoc::ClassModule then
+    when RDoc::ClassModule
       @top_level.add_to_classes_or_modules container
     end
 
@@ -577,9 +577,9 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
     new_methods.each do |method|
       case method
-      when RDoc::AnyMethod then
+      when RDoc::AnyMethod
         @container.add_method(method)
-      when RDoc::Attr then
+      when RDoc::Attr
         @container.add_attribute(method)
       end
       method.visibility = visibility
@@ -603,9 +603,9 @@ class RDoc::Parser::Ruby < RDoc::Parser
     end
     new_methods.each do |method|
       case method
-      when RDoc::AnyMethod then
+      when RDoc::AnyMethod
         @container.add_method(method)
-      when RDoc::Attr then
+      when RDoc::Attr
         @container.add_attribute(method)
       end
       method.visibility = :public

--- a/lib/rdoc/rd.rb
+++ b/lib/rdoc/rd.rb
@@ -78,7 +78,7 @@ class RDoc::RD
   def self.parse(rd)
     rd = rd.lines.to_a
 
-    if rd.find { |i| /\S/ === i } and !rd.find{|i| /^=begin\b/ === i } then
+    if rd.find { |i| /\S/ === i } and !rd.find{|i| /^=begin\b/ === i }
       rd.unshift("=begin\n").push("=end\n")
     end
 

--- a/lib/rdoc/rd/inline.rb
+++ b/lib/rdoc/rd/inline.rb
@@ -21,7 +21,7 @@ class RDoc::RD::Inline
   # will use the text from +rdoc+.
 
   def self.new(rdoc, reference = rdoc)
-    if self === rdoc and reference.equal? rdoc then
+    if self === rdoc and reference.equal? rdoc
       rdoc
     else
       super
@@ -49,10 +49,10 @@ class RDoc::RD::Inline
 
   def append(more)
     case more
-    when String then
+    when String
       @reference += more
       @rdoc      += more
-    when RDoc::RD::Inline then
+    when RDoc::RD::Inline
       @reference += more.reference
       @rdoc      += more.rdoc
     else

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -173,14 +173,14 @@ class RDoc::RDoc
 
     last = {}
 
-    if @options.dry_run then
+    if @options.dry_run
       # do nothing
-    elsif File.exist? dir then
+    elsif File.exist? dir
       error "#{dir} exists and is not a directory" unless File.directory? dir
 
       begin
         File.open flag_file do |io|
-          unless force then
+          unless force
             Time.parse io.gets
 
             io.each do |line|
@@ -275,14 +275,14 @@ option)
       stat = File.stat rel_file_name rescue next
 
       case type = stat.ftype
-      when "file" then
+      when "file"
         mtime = (stat.mtime unless (last_modified = @last_modified[rel_file_name] and
                                     stat.mtime.to_i <= last_modified.to_i))
 
-        if force_doc or RDoc::Parser.can_parse(rel_file_name) then
+        if force_doc or RDoc::Parser.can_parse(rel_file_name)
           file_list[rel_file_name] = mtime
         end
-      when "directory" then
+      when "directory"
         next if UNCONDITIONALLY_SKIPPED_DIRECTORIES.include?(rel_file_name)
 
         basename = File.basename(rel_file_name)
@@ -293,7 +293,7 @@ option)
 
         dot_doc = File.join rel_file_name, RDoc::DOT_DOC_FILENAME
 
-        if File.file? dot_doc then
+        if File.file? dot_doc
           file_list.update(parse_dot_doc_file(rel_file_name, dot_doc))
         else
           file_list.update(list_files_in_directory(rel_file_name))
@@ -480,7 +480,7 @@ The internal error was:
   # current directory, so make sure you're somewhere writable before invoking.
 
   def document(options)
-    if RDoc::Options === options then
+    if RDoc::Options === options
       @options = options
     else
       @options = RDoc::Options.load_options
@@ -490,7 +490,7 @@ The internal error was:
 
     @store = RDoc::Store.new(@options)
 
-    if @options.pipe then
+    if @options.pipe
       handle_pipe
       exit
     end
@@ -510,7 +510,7 @@ The internal error was:
       exit
     end
 
-    unless @options.coverage_report then
+    unless @options.coverage_report
       @last_modified = setup_output_dir @options.op_dir, @options.force_update
     end
 
@@ -537,11 +537,11 @@ The internal error was:
 
     @stats.coverage_level = @options.coverage_report
 
-    if @options.coverage_report then
+    if @options.coverage_report
       puts
 
       puts @stats.report
-    elsif file_info.empty? && !auto_discovered_rbs_signatures_changed then
+    elsif file_info.empty? && !auto_discovered_rbs_signatures_changed
       $stderr.puts "\nNo newer files." unless @options.quiet
     else
       gen_klass = @options.generator
@@ -551,7 +551,7 @@ The internal error was:
       generate
     end
 
-    if @stats and (@options.coverage_report or not @options.quiet) then
+    if @stats and (@options.coverage_report or not @options.quiet)
       puts
       puts @stats.summary
     end
@@ -565,12 +565,12 @@ The internal error was:
   # by the RDoc options
 
   def generate
-    if @options.dry_run then
+    if @options.dry_run
       # do nothing
       @generator.generate
     else
       Dir.chdir @options.op_dir do
-        unless @options.quiet then
+        unless @options.quiet
           $stderr.puts "\nGenerating #{@generator.class.name.sub(/^.*::/, '')} format into #{Dir.pwd}..."
           uri = "file://#{Dir.pwd}/index.html"
           ref = $stderr.tty? ? "\e]8;;#{uri}\e\\#{uri}\e]8;;\e\\" : uri

--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -283,7 +283,7 @@ or the PAGER environment variable.
              "documentation in addition to the standard",
              "directories.  May be repeated.") do |value|
         value.each do |dir|
-          unless File.directory? dir then
+          unless File.directory? dir
             raise OptionParser::InvalidArgument, "#{dir} is not a directory"
           end
 
@@ -387,7 +387,7 @@ or the PAGER environment variable.
   def self.run(argv = ARGV)
     options = process_args argv
 
-    if options[:dump_path] then
+    if options[:dump_path]
       dump options[:dump_path]
       return
     end
@@ -456,7 +456,7 @@ or the PAGER environment variable.
   # +classes+.
 
   def add_class(out, name, classes)
-    heading = if classes.all? { |klass| klass.module? } then
+    heading = if classes.all? { |klass| klass.module? }
                 name
               else
                 superclass = classes.map do |klass|
@@ -497,7 +497,7 @@ or the PAGER environment variable.
     out << RDoc::Markup::Heading.new(1, "#{type}:")
 
     extensions.each do |modules, store|
-      if modules.length == 1 then
+      if modules.length == 1
         add_extension_modules_single out, store, modules.first
       else
         add_extension_modules_multiple out, store, modules
@@ -521,7 +521,7 @@ or the PAGER environment variable.
       out << incl.comment.parse
     end
 
-    unless wout.empty? then
+    unless wout.empty?
       verb = RDoc::Markup::Verbatim.new
 
       wout.each do |incl|
@@ -540,7 +540,7 @@ or the PAGER environment variable.
     path = store.friendly_path
     out << RDoc::Markup::Paragraph.new("#{name} (from #{path})")
 
-    if include.comment then
+    if include.comment
       out << RDoc::Markup::BlankLine.new
       out << include.comment.parse
     end
@@ -583,7 +583,7 @@ or the PAGER environment variable.
     out << RDoc::Markup::Heading.new(1, "#{name}:")
     out << RDoc::Markup::BlankLine.new
 
-    if @use_stdout and !@interactive then
+    if @use_stdout and !@interactive
       out.concat methods.map { |method|
         RDoc::Markup::Verbatim.new method
       }
@@ -658,10 +658,10 @@ or the PAGER environment variable.
   # Adds the class +comment+ to +out+.
 
   def class_document_comment(out, document) # :nodoc:
-    unless document.empty? then
+    unless document.empty?
       out << RDoc::Markup::Rule.new(1)
 
-      if document.merged? then
+      if document.merged?
         parts = document.parts
         parts = parts.zip [RDoc::Markup::BlankLine.new] * parts.length
         parts.flatten!
@@ -763,27 +763,27 @@ or the PAGER environment variable.
     # may need to include Foo when given Foo::
     klass_name = method ? name : klass
 
-    if name !~ /#|\./ then
+    if name !~ /#|\./
       completions.replace klasses.grep(/^#{Regexp.escape klass_name}[^:]*$/)
       completions.concat klasses.grep(/^#{Regexp.escape name}[^:]*$/) if
         name =~ /::$/
 
       completions << klass if classes.key? klass # to complete a method name
-    elsif selector then
+    elsif selector
       completions << klass if classes.key? klass
-    elsif classes.key? klass_name then
+    elsif classes.key? klass_name
       completions << klass_name
     end
   end
 
   def complete_method(name, klass, selector, completions) # :nodoc:
-    if completions.include? klass and name =~ /#|\.|::/ then
+    if completions.include? klass and name =~ /#|\.|::/
       methods = list_methods_matching name
 
-      if not methods.empty? then
+      if not methods.empty?
         # remove Foo if given Foo:: and a method was found
         completions.delete klass
-      elsif selector then
+      elsif selector
         # replace Foo with Foo:: as given
         completions.delete klass
         completions << "#{klass}#{selector}"
@@ -850,7 +850,7 @@ or the PAGER environment variable.
   # be guessed, raises an error if +name+ couldn't be guessed.
 
   def display_name(name)
-    if name =~ /\w:(\w|$)/ then
+    if name =~ /\w:(\w|$)/
       display_page name
       return true
     end
@@ -898,14 +898,14 @@ or the PAGER environment variable.
 
     pages = store.cache[:pages]
 
-    unless pages.include? page_name then
+    unless pages.include? page_name
       found_names = pages.select do |n|
         n =~ /#{Regexp.escape page_name}\.[^.]+$/
       end
 
-      if found_names.length.zero? then
+      if found_names.length.zero?
         return display_page_list store, pages
-      elsif found_names.length > 1 then
+      elsif found_names.length > 1
         return display_page_list store, found_names, page_name
       end
 
@@ -923,7 +923,7 @@ or the PAGER environment variable.
   def display_page_list(store, pages = store.cache[:pages], search = nil)
     out = RDoc::Markup::Document.new
 
-    title = if search then
+    title = if search
               "#{search} pages"
             else
               'Pages'
@@ -988,7 +988,7 @@ or the PAGER environment variable.
     return [selector, method].join if klass.empty?
 
     case selector
-    when ':' then
+    when ':'
       [find_store(klass),   selector, method]
     else
       [expand_class(klass), selector, method]
@@ -1024,7 +1024,7 @@ or the PAGER environment variable.
     klasses = nil
     ambiguous = klass.empty?
 
-    if ambiguous then
+    if ambiguous
       klasses = classes.keys
     else
       klasses = ancestors_of klass
@@ -1080,9 +1080,9 @@ or the PAGER environment variable.
   # use it.  If we're outputting to a pager, use bs, otherwise ansi.
 
   def formatter(io)
-    if @formatter_klass then
+    if @formatter_klass
       @formatter_klass.new
-    elsif paging? or !io.tty? then
+    elsif paging? or !io.tty?
       RDoc::Markup::ToBs.new
     else
       RDoc::Markup::ToAnsi.new
@@ -1099,7 +1099,7 @@ or the PAGER environment variable.
       require 'readline'
     rescue LoadError
     end
-    if defined? Readline then
+    if defined? Readline
       Readline.completion_proc = method :complete
       puts "You can use tab to autocomplete."
     end
@@ -1107,7 +1107,7 @@ or the PAGER environment variable.
     puts "Enter a blank line to exit.\n\n"
 
     loop do
-      name = if defined? Readline then
+      name = if defined? Readline
                Readline.readline ">> ", true
              else
                print ">> "
@@ -1140,15 +1140,15 @@ or the PAGER environment variable.
 
     classes = classes.flatten.uniq.sort
 
-    unless names.empty? then
+    unless names.empty?
       filter = Regexp.union names.map { |name| /^#{name}/ }
 
       classes = classes.grep filter
     end
 
     page do |io|
-      if paging? or io.tty? then
-        if names.empty? then
+      if paging? or io.tty?
+        if names.empty?
           io.puts "Classes and Modules known to ri:"
         else
           io.puts "Classes and Modules starting with #{names.join ', '}:"
@@ -1167,10 +1167,10 @@ or the PAGER environment variable.
     found = []
 
     find_methods name do |store, klass, ancestor, types, method|
-      if types == :instance or types == :both then
+      if types == :instance or types == :both
         methods = store.instance_methods[ancestor]
 
-        if methods then
+        if methods
           matches = methods.grep(/^#{Regexp.escape method.to_s}/)
 
           matches = matches.map do |match|
@@ -1181,7 +1181,7 @@ or the PAGER environment variable.
         end
       end
 
-      if types == :class or types == :both then
+      if types == :class or types == :both
         methods = store.class_methods[ancestor]
 
         next unless methods
@@ -1304,7 +1304,7 @@ or the PAGER environment variable.
     klass, type, name = parse_name name
 
     case type
-    when '#', '::' then
+    when '#', '::'
       /^#{klass}#{type}#{Regexp.escape name}$/
     else
       /^#{klass}(#|::)#{Regexp.escape name}$/
@@ -1315,7 +1315,7 @@ or the PAGER environment variable.
   # Paginates output through a pager program.
 
   def page
-    if pager = setup_pager then
+    if pager = setup_pager
       begin
         yield pager
       ensure
@@ -1346,22 +1346,22 @@ or the PAGER environment variable.
   def parse_name(name)
     parts = name.split(/(::?|#|\.)/)
 
-    if parts.length == 1 then
-      if parts.first =~ /^[a-z]|^([%&*+\/<>^`|~-]|\+@|-@|<<|<=>?|===?|=>|=~|>>|\[\]=?|~@)$/ then
+    if parts.length == 1
+      if parts.first =~ /^[a-z]|^([%&*+\/<>^`|~-]|\+@|-@|<<|<=>?|===?|=>|=~|>>|\[\]=?|~@)$/
         type = '.'
         meth = parts.pop
       else
         type = nil
         meth = nil
       end
-    elsif parts.length == 2 or parts.last =~ /::|#|\./ then
+    elsif parts.length == 2 or parts.last =~ /::|#|\./
       type = parts.pop
       meth = nil
-    elsif parts[1] == ':' then
+    elsif parts[1] == ':'
       klass = parts.shift
       type  = parts.shift
       meth  = parts.join
-    elsif parts[-2] != '::' or parts.last !~ /^[A-Z]/ then
+    elsif parts[-2] != '::' or parts.last !~ /^[A-Z]/
       meth = parts.pop
       type = parts.pop
     end
@@ -1383,7 +1383,7 @@ or the PAGER environment variable.
     attributes       = store.attributes[klass.full_name]       || []
 
     if document.empty? and
-       instance_methods.empty? and class_methods.empty? then
+       instance_methods.empty? and class_methods.empty?
       also_in << store
       return
     end
@@ -1392,7 +1392,7 @@ or the PAGER environment variable.
 
     class_document_comment out, document
 
-    if class_methods or instance_methods or not klass.constants.empty? then
+    if class_methods or instance_methods or not klass.constants.empty?
       out << RDoc::Markup::Rule.new(1)
     end
 
@@ -1408,7 +1408,7 @@ or the PAGER environment variable.
   def render_method(out, store, method, name) # :nodoc:
     out << RDoc::Markup::Paragraph.new("(from #{store.friendly_path})")
 
-    unless name =~ /^#{Regexp.escape method.parent_name}/ then
+    unless name =~ /^#{Regexp.escape method.parent_name}/
       out << RDoc::Markup::Heading.new(3, "Implementation from #{method.parent_name}")
     end
 
@@ -1471,13 +1471,13 @@ or the PAGER environment variable.
   # Looks up and displays ri data according to the options given.
 
   def run
-    if @list_doc_dirs then
+    if @list_doc_dirs
       puts @doc_dirs
-    elsif @list then
+    elsif @list
       list_known_classes @names
-    elsif @server then
+    elsif @server
       start_server
-    elsif @interactive or @names.empty? then
+    elsif @interactive or @names.empty?
       interactive
     else
       display_names @names

--- a/lib/rdoc/ri/paths.rb
+++ b/lib/rdoc/ri/paths.rb
@@ -74,7 +74,7 @@ module RDoc::RI::Paths
       [File.join(spec.doc_dir, 'ri'), spec.name, spec.version]
     end
 
-    if filter == :all then
+    if filter == :all
       gemdirs = []
 
       all.group_by do |_, name, _|
@@ -95,7 +95,7 @@ module RDoc::RI::Paths
     all.each do |dir, name, ver|
       next unless File.exist? dir
 
-      if ri_paths[name].nil? or ver > ri_paths[name].first then
+      if ri_paths[name].nil? or ver > ri_paths[name].first
         ri_paths[name] = [ver, name, dir]
       end
     end

--- a/lib/rdoc/ri/servlet.rb
+++ b/lib/rdoc/ri/servlet.rb
@@ -120,14 +120,14 @@ class RDoc::RI::Servlet < WEBrick::HTTPServlet::AbstractServlet
     req.path.sub!(/\A#{Regexp.escape @mount_path}/, '') if @mount_path
 
     case req.path
-    when '/' then
+    when '/'
       root req, res
     when '/js/darkfish.js', '/js/jquery.js', '/js/search.js',
-         %r%^/css/%, %r%^/images/%, %r%^/fonts/% then
+         %r%^/css/%, %r%^/images/%, %r%^/fonts/%
       asset :darkfish, req, res
-    when '/js/navigation.js', '/js/searcher.js' then
+    when '/js/navigation.js', '/js/searcher.js'
       asset :json_index, req, res
-    when '/js/search_index.js' then
+    when '/js/search_index.js'
       root_search req, res
     else
       show_documentation req, res
@@ -153,11 +153,11 @@ class RDoc::RI::Servlet < WEBrick::HTTPServlet::AbstractServlet
     text_name = path.chomp '.html'
     name = text_name.gsub '/', '::'
 
-    if klass = store.find_class_or_module(name) then
+    if klass = store.find_class_or_module(name)
       res.body = generator.generate_class klass
-    elsif page = store.find_text_page(name.sub(/_([^_]*)\z/, '.\1')) then
+    elsif page = store.find_text_page(name.sub(/_([^_]*)\z/, '.\1'))
       res.body = generator.generate_page page
-    elsif page = store.find_text_page(text_name.sub(/_([^_]*)\z/, '.\1')) then
+    elsif page = store.find_text_page(text_name.sub(/_([^_]*)\z/, '.\1'))
       res.body = generator.generate_page page
     else
       not_found generator, req, res
@@ -274,7 +274,7 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
 
     ims = Time.parse ims
 
-    unless ims < last_modified then
+    unless ims < last_modified
       res.body = ''
       raise WEBrick::HTTPStatus::NotModified
     end
@@ -295,16 +295,16 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
       exists = File.exist? store.cache_path
 
       case type
-      when :gem then
+      when :gem
         gem_path = path[%r%/([^/]*)/ri$%, 1]
         [gem_path, "#{gem_path}/", exists, type, path]
-      when :system then
+      when :system
         ['Ruby Documentation', 'ruby/', exists, type, path]
-      when :site then
+      when :site
         ['Site Documentation', 'site/', exists, type, path]
-      when :home then
+      when :home
         ['Home Documentation', 'home/', exists, type, path]
-      when :extra then
+      when :extra
         extra_counter += 1
         store.load_cache if exists
         title = store.title || "Extra Documentation"
@@ -361,13 +361,13 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
 
         path    = spec.full_name
         comment = spec.summary
-      when :system then
+      when :system
         path    = 'ruby'
         comment = 'Documentation for the Ruby standard library'
-      when :site then
+      when :site
         path    = 'site'
         comment = 'Documentation for non-gem libraries'
-      when :home then
+      when :home
         path    = 'home'
         comment = 'Documentation from your home directory'
       when :extra
@@ -401,11 +401,11 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
     generator = generator_for store
 
     case path
-    when nil, '', 'index.html' then
+    when nil, '', 'index.html'
       res.body = generator.generate_index
-    when 'table_of_contents.html' then
+    when 'table_of_contents.html'
       res.body = generator.generate_table_of_contents
-    when 'js/search_index.js' then
+    when 'js/search_index.js'
       documentation_search store, generator, req, res
     else
       documentation_page store, generator, path, req, res
@@ -419,13 +419,13 @@ version.  If you're viewing Ruby's documentation, include the version of ruby.
 
   def store_for(source_name)
     case source_name
-    when 'home' then
+    when 'home'
       RDoc::Store.new(@options, path: RDoc::RI::Paths.home_dir, type: :home)
-    when 'ruby' then
+    when 'ruby'
       RDoc::Store.new(@options, path: RDoc::RI::Paths.system_dir, type: :system)
-    when 'site' then
+    when 'site'
       RDoc::Store.new(@options, path: RDoc::RI::Paths.site_dir, type: :site)
-    when /\Aextra-(\d+)\z/ then
+    when /\Aextra-(\d+)\z/
       index = $1.to_i - 1
       ri_dir = installed_docs[index][4]
       RDoc::Store.new(@options, path: ri_dir, type: :extra)

--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -169,9 +169,9 @@ class RDoc::RubyGemsHook
     args.concat @spec.extra_rdoc_files
 
     case config_args = Gem.configuration[:rdoc]
-    when String then
+    when String
       args = args.concat config_args.split(' ')
-    when Array then
+    when Array
       args = args.concat config_args
     end
 

--- a/lib/rdoc/stats.rb
+++ b/lib/rdoc/stats.rb
@@ -224,11 +224,11 @@ class RDoc::Stats
   # Returns a report on which items are not documented
 
   def report
-    if @coverage_level > 0 then
+    if @coverage_level > 0
       extend RDoc::Text
     end
 
-    if @coverage_level.zero? then
+    if @coverage_level.zero?
       calculate
 
       return GREAT_JOB_MESSAGE if @num_items == @doc_items
@@ -236,7 +236,7 @@ class RDoc::Stats
 
     items, empty_classes = collect_undocumented_items
 
-    if @coverage_level > 0 then
+    if @coverage_level > 0
       calculate
 
       return GREAT_JOB_MESSAGE if @num_items == @doc_items

--- a/lib/rdoc/stats/normal.rb
+++ b/lib/rdoc/stats/normal.rb
@@ -33,7 +33,7 @@ class RDoc::Stats::Normal < RDoc::Stats::Quiet
       terminal_width = size[1].to_i.nonzero? || 80
       max_filename_size = (terminal_width - progress_bar.size) - 1
 
-      if filename.size > max_filename_size then
+      if filename.size > max_filename_size
         # Turn "some_long_filename.rb" to "...ong_filename.rb"
         filename = filename[(filename.size - max_filename_size) .. -1]
         filename[0..2] = "..."

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -175,7 +175,7 @@ class RDoc::Store
   # created RDoc::TopLevel.
 
   def add_file(absolute_name, relative_name: absolute_name, parser: nil)
-    unless top_level = @files_hash[relative_name] then
+    unless top_level = @files_hash[relative_name]
       top_level = RDoc::TopLevel.new absolute_name, relative_name
       top_level.parser = parser if parser
       top_level.store = self
@@ -489,7 +489,7 @@ class RDoc::Store
 
   def clean_cache_collection(collection) # :nodoc:
     collection.each do |name, item|
-      if item.empty? then
+      if item.empty?
         collection.delete name
       else
         # HACK mongrel-1.1.5 documents its files twice
@@ -521,7 +521,7 @@ class RDoc::Store
     # cache included modules before they are removed from the documentation
     all_classes_and_modules.each { |cm| cm.ancestors }
 
-    unless min_visibility == :nodoc then
+    unless min_visibility == :nodoc
       remove_nodoc @classes_hash
       remove_nodoc @modules_hash
     end
@@ -536,13 +536,13 @@ class RDoc::Store
     @files_hash.each_key do |file_name|
       tl = @files_hash[file_name]
 
-      unless tl.text? then
+      unless tl.text?
         tl.modules_hash.clear
         tl.classes_hash.clear
 
         tl.classes_or_modules.each do |cm|
           name = cm.full_name
-          if cm.type == 'class' then
+          if cm.type == 'class'
             tl.classes_hash[name] = cm if @classes_hash[name]
           else
             tl.modules_hash[name] = cm if @modules_hash[name]
@@ -568,7 +568,7 @@ class RDoc::Store
 
       mod = find_class_or_module name
 
-      unless mod then
+      unless mod
         loaded_mod = load_class_data name
 
         file = loaded_mod.in_files.first
@@ -678,7 +678,7 @@ class RDoc::Store
 
   def friendly_path
     case type
-    when :gem    then
+    when :gem
       parent = File.expand_path '..', @path
       "gem #{File.basename parent}"
     when :home   then RDoc.home
@@ -734,9 +734,9 @@ class RDoc::Store
         descendent = find_class_or_module name
 
         case descendent
-        when RDoc::NormalClass then
+        when RDoc::NormalClass
           mod.classes_hash[name] = descendent
-        when RDoc::NormalModule then
+        when RDoc::NormalModule
           mod.modules_hash[name] = descendent
         end
       end
@@ -797,11 +797,11 @@ class RDoc::Store
     obj.store = self
 
     case obj
-    when RDoc::NormalClass then
+    when RDoc::NormalClass
       @classes_hash[klass_name] = obj
-    when RDoc::SingleClass then
+    when RDoc::SingleClass
       @classes_hash[klass_name] = obj
-    when RDoc::NormalModule then
+    when RDoc::NormalModule
       @modules_hash[klass_name] = obj
     end
   end
@@ -1021,14 +1021,14 @@ class RDoc::Store
       "#{attribute.definition} #{attribute.name}"
     end
 
-    unless attribute_definitions.empty? then
+    unless attribute_definitions.empty?
       @cache[:attributes][full_name] ||= []
       @cache[:attributes][full_name].concat attribute_definitions
     end
 
     to_delete = []
 
-    unless klass.method_list.empty? then
+    unless klass.method_list.empty?
       @cache[:class_methods][full_name]    ||= []
       @cache[:instance_methods][full_name] ||= []
 
@@ -1071,7 +1071,7 @@ class RDoc::Store
 
     FileUtils.mkdir_p class_path(full_name) unless @dry_run
 
-    cache = if method.singleton then
+    cache = if method.singleton
               @cache[:class_methods]
             else
               @cache[:instance_methods]

--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -176,7 +176,7 @@ class RDoc::Task < Rake::TaskLib
     invalid_options =
       names.keys.map { |k| k.to_sym } - [:rdoc, :clobber_rdoc, :rerdoc]
 
-    unless invalid_options.empty? then
+    unless invalid_options.empty?
       raise ArgumentError, "invalid options: #{invalid_options.join ', '}"
     end
   end

--- a/lib/rdoc/token_stream.rb
+++ b/lib/rdoc/token_stream.rb
@@ -36,7 +36,7 @@ module RDoc::TokenStream
 
       text = CGI.escapeHTML text
 
-      if style then
+      if style
         end_with_newline = text.end_with?("\n")
         text = text.chomp if end_with_newline
         "<span class=\"#{style}\">#{text}</span>#{"\n" if end_with_newline}"

--- a/lib/rdoc/tom_doc.rb
+++ b/lib/rdoc/tom_doc.rb
@@ -110,7 +110,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
 
       next true if RDoc::Markup::BlankLine === part
 
-      if RDoc::Markup::Verbatim === part then
+      if RDoc::Markup::Verbatim === part
         signature = part
         found_signature = true
       end
@@ -173,16 +173,16 @@ class RDoc::TomDoc < RDoc::Markup::Parser
       type, data, = get
 
       case type
-      when :TEXT then
+      when :TEXT
         @section = 'Returns' if data =~ /\A(Returns|Raises)/
 
         paragraph << data
-      when :NEWLINE then
-        if :TEXT == peek_token[0] then
+      when :NEWLINE
+        if :TEXT == peek_token[0]
           # Lines beginning with 'Raises' in the Returns section should not be
           # treated as multiline text
           if 'Returns' == @section and
-            peek_token[1].start_with?('Raises') then
+            peek_token[1].start_with?('Raises')
             break
           else
             paragraph << ' '
@@ -207,7 +207,7 @@ class RDoc::TomDoc < RDoc::Markup::Parser
   def parse_text(parent, indent) # :nodoc:
     paragraph = build_paragraph indent
 
-    if false == @seen_returns and 'Returns' == @section then
+    if false == @seen_returns and 'Returns' == @section
       @seen_returns = true
       parent << RDoc::Markup::Heading.new(3, 'Returns')
       parent << RDoc::Markup::BlankLine.new
@@ -235,15 +235,15 @@ class RDoc::TomDoc < RDoc::Markup::Parser
       next if @s.scan(/ +/)
 
       @tokens << case
-                 when @s.scan(/\r?\n/) then
+                 when @s.scan(/\r?\n/)
                    token = [:NEWLINE, @s.matched, *pos]
                    @s.newline!
                    token
-                 when @s.scan(/(Examples|Signature)$/) then
+                 when @s.scan(/(Examples|Signature)$/)
                    @tokens << [:HEADER, 3, *pos]
 
                    [:TEXT, @s[1], *pos]
-                 when @s.scan(/([:\w][\w\[\]]*)[ ]+- /) then
+                 when @s.scan(/([:\w][\w\[\]]*)[ ]+- /)
                    [:NOTE, @s[1], *pos]
                  else
                    @s.scan(/.*/)

--- a/test/rdoc/code_object/class_module_test.rb
+++ b/test/rdoc/code_object/class_module_test.rb
@@ -760,7 +760,7 @@ class RDocClassModuleTest < XrefTestCase
     removed = []
 
     cm1.merge_collections cm1.constants, cm2.constants, cm2.in_files do |add, c|
-      if add then
+      if add
         added << c
       else
         removed << c


### PR DESCRIPTION
This has bothered me for quite a while. I was thinking about dropping them gradually, but with agents reading other code they constantly add `then` too. So let's ban this.

## Cops enabled

`.rubocop.yml` uses `DisabledByDefault: true`, so each cop is opted in explicitly:

- `Style/MultilineIfThen` — `if cond then` with the body on the next line
- `Style/MultilineWhenThen` — same for `when`
- `Style/MultilineInPatternThen` — same for `in` pattern matching

There is no single "redundant then" cop; these three are RuboCop's coverage for it. 

They intentionally leave single-line forms alone, where `then` is required and not redundant:

```ruby
when Hash then (name[:rdoc] || "rdoc").to_s
```