### PR TITLE
Add memoized page lookup index to `RDoc::Store`

### DIFF
--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -140,6 +140,8 @@ class RDoc::Store
     @modules_hash = {}
     @files_hash   = {}
     @text_files_hash = {}
+    # lazy cache, used for quick lookup by page name.
+    @page_index = nil
 
     @c_enclosure_classes = {}
     @c_enclosure_names   = {}
@@ -181,6 +183,7 @@ class RDoc::Store
       top_level.store = self
       @files_hash[relative_name] = top_level
       @text_files_hash[relative_name] = top_level if top_level.text?
+      @page_index = nil
     end
 
     top_level
@@ -203,6 +206,7 @@ class RDoc::Store
     @c_singleton_class_variables.delete(relative_name)
     return unless top_level
 
+    @page_index = nil
     remove_classes_and_modules(top_level.classes_or_modules)
   end
 
@@ -742,6 +746,7 @@ class RDoc::Store
       end
     end
 
+    @page_index = nil
     @cache[:pages].each do |page_name|
       page = load_page page_name
       @files_hash[page_name] = page
@@ -911,9 +916,12 @@ class RDoc::Store
   # Returns the RDoc::TopLevel that is a file and has the given +name+
 
   def page(name)
-    @files_hash.each_value.find do |file|
-      file.page_name == name or file.base_name == name
+    @page_index ||= @files_hash.each_value.each_with_object({}) do |file, index|
+      index[file.page_name] ||= file
+      index[file.base_name] ||= file
     end
+
+    @page_index[name]
   end
 
   ##

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -650,6 +650,25 @@ class RDocStoreTest < XrefTestCase
     assert_equal page, @store.page('PAGE.txt')
   end
 
+  def test_page_index
+    page = @store.add_file 'PAGE.txt', parser: RDoc::Parser::Simple
+    page_name = page.page_name
+    page_name_calls = 0
+    page.define_singleton_method(:page_name) do
+      page_name_calls += 1
+      page_name
+    end
+
+    2.times { assert_same page, @store.page('PAGE') }
+    assert_equal 1, page_name_calls
+
+    other_page = @store.add_file 'doc/PAGE.md', parser: RDoc::Parser::Simple
+    assert_same page, @store.page('PAGE')
+
+    @store.remove_file 'PAGE.txt'
+    assert_same other_page, @store.page('PAGE')
+  end
+
   def test_save
     FileUtils.mkdir_p @tmpdir
 


### PR DESCRIPTION
`page(name)` currently resolves page lookups by scanning every `TopLevel` in `@files_hash` each time it’s called (`each_value.each_with_object(...)`). In large documentation sets (or in server/live reload flows where lookups happen repeatedly), this results in repeated linear scans. 

This PR introduces `@page_index` as a memoized secondary index keyed by both `page_name` and `base_name` to avoid that repeated work and make page lookup O(1) on steady-state access.

## Benchmarks

Based on my findings, speed-up is noticeable in gems with many pages. This improvement doesn't affect smaller gems.


-> TODO: add exact numbers