### PR TITLE
Add Darkfish deprecation warning

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -214,6 +214,10 @@ module RDoc
       # objects containing the extracted information.
 
       def generate
+        if self.class == Generator::Darkfish
+          warn "The Darkfish template is deprecated and will be removed in version 9.0."
+        end
+
         setup
 
         write_style_sheet

--- a/test/rdoc/generator/aliki_test.rb
+++ b/test/rdoc/generator/aliki_test.rb
@@ -59,6 +59,14 @@ class RDocGeneratorAlikiTest < RDoc::TestCase
     FileUtils.rm_rf @tmpdir
   end
 
+  def test_generate_does_not_warn_about_darkfish_deprecation
+    _, err = capture_output do
+      @g.generate
+    end
+
+    assert_empty err
+  end
+
   def test_inheritance_and_template_dir
     assert_kind_of RDoc::Generator::Darkfish, @g
     assert_match %r{/template/aliki\z}, @g.template_dir.to_s

--- a/test/rdoc/generator/darkfish_test.rb
+++ b/test/rdoc/generator/darkfish_test.rb
@@ -69,6 +69,14 @@ class RDocGeneratorDarkfishTest < RDoc::TestCase
     FileUtils.rm_rf @tmpdir
   end
 
+  def test_generate_warns_about_deprecation
+    _, err = capture_output do
+      @g.generate
+    end
+
+    assert_equal "The Darkfish template is deprecated and will be removed in version 9.0.\n", err
+  end
+
   def test_generate
     top_level = @store.add_file 'file.rb'
     top_level.add_class @klass.class, @klass.name


### PR DESCRIPTION
I want to remove Darkfish completely in the next major release, so let's start showing deprecation warnings for it.

- Aliki shouldn't show the deprecation message
- Other generators thats' built on top of Darkfish should see it, such as [rorvswild](https://github.com/BaseSecrete/rorvswild-theme-rdoc)

We can't cover all the cases where Darkfish is used, so this is just a best effort notification. Readme has been announcing this removal for a while.
