### PR TITLE
Include the documented RDoc example in the gem

### DIFF
--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -42,6 +42,7 @@ RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentat
     "CVE-2013-0256.rdoc",
     "doc/markup_reference/markdown.md",
     "doc/markup_reference/rdoc.rdoc",
+    "doc/rdoc/example.rb",
     "History.rdoc",
     "LEGAL.rdoc",
     "LICENSE.rdoc",


### PR DESCRIPTION
## Summary

Include `doc/rdoc/example.rb` in the packaged gem so the example referenced by the documentation is present after installation.

Fixes #1761.

## Verification

- complete suite: 2,529 tests / 6,181 assertions on Ruby 3.2 and 4.0;
- RubyGems integration: 20 tests / 46 assertions;
- full self-documentation generation;
- 209-file RuboCop, CSS/template lint, syntax and package model.

No test files were changed. The package gains only the already tracked example source; runtime behavior is unchanged.
