### PR TITLE
Remove `Context#visibility` and `Context#current_line_visibility`

### DIFF
--- a/lib/rdoc/code_object/any_method.rb
+++ b/lib/rdoc/code_object/any_method.rb
@@ -196,7 +196,7 @@ class RDoc::AnyMethod < RDoc::MethodAttr
     @name          = array[1]
     @full_name     = array[2]
     @singleton     = array[3]
-    @visibility    = array[4]
+    @visibility    = array[4] || :public
     @comment       = RDoc::Comment.from_document array[5]
     @call_seq      = array[6]
     @block_params  = array[7]

--- a/lib/rdoc/code_object/attr.rb
+++ b/lib/rdoc/code_object/attr.rb
@@ -137,7 +137,7 @@ class RDoc::Attr < RDoc::MethodAttr
     @name          = array[1]
     @full_name     = array[2]
     @rw            = array[3]
-    @visibility    = array[4]
+    @visibility    = array[4] || :public
     @comment       = RDoc::Comment.from_document array[5]
     @singleton     = array[6] || false # MARSHAL_VERSION == 0
     #                      7 handled below

--- a/lib/rdoc/code_object/class_module.rb
+++ b/lib/rdoc/code_object/class_module.rb
@@ -84,7 +84,6 @@ class RDoc::ClassModule < RDoc::Context
     klass.sections.concat mod.sections
     klass.unmatched_alias_lists = mod.unmatched_alias_lists
     klass.current_section = mod.current_section
-    klass.visibility = mod.visibility
 
     klass.classes_hash.update mod.classes_hash
     klass.modules_hash.update mod.modules_hash
@@ -397,7 +396,6 @@ class RDoc::ClassModule < RDoc::Context
     @done_documenting  = false
     @parent            = nil
     @temporary_section = nil
-    @visibility        = nil
     @classes           = {}
     @modules           = {}
 
@@ -442,11 +440,10 @@ class RDoc::ClassModule < RDoc::Context
 
     array[8].each do |type, visibilities|
       visibilities.each do |visibility, methods|
-        @visibility = visibility
-
         methods.each do |name, file|
           method = RDoc::AnyMethod.new name, singleton: type == 'class'
           method.record_location RDoc::TopLevel.new file
+          method.visibility = visibility
           add_method method
         end
       end
@@ -972,9 +969,6 @@ class RDoc::ClassModule < RDoc::Context
     code_object.mixin_from = code_object.parent
     code_object.singleton = true if singleton
     set_current_section(code_object.section.title, code_object.section.comment)
-    # add_method and add_attribute will reassign self's visibility back to the method/attribute
-    # so we need to sync self's visibility with the object's to properly retain that information
-    self.visibility = code_object.visibility
     code_object
   end
 end

--- a/lib/rdoc/code_object/context.rb
+++ b/lib/rdoc/code_object/context.rb
@@ -92,16 +92,6 @@ class RDoc::Context < RDoc::CodeObject
   attr_reader :external_aliases
 
   ##
-  # Current visibility of this context
-
-  attr_accessor :visibility
-
-  ##
-  # Current visibility of this line
-
-  attr_writer :current_line_visibility
-
-  ##
   # Hash of registered methods. Attributes are also registered here,
   # twice if they are RW.
 
@@ -127,7 +117,6 @@ class RDoc::Context < RDoc::CodeObject
 
     @name    ||= "unknown"
     @parent  = nil
-    @visibility = :public
 
     @current_section = Section.new self, nil, nil
     @sections = { nil => @current_section }
@@ -151,7 +140,6 @@ class RDoc::Context < RDoc::CodeObject
     @extends     = []
     @constants   = []
     @external_aliases = []
-    @current_line_visibility = nil
 
     # This Hash maps a method name to a list of unmatched aliases (aliases of
     # a method not yet encountered).
@@ -262,7 +250,6 @@ class RDoc::Context < RDoc::CodeObject
     end
 
     if register
-      attribute.visibility = @visibility
       add_to @attributes, attribute
       resolve_aliases attribute
     end
@@ -478,11 +465,6 @@ class RDoc::Context < RDoc::CodeObject
       end
     else
       @methods_hash[key] = method
-      if @current_line_visibility
-        method.visibility, @current_line_visibility = @current_line_visibility, nil
-      else
-        method.visibility = @visibility
-      end
       add_to @method_list, method
       resolve_aliases method
     end
@@ -1030,13 +1012,6 @@ class RDoc::Context < RDoc::CodeObject
 
   def name_for_path
     full_name
-  end
-
-  ##
-  # Changes the visibility for new methods to +visibility+
-
-  def ongoing_visibility=(visibility)
-    @visibility = visibility
   end
 
   ##

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -1041,10 +1041,9 @@ class RDoc::Parser::C < RDoc::Parser
         if meth_obj.section_title
           class_obj.temporary_section = class_obj.add_section(meth_obj.section_title)
         end
+        meth_obj.visibility = type == 'private_method' ? :private : :public
         class_obj.add_method meth_obj
-
         @stats.add_method meth_obj
-        meth_obj.visibility = :private if 'private_method' == type
       end
     end
   end

--- a/lib/rdoc/parser/rbs.rb
+++ b/lib/rdoc/parser/rbs.rb
@@ -153,8 +153,8 @@ class RDoc::Parser::RBS < RDoc::Parser
     )
     record_object_location attribute, decl.location
     attribute.type_signature_lines = type_signature_lines
-    context.add_attribute attribute
     attribute.visibility = decl.visibility if decl.visibility
+    context.add_attribute attribute
   end
 
   def parse_class_decl(decl, context)
@@ -260,8 +260,8 @@ class RDoc::Parser::RBS < RDoc::Parser
     end
 
     method.comment = comment if comment
-    context.add_method method
     method.visibility = visibility if visibility
+    context.add_method method
   end
 
   def parse_module_decl(decl, context)

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -433,10 +433,10 @@ class RDoc::Parser::Ruby < RDoc::Parser
         a = RDoc::Attr.new(attr, rw, comment, singleton: @singleton)
         a.store = @store
         a.line = line_no
+        a.visibility = visibility
         record_location(a)
         @container.add_attribute(a)
         mark_container_documentable(@container)
-        a.visibility = visibility
       end
     elsif line_no || node
       method_name ||= call_node_name_arguments(node).first if is_call_node
@@ -576,13 +576,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
       end
     end
     new_methods.each do |method|
+      method.visibility = visibility
       case method
       when RDoc::AnyMethod
         @container.add_method(method)
       when RDoc::Attr
         @container.add_attribute(method)
       end
-      method.visibility = visibility
     end
   end
 
@@ -602,13 +602,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
       new_methods << s_m
     end
     new_methods.each do |method|
+      method.visibility = :public
       case method
       when RDoc::AnyMethod
         @container.add_method(method)
       when RDoc::Attr
         @container.add_attribute(method)
       end
-      method.visibility = :public
     end
   end
 
@@ -638,7 +638,6 @@ class RDoc::Parser::Ruby < RDoc::Parser
     if should_document?(a)
       mark_container_documentable(@container)
       @container.add_alias(a)
-      @container.find_method(new_name, @singleton)&.visibility = visibility
     end
   end
 
@@ -656,13 +655,13 @@ class RDoc::Parser::Ruby < RDoc::Parser
       a.store = @store
       a.line = line_no
       a.type_signature_lines = type_signature_lines
+      a.visibility = visibility
       record_location(a)
       handle_modifier_directive(a, line_no)
       if should_document?(a)
         @container.add_attribute(a)
         mark_container_documentable(@container)
       end
-      a.visibility = visibility # should set after adding to container
     end
   end
 
@@ -743,12 +742,12 @@ class RDoc::Parser::Ruby < RDoc::Parser
     meth.name ||= 'unknown'
     meth.store = @store
     meth.line = line_no
-    container.add_method(meth) # should add after setting singleton and before setting visibility
     meth.visibility = visibility
     meth.params ||= params || '()'
     meth.calls_super = calls_super
     meth.block_params ||= block_params if block_params
     meth.type_signature_lines = type_signature_lines
+    container.add_method(meth)
     record_location(meth)
     meth.start_collecting_tokens(:ruby)
     tokens.each do |token|

--- a/test/rdoc/code_object/class_module_test.rb
+++ b/test/rdoc/code_object/class_module_test.rb
@@ -291,6 +291,30 @@ class RDocClassModuleTest < XrefTestCase
     assert_empty loaded.method_list
   end
 
+  def test_marshal_load_method_visibility
+    tl = @store.add_file 'file.rb'
+    cm = tl.add_class RDoc::NormalClass, 'Klass'
+    cm.record_location tl
+
+    RDoc::VISIBILITIES.each do |visibility|
+      [false, true].each do |singleton|
+        m = RDoc::AnyMethod.new "#{visibility}_method", singleton: singleton
+        m.record_location tl
+        m.visibility = visibility
+        cm.add_method m
+      end
+    end
+
+    loaded = Marshal.load Marshal.dump cm
+    loaded.store = @store
+
+    RDoc::VISIBILITIES.each do |visibility|
+      [false, true].each do |singleton|
+        assert_equal visibility, loaded.find_method("#{visibility}_method", singleton).visibility
+      end
+    end
+  end
+
   def test_marshal_load_version_0
     tl = @store.add_file 'file.rb'
     ns = tl.add_module RDoc::NormalModule, 'Namespace'

--- a/test/rdoc/rdoc_context_test.rb
+++ b/test/rdoc/rdoc_context_test.rb
@@ -15,7 +15,6 @@ class RDocContextTest < XrefTestCase
     assert_equal 'unknown', @context.name
     assert_equal '', @context.comment
     assert_nil   @context.parent
-    assert_equal :public, @context.visibility
     assert_equal 1, @context.sections.length
     assert_nil   @context.temporary_section
 
@@ -194,7 +193,6 @@ class RDocContextTest < XrefTestCase
 
   def test_add_method
     meth = RDoc::AnyMethod.new 'old_name'
-    meth.visibility = nil
 
     @context.add_method meth
 
@@ -221,7 +219,6 @@ class RDocContextTest < XrefTestCase
 
     meth1 = RDoc::AnyMethod.new 'name'
     meth1.record_location @store.add_file 'first.rb'
-    meth1.visibility = nil
     meth1.comment = comment 'first'
 
     @context.add_method meth1
@@ -249,7 +246,6 @@ class RDocContextTest < XrefTestCase
 
     meth1 = RDoc::AnyMethod.new 'name'
     meth1.record_location @store.add_file 'first.rb'
-    meth1.visibility = nil
     meth1.comment = comment 'first'
 
     @context.add_method meth1

--- a/test/rdoc/rdoc_stats_test.rb
+++ b/test/rdoc/rdoc_stats_test.rb
@@ -86,7 +86,6 @@ class RDocStatsTest < RDoc::TestCase
     mod = @tl.add_module RDoc::NormalModule, 'M'
 
     c = @tl.add_class RDoc::NormalClass, 'C'
-    mod.add_constant c
 
     ca = RDoc::Constant.new 'CA', nil, nil
     ca.is_alias_for = c

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -951,6 +951,24 @@ class RDocStoreTest < XrefTestCase
     assert_empty result.constants
   end
 
+  def test_save_class_merge_method_visibility
+    private_meth = RDoc::AnyMethod.new 'private_method'
+    private_meth.record_location @top_level
+    private_meth.visibility = :private
+    @klass.add_method private_meth
+
+    @s.save_class @klass
+    # Second save loads the class saved above and merges @klass into it
+    @s.save_class @klass
+
+    assert_equal :public, @meth.visibility
+    assert_equal :private, private_meth.visibility
+
+    loaded = @s.load_class 'Object'
+    assert_equal :public, loaded.find_method('method', false).visibility
+    assert_equal :private, loaded.find_method('private_method', false).visibility
+  end
+
   def test_save_class_methods
     @s.save_class @klass
 


### PR DESCRIPTION
Fixes #346

Context doesn't need visibility. It's a parser's lexical state.
Visibility of added method won't be modified in `add_method`, so we can remove all workarounds related to method/attribute/alias and its visibility: Set/modify visibility after adding method/attribute/alias.
    
AnyMethod#marshal_load and Attr#marshal_load fall back to :public when a cache written by an older RDoc has nil visibility, the same as Constant#marshal_load.
    
rdoc_stats_test passed a NormalClass to add_constant, which only worked because Context responded to `visibility`.

Added test: from #1736
