### PR TITLE
Lazy page index in RDoc::Store (42.7% perf improvement)

### DIFF
--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -141,6 +141,7 @@ module RDoc
       @modules_hash = {}
       @files_hash   = {}
       @text_files_hash = {}
+      @page_index = nil
 
       @c_enclosure_classes = {}
       @c_enclosure_names   = {}
@@ -182,6 +183,7 @@ module RDoc
         top_level.store = self
         @files_hash[relative_name] = top_level
         @text_files_hash[relative_name] = top_level if top_level.text?
+        @page_index = nil
       end
 
       top_level
@@ -204,6 +206,7 @@ module RDoc
       @c_singleton_class_variables.delete(relative_name)
       return unless top_level
 
+      @page_index = nil
       remove_classes_and_modules(top_level.classes_or_modules)
     end
 
@@ -743,6 +746,7 @@ module RDoc
         end
       end
 
+      @page_index = nil
       @cache[:pages].each do |page_name|
         page = load_page page_name
         @files_hash[page_name] = page
@@ -912,9 +916,12 @@ module RDoc
     # Returns the RDoc::TopLevel that is a file and has the given +name+
 
     def page(name)
-      @files_hash.each_value.find do |file|
-        file.page_name == name or file.base_name == name
+      @page_index ||= @files_hash.each_value.each_with_object({}) do |file, index|
+        index[file.page_name] ||= file
+        index[file.base_name] ||= file
       end
+
+      @page_index[name]
     end
 
     ##

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -141,7 +141,6 @@ module RDoc
       @modules_hash = {}
       @files_hash   = {}
       @text_files_hash = {}
-      @page_index = nil
 
       @c_enclosure_classes = {}
       @c_enclosure_names   = {}

--- a/test/rdoc/rdoc_rubygems_hook_test.rb
+++ b/test/rdoc/rdoc_rubygems_hook_test.rb
@@ -146,6 +146,19 @@ class RDocRubyGemsHookTest < Test::Unit::TestCase
     assert_equal 'MyTitle', rdoc.store.main
   end
 
+  def test_generate_rdoc_with_page_cross_reference
+    @hook.generate_rdoc = true
+    @hook.generate_ri = false
+    @a.extra_rdoc_files << 'GUIDE.md'
+
+    File.write File.join(@a.gem_dir, 'GUIDE.md'), '# Guide'
+    File.write File.join(@a.gem_dir, 'lib', 'a.rb'), "# See rdoc-ref:GUIDE\nclass A; end\n"
+
+    @hook.generate
+
+    assert @hook.rdoc_installed?
+  end
+
   def test_generate_configuration_rdoc_array
     Gem.configuration[:rdoc] = %w[-A]
 

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -650,6 +650,56 @@ class RDocStoreTest < XrefTestCase
     assert_equal page, @store.page('PAGE.txt')
   end
 
+  def test_page_index
+    page = @store.add_file 'PAGE.txt', parser: RDoc::Parser::Simple
+    page_name = page.page_name
+    base_name = page.base_name
+    name_calls = 0
+    page.define_singleton_method(:page_name) do
+      name_calls += 1
+      page_name
+    end
+    page.define_singleton_method(:base_name) do
+      name_calls += 1
+      base_name
+    end
+
+    2.times do
+      assert_same page, @store.page('PAGE')
+      assert_same page, @store.page('PAGE.txt')
+      assert_nil @store.page('missing')
+    end
+
+    assert_equal 2, name_calls
+  end
+
+  def test_page_index_invalidated_when_files_change
+    assert_nil @store.page('PAGE')
+
+    first_page = @store.add_file 'PAGE.txt', parser: RDoc::Parser::Simple
+    assert_same first_page, @store.page('PAGE')
+
+    second_page = @store.add_file 'doc/PAGE.md', parser: RDoc::Parser::Simple
+    assert_same first_page, @store.page('PAGE')
+
+    @store.remove_file 'PAGE.txt'
+    assert_same second_page, @store.page('PAGE')
+  end
+
+  def test_page_index_invalidated_by_load_all
+    FileUtils.mkdir_p @tmpdir
+    source = RDoc::Store.new RDoc::Options.new, path: @tmpdir
+    source.add_file 'README.txt', parser: RDoc::Parser::Simple
+    source.save
+
+    loaded = RDoc::Store.new RDoc::Options.new, path: @tmpdir
+    assert_nil loaded.page('README')
+
+    loaded.load_all
+
+    assert_equal 'README.txt', loaded.page('README').relative_name
+  end
+
   def test_save
     FileUtils.mkdir_p @tmpdir
 

--- a/test/rdoc/rdoc_store_test.rb
+++ b/test/rdoc/rdoc_store_test.rb
@@ -650,27 +650,16 @@ class RDocStoreTest < XrefTestCase
     assert_equal page, @store.page('PAGE.txt')
   end
 
-  def test_page_index
-    page = @store.add_file 'PAGE.txt', parser: RDoc::Parser::Simple
-    page_name = page.page_name
-    base_name = page.base_name
-    name_calls = 0
-    page.define_singleton_method(:page_name) do
-      name_calls += 1
-      page_name
-    end
-    page.define_singleton_method(:base_name) do
-      name_calls += 1
-      base_name
-    end
+  def test_page_index_linear_performance
+    assert_linear_performance((1..4).map { |i| 10**i }) do |count|
+      store = RDoc::Store.new RDoc::Options.new
+      count.times { |i| store.add_file "page_#{i}.txt" }
 
-    2.times do
-      assert_same page, @store.page('PAGE')
-      assert_same page, @store.page('PAGE.txt')
-      assert_nil @store.page('missing')
+      count.times do
+        store.page 'page_0'
+        store.page 'missing'
+      end
     end
-
-    assert_equal 2, name_calls
   end
 
   def test_page_index_invalidated_when_files_change


### PR DESCRIPTION
`RDoc::Store#page` previously scanned every known file for each page lookup, including repeated misses.

This adds a lazily built hash index keyed by both `page_name` and `base_name`, preserving existing first-match behavior when names collide.

The index is invalidated whenever files are added, removed, or bulk-loaded. The implementation remains private to `RDoc::Store` and adds no public API or configuration. 

## Benchmark

For testing I used latest rdoc(master) + rdoc-markdown gem. Generation was done on a rails codebase.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Generation time | 74.91s | 42.08s | -43.8% |
| Total time | 88.52s | 50.76s | -42.7% |
| Peak RSS | 411.1 MiB | 422.8 MiB | +2.8% |

Total time to generate documentation decreased from 88.52s to 50.76s (42.7%). 