### PR TITLE
Remove unused method `RDoc::Require#top_level` that always raises NoMethodError

### DIFF
--- a/lib/rdoc/code_object/require.rb
+++ b/lib/rdoc/code_object/require.rb
@@ -15,8 +15,7 @@ module RDoc
 
     def initialize(name, comment)
       super()
-      @name = name.gsub(/'|"/, "") #'
-      @top_level = nil
+      @name = name.gsub(/'|"/, "")
       self.comment = comment
     end
 
@@ -32,22 +31,5 @@ module RDoc
     def to_s # :nodoc:
       "require #{name} in: #{parent}"
     end
-
-    ##
-    # The RDoc::TopLevel corresponding to this require, or +nil+ if not found.
-
-    def top_level
-      @top_level ||= begin
-        tl = TopLevel.all_files_hash[name + '.rb']
-
-        if tl.nil? and TopLevel.all_files.first.full_name =~ %r(^lib/)
-          # second chance
-          tl = TopLevel.all_files_hash['lib/' + name + '.rb']
-        end
-
-        tl
-      end
-    end
-
   end
 end


### PR DESCRIPTION
It has been broken since 2d884240 (Move global parse state to RDoc::Store) removed TopLevel.all_files_hash and TopLevel.all_files.

Result of `RDoc::Require.new('a','b').top_level` is basically unchanged.
Before: `NoMethodError(undefined method 'all_files_hash')`
After: `NoMethodError(undefined method 'top_level')`